### PR TITLE
[bugfix] Update UVB rates using a local struct for thread-safety

### DIFF
--- a/src/clib/calculate_cooling_time.c
+++ b/src/clib/calculate_cooling_time.c
@@ -94,12 +94,37 @@ int _calculate_cooling_time(chemistry_data *my_chemistry,
   /* Update UV background rates. */
   photo_rate_storage my_uvb_rates;
 
+  my_uvb_rates.k24 = my_uvb_rates.k25 = my_uvb_rates.k26 =
+    my_uvb_rates.k27 = my_uvb_rates.k28 = my_uvb_rates.k29 =
+    my_uvb_rates.k30 = my_uvb_rates.k31 = my_uvb_rates.piHI =
+    my_uvb_rates.piHeI = my_uvb_rates.piHeII = my_uvb_rates.crsHI =
+    my_uvb_rates.crsHeI = my_uvb_rates.crsHeII =
+    my_uvb_rates.comp_xray = my_uvb_rates.temp_xray = 0.;
+
   if (my_chemistry->UVbackground == 1) {
     if (update_UVbackground_rates(my_chemistry, my_rates,
                                   &my_uvb_rates, my_units) == FAIL) {
       fprintf(stderr, "Error in update_UVbackground_rates.\n");
       return FAIL;
     }
+  }
+  else {
+    my_uvb_rates.k24       = my_rates->k24;
+    my_uvb_rates.k25       = my_rates->k25;
+    my_uvb_rates.k26       = my_rates->k26;
+    my_uvb_rates.k27       = my_rates->k27;
+    my_uvb_rates.k28       = my_rates->k28;
+    my_uvb_rates.k29       = my_rates->k29;
+    my_uvb_rates.k30       = my_rates->k30;
+    my_uvb_rates.k31       = my_rates->k31;
+    my_uvb_rates.piHI      = my_rates->piHI;
+    my_uvb_rates.piHeI     = my_rates->piHeI;
+    my_uvb_rates.piHeII    = my_rates->piHeII;
+    my_uvb_rates.crsHI     = my_rates->crsHI;
+    my_uvb_rates.crsHeI    = my_rates->crsHeI;
+    my_uvb_rates.crsHeII   = my_rates->crsHeII;
+    my_uvb_rates.comp_xray = my_rates->comp_xray;
+    my_uvb_rates.temp_xray = my_rates->temp_xray;
   }
 
   /* Check for a metal field. */

--- a/src/clib/calculate_cooling_time.c
+++ b/src/clib/calculate_cooling_time.c
@@ -26,6 +26,7 @@ extern chemistry_data_storage grackle_rates;
 
 int update_UVbackground_rates(chemistry_data *my_chemistry,
                               chemistry_data_storage *my_rates,
+                              photo_rate_storage *my_uvb_rates,
                               code_units *my_units);
  
 extern void FORTRAN_NAME(cool_multi_time_g)(
@@ -91,9 +92,11 @@ int _calculate_cooling_time(chemistry_data *my_chemistry,
     return SUCCESS;
 
   /* Update UV background rates. */
+  photo_rate_storage my_uvb_rates;
 
   if (my_chemistry->UVbackground == 1) {
-    if (update_UVbackground_rates(my_chemistry, my_rates, my_units) == FAIL) {
+    if (update_UVbackground_rates(my_chemistry, my_rates,
+                                  &my_uvb_rates, my_units) == FAIL) {
       fprintf(stderr, "Error in update_UVbackground_rates.\n");
       return FAIL;
     }
@@ -145,8 +148,8 @@ int _calculate_cooling_time(chemistry_data *my_chemistry,
        my_rates->ciHeI, my_rates->ciHeIS, my_rates->ciHeII, my_rates->reHII,
        my_rates->reHeII1, my_rates->reHeII2, my_rates->reHeIII,
        my_rates->brem, &my_rates->comp, &my_rates->gammah,
-       &my_rates->comp_xray, &my_rates->temp_xray,
-       &my_rates->piHI, &my_rates->piHeI, &my_rates->piHeII,
+       &my_uvb_rates.comp_xray, &my_uvb_rates.temp_xray,
+       &my_uvb_rates.piHI, &my_uvb_rates.piHeI, &my_uvb_rates.piHeII,
        HM_density, H2I_density, H2II_density,
        DI_density, DII_density, HDI_density, metal_density,
        my_rates->hyd01k, my_rates->h2k01, my_rates->vibh,
@@ -155,9 +158,9 @@ int _calculate_cooling_time(chemistry_data *my_chemistry,
        my_rates->HDlte, my_rates->HDlow,
        my_rates->GAHI, my_rates->GAH2, my_rates->GAHe, my_rates->GAHp,
        my_rates->GAel, my_rates->H2LTE, my_rates->gas_grain,
-       &my_chemistry->self_shielding_method, &my_rates->hi_avg_crs,
-       &my_rates->hei_avg_crs, &my_rates->heii_avg_crs,
-       &my_rates->k24, &my_rates->k26,
+       &my_chemistry->self_shielding_method, &my_uvb_rates.crsHI,
+       &my_uvb_rates.crsHeI, &my_uvb_rates.crsHeII,
+       &my_uvb_rates.k24, &my_uvb_rates.k26,
        &my_chemistry->use_radiative_transfer, RT_heating_rate,
        &my_chemistry->h2_optical_depth_approximation,
        &my_chemistry->cie_cooling, my_rates->cieco,

--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -157,16 +157,19 @@ typedef struct
  *** UVbackground table storage ***
  **********************************/
 
-typedef struct{
+typedef struct
+{
 
     long long Nz;
 
     double zmin, zmax;    
     double *z;
 
+    /* Radiative rates for 6-species. */
     double *k24;
     double *k25;
     double *k26;
+    /* Radiative rates for 9-species. */
     double *k27;
     double *k28;
     double *k29;
@@ -223,18 +226,6 @@ typedef struct
   double *k13dd;  /* density dependent version of k13 (collisional H2
                     dissociation); actually 7 functions instead of 1. */
 
-  /* Radiative rates for 6-species (for external field). */
-  double k24;
-  double k25;
-  double k26;
-
-  /* Radiative rates for 9-species (for external field). */
-  double k27;
-  double k28;
-  double k29;
-  double k30;
-  double k31;
-
   /* 12 species rates (with Deuterium). */
   double *k50;
   double *k51;
@@ -275,14 +266,7 @@ typedef struct
   double *reHeIII;
   double *brem;                   // free-free (Bremsstrahlung)
   double comp;                    // Compton cooling
-  double comp_xray;               // X-ray compton heating coefficient
-  double temp_xray;               // X-ray compton heating temperature (K)
   double gammah;                  // Photoelectric heating (code units)
-
-  /* radiative rates (external field). */
-  double piHI;                    // photo-ionization cooling
-  double piHeI;                   //    (no temperature dependance)
-  double piHeII;
 
   /* 9 species rates (including H2) 
        The first five are for the Lepp & Shull rates.
@@ -328,11 +312,40 @@ typedef struct
   /* New/old cloudy data flag */
   int cloudy_data_new;
 
-  /* gray averaged cross sections for UVB self shielding */
-  double hi_avg_crs;
-  double heii_avg_crs;
-  double hei_avg_crs;
-
 } chemistry_data_storage;
+
+/**************************
+ *** photo-rate storage ***
+ **************************/
+
+typedef struct
+{
+
+    /* Radiative rates for 6-species. */
+    double k24;
+    double k25;
+    double k26;
+    /* Radiative rates for 9-species. */
+    double k27;
+    double k28;
+    double k29;
+    double k30;
+    double k31;
+
+    double piHI;
+    double piHeII;
+    double piHeI;
+
+    // spectrum averaged absorption cross sections
+    double crsHI;
+    double crsHeII;
+    double crsHeI;
+
+    // X-ray compton heating coefficient
+    double comp_xray;
+    // X-ray compton heating temperature (K)
+    double temp_xray;
+
+} photo_rate_storage;
 
 #endif

--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -177,13 +177,13 @@ typedef struct
     double *k31;
 
     double *piHI;
-    double *piHeII;
     double *piHeI;
+    double *piHeII;
 
     // spectrum averaged absorption cross sections
     double *crsHI;
-    double *crsHeII;
     double *crsHeI;
+    double *crsHeII;
 
 } UVBtable;
 
@@ -357,13 +357,13 @@ typedef struct
     double k31;
 
     double piHI;
-    double piHeII;
     double piHeI;
+    double piHeII;
 
     // spectrum averaged absorption cross sections
     double crsHI;
-    double crsHeII;
     double crsHeI;
+    double crsHeII;
 
     // X-ray compton heating coefficient
     double comp_xray;

--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -226,6 +226,18 @@ typedef struct
   double *k13dd;  /* density dependent version of k13 (collisional H2
                     dissociation); actually 7 functions instead of 1. */
 
+  /* Radiative rates for 6-species (for external field). */
+  double k24;
+  double k25;
+  double k26;
+
+  /* Radiative rates for 9-species (for external field). */
+  double k27;
+  double k28;
+  double k29;
+  double k30;
+  double k31;
+
   /* 12 species rates (with Deuterium). */
   double *k50;
   double *k51;
@@ -266,7 +278,19 @@ typedef struct
   double *reHeIII;
   double *brem;                   // free-free (Bremsstrahlung)
   double comp;                    // Compton cooling
+  double comp_xray;               // X-ray compton heating coefficient
+  double temp_xray;               // X-ray compton heating temperature (K)
   double gammah;                  // Photoelectric heating (code units)
+
+  /* radiative rates (external field). */
+  double piHI;                    // photo-ionization cooling
+  double piHeI;                   //    (no temperature dependance)
+  double piHeII;
+
+  // spectrum averaged absorption cross sections
+  double crsHI;
+  double crsHeI;
+  double crsHeII;
 
   /* 9 species rates (including H2) 
        The first five are for the Lepp & Shull rates.

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -216,6 +216,23 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
     my_rates->n_cr_d1 = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
     my_rates->n_cr_d2 = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
 
+    my_rates->k24 = 0;
+    my_rates->k25 = 0;
+    my_rates->k26 = 0;
+    my_rates->k27 = 0;
+    my_rates->k28 = 0;
+    my_rates->k29 = 0;
+    my_rates->k30 = 0;
+    my_rates->k31 = 0;
+    my_rates->piHI = 0;
+    my_rates->piHeII = 0;
+    my_rates->piHeI = 0;
+    my_rates->crsHI = 0;
+    my_rates->crsHeI = 0;
+    my_rates->crsHeII = 0;
+    my_rates->comp_xray = 0;
+    my_rates->temp_xray = 0;
+
   }
 
   int ioutput = 0;

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -216,21 +216,6 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
     my_rates->n_cr_d1 = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
     my_rates->n_cr_d2 = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
 
-    my_rates->k24 = 0;
-    my_rates->k25 = 0;
-    my_rates->k26 = 0;
-    my_rates->k27 = 0;
-    my_rates->k28 = 0;
-    my_rates->k29 = 0;
-    my_rates->k30 = 0;
-    my_rates->k31 = 0;
-    my_rates->piHI = 0;
-    my_rates->piHeII = 0;
-    my_rates->piHeI = 0;
-    my_rates->hi_avg_crs   = 0.0;
-    my_rates->heii_avg_crs = 0.0;
-    my_rates->hei_avg_crs  = 0.0;
-
   }
 
   int ioutput = 0;
@@ -303,8 +288,6 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
   }
 
   /* Initialize UV Background data. */
-  my_rates->comp_xray                 = 0;
-  my_rates->temp_xray                 = 0;
   my_rates->UVbackground_table.Nz     = 0;
   my_rates->UVbackground_table.z      = NULL;
   my_rates->UVbackground_table.k24    = NULL;

--- a/src/clib/solve_chemistry.c
+++ b/src/clib/solve_chemistry.c
@@ -114,6 +114,24 @@ int _solve_chemistry(chemistry_data *my_chemistry,
       return FAIL;
     }
   }
+  else {
+    my_uvb_rates.k24       = my_rates->k24;
+    my_uvb_rates.k25       = my_rates->k25;
+    my_uvb_rates.k26       = my_rates->k26;
+    my_uvb_rates.k27       = my_rates->k27;
+    my_uvb_rates.k28       = my_rates->k28;
+    my_uvb_rates.k29       = my_rates->k29;
+    my_uvb_rates.k30       = my_rates->k30;
+    my_uvb_rates.k31       = my_rates->k31;
+    my_uvb_rates.piHI      = my_rates->piHI;
+    my_uvb_rates.piHeI     = my_rates->piHeI;
+    my_uvb_rates.piHeII    = my_rates->piHeII;
+    my_uvb_rates.crsHI     = my_rates->crsHI;
+    my_uvb_rates.crsHeI    = my_rates->crsHeI;
+    my_uvb_rates.crsHeII   = my_rates->crsHeII;
+    my_uvb_rates.comp_xray = my_rates->comp_xray;
+    my_uvb_rates.temp_xray = my_rates->temp_xray;
+  }
 
   /* Check for a metal field. */
 

--- a/src/clib/solve_chemistry.c
+++ b/src/clib/solve_chemistry.c
@@ -25,6 +25,7 @@ extern chemistry_data_storage grackle_rates;
 
 int update_UVbackground_rates(chemistry_data *my_chemistry,
                               chemistry_data_storage *my_rates,
+                              photo_rate_storage *my_uvb_rates,
                               code_units *my_units);
 
 extern void FORTRAN_NAME(solve_rate_cool_g)(
@@ -104,9 +105,11 @@ int _solve_chemistry(chemistry_data *my_chemistry,
     return SUCCESS;
 
   /* Update UV background rates. */
+  photo_rate_storage my_uvb_rates;
 
   if (my_chemistry->UVbackground == 1) {
-    if (update_UVbackground_rates(my_chemistry, my_rates, my_units) == FAIL) {
+    if (update_UVbackground_rates(my_chemistry, my_rates,
+                                  &my_uvb_rates, my_units) == FAIL) {
       fprintf(stderr, "Error in update_UVbackground_rates.\n");
       return FAIL;
     }
@@ -169,8 +172,8 @@ int _solve_chemistry(chemistry_data *my_chemistry,
     my_rates->k11, my_rates->k12, my_rates->k13, my_rates->k13dd,
     my_rates->k14, my_rates->k15, my_rates->k16,
     my_rates->k17, my_rates->k18, my_rates->k19, my_rates->k22,
-    &my_rates->k24, &my_rates->k25, &my_rates->k26, &my_rates->k27,
-    &my_rates->k28, &my_rates->k29, &my_rates->k30, &my_rates->k31,
+    &my_uvb_rates.k24, &my_uvb_rates.k25, &my_uvb_rates.k26, &my_uvb_rates.k27,
+    &my_uvb_rates.k28, &my_uvb_rates.k29, &my_uvb_rates.k30, &my_uvb_rates.k31,
     my_rates->k50, my_rates->k51, my_rates->k52, my_rates->k53,
     my_rates->k54, my_rates->k55, my_rates->k56,
     my_rates->k57, my_rates->k58,
@@ -181,8 +184,8 @@ int _solve_chemistry(chemistry_data *my_chemistry,
     my_rates->ciHeI, my_rates->ciHeIS, my_rates->ciHeII, my_rates->reHII,
     my_rates->reHeII1, my_rates->reHeII2, my_rates->reHeIII, my_rates->brem,
     &my_rates->comp, &my_rates->gammah,
-    &my_rates->comp_xray, &my_rates->temp_xray,
-    &my_rates->piHI, &my_rates->piHeI, &my_rates->piHeII,
+    &my_uvb_rates.comp_xray, &my_uvb_rates.temp_xray,
+    &my_uvb_rates.piHI, &my_uvb_rates.piHeI, &my_uvb_rates.piHeII,
     HM_density, H2I_density, H2II_density,
     DI_density, DII_density, HDI_density, metal_density,
     my_rates->hyd01k, my_rates->h2k01, my_rates->vibh,
@@ -192,8 +195,8 @@ int _solve_chemistry(chemistry_data *my_chemistry,
     my_rates->GAHI, my_rates->GAH2, my_rates->GAHe, my_rates->GAHp,
     my_rates->GAel, my_rates->H2LTE, my_rates->gas_grain,
     &my_chemistry->H2_self_shielding,
-    &my_chemistry->self_shielding_method, &my_rates->hi_avg_crs,
-    &my_rates->hei_avg_crs, &my_rates->heii_avg_crs,
+    &my_chemistry->self_shielding_method, &my_uvb_rates.crsHI,
+    &my_uvb_rates.crsHeI, &my_uvb_rates.crsHeII,
     &my_chemistry->use_radiative_transfer, &my_chemistry->radiative_transfer_coupled_rate_solver,
     &my_chemistry->radiative_transfer_intermediate_step, &my_chemistry->radiative_transfer_hydrogen_only,
     RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,

--- a/src/clib/solve_chemistry.c
+++ b/src/clib/solve_chemistry.c
@@ -107,6 +107,13 @@ int _solve_chemistry(chemistry_data *my_chemistry,
   /* Update UV background rates. */
   photo_rate_storage my_uvb_rates;
 
+  my_uvb_rates.k24 = my_uvb_rates.k25 = my_uvb_rates.k26 =
+    my_uvb_rates.k27 = my_uvb_rates.k28 = my_uvb_rates.k29 =
+    my_uvb_rates.k30 = my_uvb_rates.k31 = my_uvb_rates.piHI =
+    my_uvb_rates.piHeI = my_uvb_rates.piHeII = my_uvb_rates.crsHI =
+    my_uvb_rates.crsHeI = my_uvb_rates.crsHeII =
+    my_uvb_rates.comp_xray = my_uvb_rates.temp_xray = 0.;
+
   if (my_chemistry->UVbackground == 1) {
     if (update_UVbackground_rates(my_chemistry, my_rates,
                                   &my_uvb_rates, my_units) == FAIL) {

--- a/src/clib/update_UVbackground_rates.c
+++ b/src/clib/update_UVbackground_rates.c
@@ -24,6 +24,7 @@
 
 int update_UVbackground_rates(chemistry_data *my_chemistry,
                               chemistry_data_storage *my_rates,
+                              photo_rate_storage *my_uvb_rates,
                               code_units *my_units)
 {
   /* Return if there is no radiation (rates should be all zero). */
@@ -78,19 +79,19 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
   // *** k24 ***
   slope = (my_rates->UVbackground_table.k24[index] -
            my_rates->UVbackground_table.k24[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->k24 = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->k24 = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.k24[index-1];
 
   // *** k25 ***
   slope = (my_rates->UVbackground_table.k25[index] -
            my_rates->UVbackground_table.k25[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->k25 = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->k25 = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.k25[index-1];
 
   // *** k26 ***
   slope = (my_rates->UVbackground_table.k26[index] -
            my_rates->UVbackground_table.k26[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->k26 = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->k26 = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.k26[index-1];
 
   if (my_chemistry->primordial_chemistry > 1) {
@@ -98,31 +99,31 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
     // *** k27 ***
     slope = (my_rates->UVbackground_table.k27[index] -
              my_rates->UVbackground_table.k27[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->k27 = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->k27 = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.k27[index-1];
 
     // *** k28 ***
     slope = (my_rates->UVbackground_table.k28[index] -
              my_rates->UVbackground_table.k28[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->k28 = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->k28 = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.k28[index-1];
 
     // *** k29 ***
     slope = (my_rates->UVbackground_table.k29[index] -
              my_rates->UVbackground_table.k29[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->k29 = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->k29 = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.k29[index-1];
 
     // *** k30 ***
     slope = (my_rates->UVbackground_table.k30[index] -
              my_rates->UVbackground_table.k30[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->k30 = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->k30 = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.k30[index-1];
 
     // *** k31 ***
     slope = (my_rates->UVbackground_table.k31[index] -
              my_rates->UVbackground_table.k31[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->k31 = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->k31 = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.k31[index-1];
 
   }
@@ -130,19 +131,19 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
   // *** piHI ***
   slope = (my_rates->UVbackground_table.piHI[index] -
            my_rates->UVbackground_table.piHI[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->piHI = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->piHI = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.piHI[index-1];
 
   // *** piHeII ***
   slope = (my_rates->UVbackground_table.piHeII[index] -
            my_rates->UVbackground_table.piHeII[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->piHeII = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->piHeII = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.piHeII[index-1];
 
   // *** piHeI ***
   slope = (my_rates->UVbackground_table.piHeI[index] -
            my_rates->UVbackground_table.piHeI[index-1]) / (zvec[index] - zvec[index-1]);
-  my_rates->piHeI = (Redshift - zvec[index-1]) * slope +
+  my_uvb_rates->piHeI = (Redshift - zvec[index-1]) * slope +
     my_rates->UVbackground_table.piHeI[index-1];
 
   //
@@ -154,19 +155,19 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
   if (my_chemistry->self_shielding_method > 0){
     slope = (my_rates->UVbackground_table.crsHI[index] -
              my_rates->UVbackground_table.crsHI[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->hi_avg_crs = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->crsHI = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.crsHI[index-1];
 
     // *** crsHeI ***
     slope = (my_rates->UVbackground_table.crsHeI[index] -
              my_rates->UVbackground_table.crsHeI[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->hei_avg_crs = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->crsHeI = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.crsHeI[index-1];
 
     // *** crsHeII ***
     slope = (my_rates->UVbackground_table.crsHeII[index] -
              my_rates->UVbackground_table.crsHeII[index-1]) / (zvec[index] - zvec[index-1]);
-    my_rates->heii_avg_crs = (Redshift - zvec[index-1]) * slope +
+    my_uvb_rates->crsHeII = (Redshift - zvec[index-1]) * slope +
       my_rates->UVbackground_table.crsHeII[index-1];
   }
 
@@ -199,36 +200,36 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
     (POW(tbase1, 3) * dbase1) / ev2erg;
 
 
-  my_rates->k24 *= my_units->time_units;
-  my_rates->k25 *= my_units->time_units;
-  my_rates->k26 *= my_units->time_units;
+  my_uvb_rates->k24 *= my_units->time_units;
+  my_uvb_rates->k25 *= my_units->time_units;
+  my_uvb_rates->k26 *= my_units->time_units;
   
   if (my_chemistry->primordial_chemistry > 1) {
-    my_rates->k27 *= my_units->time_units;
-    my_rates->k28 *= my_units->time_units;
-    my_rates->k29 *= my_units->time_units;
-    my_rates->k30 *= my_units->time_units;
-    my_rates->k31 *= my_units->time_units;
+    my_uvb_rates->k27 *= my_units->time_units;
+    my_uvb_rates->k28 *= my_units->time_units;
+    my_uvb_rates->k29 *= my_units->time_units;
+    my_uvb_rates->k30 *= my_units->time_units;
+    my_uvb_rates->k31 *= my_units->time_units;
   }
     
-  my_rates->piHI /= CoolingUnits;
-  my_rates->piHeII /= CoolingUnits;
-  my_rates->piHeI /= CoolingUnits;
+  my_uvb_rates->piHI /= CoolingUnits;
+  my_uvb_rates->piHeII /= CoolingUnits;
+  my_uvb_rates->piHeI /= CoolingUnits;
   
   // Now apply the Ramp factor
-  my_rates->k24 *= Ramp;
-  my_rates->k25 *= Ramp;
-  my_rates->k26 *= Ramp;
+  my_uvb_rates->k24 *= Ramp;
+  my_uvb_rates->k25 *= Ramp;
+  my_uvb_rates->k26 *= Ramp;
   if (my_chemistry->primordial_chemistry > 1) {
-    my_rates->k27 *= Ramp;
-    my_rates->k28 *= Ramp;
-    my_rates->k29 *= Ramp;
-    my_rates->k30 *= Ramp;
-    my_rates->k31 *= Ramp;
+    my_uvb_rates->k27 *= Ramp;
+    my_uvb_rates->k28 *= Ramp;
+    my_uvb_rates->k29 *= Ramp;
+    my_uvb_rates->k30 *= Ramp;
+    my_uvb_rates->k31 *= Ramp;
   } 
-  my_rates->piHI *= Ramp;
-  my_rates->piHeII *= Ramp;
-  my_rates->piHeI *= Ramp;
+  my_uvb_rates->piHI *= Ramp;
+  my_uvb_rates->piHeII *= Ramp;
+  my_uvb_rates->piHeI *= Ramp;
 
   /* Molecular hydrogen constant photo-dissociation */
 
@@ -237,7 +238,8 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
      0.0). */
 
   if (my_chemistry->LWbackground_intensity > 0.0) 
-    my_rates->k31 = 1.13e8 * my_chemistry->LWbackground_intensity * my_units->time_units;
+    my_uvb_rates->k31 = 1.13e8 * my_chemistry->LWbackground_intensity *
+      my_units->time_units;
   
   /* LWbackground_sawtooth_suppression is supposed to account for the
      suppression of LW flux due to Lyman-series absorption (giving a
@@ -249,7 +251,7 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
   if (my_chemistry->LWbackground_sawtooth_suppression) {
     double LymanSawtoothSuppressionFactor = 0.1 + 0.9 * Ramp;
   
-    my_rates->k31 *= LymanSawtoothSuppressionFactor;
+    my_uvb_rates->k31 *= LymanSawtoothSuppressionFactor;
   }
 
   /* Compton X-ray heating */
@@ -263,19 +265,18 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
        is the average photon energy in keV, corrected for relativistic
        effects.  Eq.(4) and Eq.(11) of Madau & Efstathiou (1999) */
     
-    my_rates->comp_xray = 4.15e-13 * 3.0e10 *
+    my_uvb_rates->comp_xray = 4.15e-13 * 3.0e10 *
       (31.8*POW(1.0+Redshift, 0.3333)/511.0) * 
       (6.3e-5 * 1.6e-12) * 
       POW(1.0 + Redshift, 4) * 
       exp(-POW(Redshift/RedshiftXrayCutoff, 2)) / 
       CoolingUnits; 
-    
   
     /* The effective temperature (in K).  Eq.(10) of Madau &
        Efstathiou (1999) with U_xray(z=0) = 6.3e-5 and U_cmb(z=0) =
        0.256 eV/cm3 */
     
-    my_rates->temp_xray = 31.8e3*POW(1.0+Redshift, 0.3333)*1.6e-12/
+    my_uvb_rates->temp_xray = 31.8e3*POW(1.0+Redshift, 0.3333)*1.6e-12/
       (4.0*1.38e-16) *
       6.3e-5 * POW(1.0 + Redshift, 4) * 
       exp(-POW(Redshift/RedshiftXrayCutoff, 2)) /

--- a/src/clib/update_UVbackground_rates.c
+++ b/src/clib/update_UVbackground_rates.c
@@ -33,11 +33,11 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
       my_chemistry->primordial_chemistry == 0)
     return SUCCESS;
 
-  /* Return if redshift is outside of table (rates should be all zero). */
+  /* Return if redshift is outside of on/off redshifts. */
 
   double Redshift = 1.0 / (my_units->a_value * my_units->a_units) - 1;
-  if ( (Redshift < my_rates->UVbackground_table.zmin) ||
-       (Redshift > my_rates->UVbackground_table.zmax) )
+  if ( (Redshift < my_chemistry->UVbackground_redshift_off) ||
+       (Redshift > my_chemistry->UVbackground_redshift_on) )
     return SUCCESS;
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Strictly speaking, `update_UVbackground_rates` is not thread-safe as it updates global variables in the `chemistry_data_storage` struct. This is not a problem for Grackle's OpenMP implementation, but could be an issue for codes that have multiple threads calling `calculate_cooling_time` or `solve_chemistry`.

This PR makes use of a temporary struct that holds only the interpolated photo-rates and passes those to `calculate_cooling_time` and `solve_chemistry`.