### PR TITLE
Updates for Stampede Builds

### DIFF
--- a/src/clib/Make.mach.tacc-stampede-gnu
+++ b/src/clib/Make.mach.tacc-stampede-gnu
@@ -26,6 +26,7 @@ MACH_CXX_NOMPI = g++ # C++ compiler
 MACH_FC_NOMPI  = gfortran # Fortran 77
 MACH_F90_NOMPI = gfortran # Fortran 90
 MACH_LD_NOMPI  = gfortran # Linker
+MACH_LIBTOOL   = libtool
 
 #-----------------------------------------------------------------------
 # Machine-dependent defines
@@ -63,7 +64,6 @@ MACH_OPT_AGGRESSIVE  = -O3 -g
 #-----------------------------------------------------------------------
 
 LOCAL_HDF5_INSTALL = $(TACC_HDF5_DIR)
-LOCAL_FC_INSTALL = 
 
 LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL)/include # HDF5 includes
 MACH_INCLUDES         = $(LOCAL_INCLUDES_HDF5)
@@ -73,7 +73,7 @@ MACH_INCLUDES         = $(LOCAL_INCLUDES_HDF5)
 #-----------------------------------------------------------------------
 
 LOCAL_LIBS_HDF5   = -L$(LOCAL_HDF5_INSTALL)/lib -lhdf5 # HDF5 libraries
-LOCAL_LIBS_MACH   = -L$(LOCAL_FC_INSTALL) -lm # Machine-dependent libraries
+LOCAL_LIBS_MACH   = -lm # Machine-dependent libraries
 
 MACH_LIBS         = $(LOCAL_LIBS_HDF5) $(LOCAL_LIBS_MACH)
 

--- a/src/clib/Make.mach.tacc-stampede-intel
+++ b/src/clib/Make.mach.tacc-stampede-intel
@@ -20,7 +20,7 @@ MACH_FILE  = Make.mach.tacc-stampede-intel
 #-----------------------------------------------------------------------
 
 LOCAL_HDF5_INSTALL = $(TACC_HDF5_DIR)
-LOCAL_FC_INSTALL    = /opt/apps/intel/13/composer_xe_2013.2.146/compiler/lib/intel64
+LOCAL_FC_INSTALL   = $(TACC_INTEL_LIB)
 
 #-----------------------------------------------------------------------
 # Compiler settings
@@ -64,8 +64,12 @@ MACH_LDFLAGS  = -lifcore -lifport -lpthread -ldl # Linker flags
 
 MACH_OPT_WARN        = # Flags for verbose compiler warnings
 MACH_OPT_DEBUG       = -g -O0 # Flags for debugging
-MACH_OPT_HIGH        = -O2 # Flags for high conservative optimization
-MACH_OPT_AGGRESSIVE  = -O3 -Mfptrap -Mflushz -fastsse -Mdaz -Mnontemporal -Mnofprelaxed -Mvect=altcode,assoc,prefetch -Kieee # Flags for aggressive optimization
+MACH_OPT_HIGH        = -O2 -xCORE-AVX2
+# use -xMIC-AVX512  (without -xCORE-AVX2) to build for KNL nodes
+# use -xCORE-AVX512 (without -xCORE-AVX2) to build for SKX nodes
+# use -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 to build a single binary for both
+#     node types that dispatches optimal code path at execution
+MACH_OPT_AGGRESSIVE  = -O3 -xCORE-AVX2 -Mfptrap -Mflushz -fastsse -Mdaz -Mnontemporal -Mnofprelaxed -Mvect=altcode,assoc,prefetch -Kieee # Flags for aggressive optimization
 
 #-----------------------------------------------------------------------
 # Includes

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -15,7 +15,7 @@ from pygrackle.utilities.physical_constants import \
     boltzmann_constant_cgs, \
     mass_hydrogen_cgs
 
-from grackle_defs cimport *
+from .grackle_defs cimport *
 import numpy as np
 cimport numpy as np
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup, find_packages
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.extension import Extension
@@ -16,6 +17,11 @@ cython_extensions = [
     ),
 ]
 
+# on some platforms the cython bindings don't work unless the
+# language_level matches the python version. To specify the level
+# see https://stackoverflow.com/a/58116368
+for e in cython_extensions:
+    e.cython_directives = {'language_level': sys.version_info[0]}
 
 class build_ext(_build_ext):
     # subclass setuptools extension builder to avoid importing numpy


### PR DESCRIPTION
This pull request includes includes fixes to issues with building grackle on stampede2. There are 2 main sets of changes.

First, I updated the compile settings in the tacc-stampede-intel and tacc-stampede-gnu build settings. I have originally made these modifications on commit 6ae37b2b1fc1957aeb6020a85a3b1f23ee14f489 and on that commit I confirmed that grackle will now successfully compile using both compilers.  After rebasing the branch I subsequently reconfirmed that grackle builds with the intel compiler (but have not checked again with the intel compilers). 

As a brief aside, the Stampede2 user guide recommends a few different sets of compiler flags to be used with the intel compiler based on which of the 2 types of compute nodes are used. They suggest two flexible options: only use the advanced instruction set common to both types of nodes or make a larger binary using that includes code paths optimized for both types of compute nodes (the appropriate code path is selected at run time). I added the former option to the ``MACH_OPT_AGGRESSIVE`` (since the latter slightly increases compile time) and documented the other options. Let me know if you want to switch this (the user guide actually recommends the second option).

The second set of changes may have far-reaching consequences and I'm more than happy to drop these from the pull request. These changes fixed an issue I was having with installing the python bindings on stampede2 (I successfully did it on my local machine). After building the bindings, my python3 installation was unable to find the ``pygrackle`` module (which prevented running the test suite). I found that building the cython extensions using ``language_level=3`` fixed this issue. Previously, ``language_level`` was unspecified and defaulted to a value of 2. I added a few lines to ``setup.py`` to set the language level to match the major version number of the python installation. I also modified a single line ``grackle_wrapper.pyx`` to support ``language_level=3`` (I had to change an implicit relative import to an explicit relative import).

I tested the python binding changes with the intel version of the code (I followed the example from continuous integration file and called `pytest python/tests` from the `grackle/src` directory). Before rebasing the code (when the changes were applied to commit 6ae37b2b1fc1957aeb6020a85a3b1f23ee14f489), all of the tests passed (grackle was built with the  ``MACH_OPT_HIGH`` flags). However, after rebasing the commit, the part of `test_code_examples.py`  that calls `cxx_omp_example.C` raises an error that reads:

> RuntimeError: Command ./cxx_omp_example failed with return code 1 and the following output: b'Calculating cooling (tabulated) ...\n   Number of threads =  1 ... done\n   Number of threads =  1 ... done\n   Checking results ... passed\nCalculating cooling time (tabulated) ...\n   Number of threads =  1 ... done\n   Number of threads =  1 ... done\n   Checking results ... passed\nCalculating temperature (tabulated) ...\n   Number of threads =  1 ... done\n   Number of threads =  1 ... done\n   Checking results ... passed\nCalculating pressure (tabulated) ...\n   Number of threads =  1 ... done\n   Number of threads =  1 ... done\n   Checking results ... passed\nCalculating cooling (non-equilibrium chemistry) ...\n   Number of threads =  1 ... done\n   Number of threads =  1 ... done\n   Checking results ... \nERROR: inconsistent results for field 0, cell 12\n   single-thread  5.44667301737654e-01, multi-thread  5.44667301737655e-01, error  4.07670157941631e-16 !!\n\n'

However, this isn't an issue test passes when I use the `MACH_OPT_DEBUG`.