### PR TITLE
k31 changed - H2 photodissociation rate

### DIFF
--- a/src/clib/update_UVbackground_rates.c
+++ b/src/clib/update_UVbackground_rates.c
@@ -238,7 +238,7 @@ int update_UVbackground_rates(chemistry_data *my_chemistry,
      0.0). */
 
   if (my_chemistry->LWbackground_intensity > 0.0) 
-    my_uvb_rates->k31 = 1.13e8 * my_chemistry->LWbackground_intensity *
+    my_uvb_rates->k31 = 1.38e-12 * my_chemistry->LWbackground_intensity *
       my_units->time_units;
   
   /* LWbackground_sawtooth_suppression is supposed to account for the


### PR DESCRIPTION
The older value (1.13e8) is valid for an unnormalized flat incident radiation flux in units of erg cm^-2 s^-1 Hz^-1 (see Abel et al., 1997).
1.38e-12, instead, is valid for a flat intensity in units of 10^-21 erg cm^-2 s^-1 Hz^-1 sr^-1.
Since the LWbackground_intensity is expressed with these units, the latter value should be used.