### PR TITLE
Minor tweak to allow tests to pass with gfortran

### DIFF
--- a/src/example/Makefile
+++ b/src/example/Makefile
@@ -185,7 +185,7 @@ fortran_example: $(MODULES) fortran_example.o
 .F.o:
 	@rm -f $@
 	@echo "Compiling $<"
-	-@($(FC) -c -o $@ $(DEFINES) $(FFLAGS) $(INCLUDES) $(GRACKLE_INCLUDE) $*.F) >& $(OUTPUT)
+	-@($(FC) -c -o $@ $(DEFINES) $(FFLAGS) -O1 $(INCLUDES) $(GRACKLE_INCLUDE) $*.F) >& $(OUTPUT)
 	@(if [ ! -e $@ ]; then \
              echo; \
              echo "$(FC) -c -o $@ $(DEFINES) $(FFLAGS) $(INCLUDES) $(GRACKLE_INCLUDE) $*.F"; \


### PR DESCRIPTION
For gfortran version 9.2.1, an optimization level of -O2 or higher leads to weird optimizations of the string that holds the path to the grackle input file in the fortran code example. This causes one of the tests to fail.

To remedy this issue I have hardcoded in the -O1 optimization flag into the portion of the Makefile responsible for compiling this test program in order to overwrite whatever optimization flag was specified for compiling the grackle library.

Let me know if there is a better way to resolve this issue.