### PR TITLE
Require older sphinx version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           pip install --upgrade pip
           pip install --upgrade wheel
           pip install --upgrade setuptools
-          pip install sphinx
+          pip install 'sphinx<3.0'
 
   download-test-data:
     description: "Download test data."


### PR DESCRIPTION
This is a stopgap to get the docs building again. Unclear if it will be necessary to change things or if there is a bug in newer versions of sphinx.