### PR TITLE
Add high density table

### DIFF
--- a/doc/source/Parameters.rst
+++ b/doc/source/Parameters.rst
@@ -330,7 +330,7 @@ solar metallicity and scaled linearly with the metallicity of the gas.
 
 Valid range:
 
- - number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 4
+ - number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`3`) < 4
 
  - temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 9.
 
@@ -350,6 +350,10 @@ Data files:
    <http://adsabs.harvard.edu/abs/2012ApJ...746..125H>`_.  The maximum
    redshift is 15.13.  Above that, collisional ionization equilibrium is
    assumed.
+
+The file **CloudyData_UVB=HM2012_high_density.h5** is the same than
+**CloudyData_UVB=HM2012.h5** but goes to higher density (:math:`10^{10}`
+atom / cm3) and was computed with a more recent version of Cloudy (17.06).
 
 To use the self-shielding approximation (see ``self_shielding_method``),
 one must properly account for the change in metal line cooling rates in

--- a/doc/source/Parameters.rst
+++ b/doc/source/Parameters.rst
@@ -352,7 +352,7 @@ Data files:
    assumed.
 
 The file **CloudyData_UVB=HM2012_high_density.h5** is the same than
-**CloudyData_UVB=HM2012.h5** but goes to higher density (:math:`10^{10}`
+**CloudyData_UVB=HM2012.h5** but goes to higher density (10:sup:`10`
 atom / cm:sup:`3`) and was computed with a more recent version of Cloudy (17.06).
 
 To use the self-shielding approximation (see ``self_shielding_method``),

--- a/doc/source/Parameters.rst
+++ b/doc/source/Parameters.rst
@@ -330,7 +330,7 @@ solar metallicity and scaled linearly with the metallicity of the gas.
 
 Valid range:
 
- - number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`3`) < 4
+ - number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 4
 
  - temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 9.
 

--- a/doc/source/Parameters.rst
+++ b/doc/source/Parameters.rst
@@ -353,7 +353,7 @@ Data files:
 
 The file **CloudyData_UVB=HM2012_high_density.h5** is the same than
 **CloudyData_UVB=HM2012.h5** but goes to higher density (:math:`10^{10}`
-atom / cm3) and was computed with a more recent version of Cloudy (17.06).
+atom / cm:sup:`3`) and was computed with a more recent version of Cloudy (17.06).
 
 To use the self-shielding approximation (see ``self_shielding_method``),
 one must properly account for the change in metal line cooling rates in


### PR DESCRIPTION
Hi,

The current table goes up to a density of 10^4 atom / cm3. Here is a table going up to a density of 10^10 atom / cm3.

Below, you will find a few plots in order to compare the different tables.

The cooling length for the new table:
![new_3](https://user-images.githubusercontent.com/14158679/86103877-98997300-babd-11ea-9a1a-777d0ae9b4ec.png)

The cooling length for the old table (extrapolated above 10^4 atom/cm3):
![rho_1_z_1](https://user-images.githubusercontent.com/14158679/86104971-06926a00-babf-11ea-9f52-a14c30253307.png)


The cooling length for a reproduction of the old table done with my script and a recent version of Cloudy:
![grackle_copy_3](https://user-images.githubusercontent.com/14158679/86106246-9be22e00-bac0-11ea-9a44-36ee5ef11ccb.png)


The relative difference between the cooling length of the old and new table `(L_old - L_new) / L_old`:
![diff](https://user-images.githubusercontent.com/14158679/86107491-32631f00-bac2-11ea-8c86-0f6c02b1289d.png)


We can see that it impacts mostly the dense gas heated by supernovae and slightly shift the equilibrium.

By the way, I have also updated the documentation with a comment about the new table and with a fix on the unit of density (I removed an extra `-`).