### PR TITLE
Mmw bugfix

### DIFF
--- a/src/clib/calc_temp1d_cloudy_g.F
+++ b/src/clib/calc_temp1d_cloudy_g.F
@@ -214,7 +214,8 @@
 !     Add metal species to mean molecular weight
 
                   if (imetal .eq. 1) then
-                     munew = d(i,j,k) / (d(i,j,k) / munew +
+                     munew = d(i,j,k) /
+     &                    ((d(i,j,k) - metal(i,j,k))/ munew +
      &                    metal(i,j,k) / mu_metal)
                      tgas(i) = tgas(i) * munew / muold
                   endif


### PR DESCRIPTION
This PR is meant to address Issue #67. I also introduced a simple test to make sure that introducing a metal density field increases the mmw, when `primordial_chemistry=0`.

I have included the updated answer tests here since I'm not sure what the protocol is for updating the submodule:

- [cooling_cell.zip](https://github.com/grackle-project/grackle/files/5876903/cooling_cell.zip)
- [cooling_rate.pc0.zip](https://github.com/grackle-project/grackle/files/5876904/cooling_rate.pc0.zip)

I considered generalizing this test to also include the other `primordial_chemistry` values, but that involves tweaking both
- `FluidContainer`'s `calculate_mean_molecular_weight` method to account for the presence of metals when the `"energy"` field is uniformly zero
-  and `setup_fluid_container` to ensure that the species fields and metal field sum to 1 when `metal_mass_fraction` exceeds 1 (I'm less sure this change is necessary if `converge=True`).

Anyway I decided against doing this because I didn't want to potentially break more of the answer tests.