### PR TITLE
updating makefiles for NASA's HECC machines

### DIFF
--- a/src/clib/Make.mach.nasa-aitken-rome
+++ b/src/clib/Make.mach.nasa-aitken-rome
@@ -68,7 +68,7 @@ MACH_OPT_WARN        =
 MACH_OPT_DEBUG       = -g
 MACH_OPT_HIGH        = -O2 -axAVX -xSSE4.1 -ip -ipo
 # use -xSSE4.2, if you're using Pleiades/Nehalem-EP cores
-MACH_OPT_AGGRESSIVE  = -O3 -axAVX -ip -ipo -xSSE4.1
+MACH_OPT_AGGRESSIVE  = -O3 -axAVX -ip -ipo 
 
 #-----------------------------------------------------------------------
 # Includes

--- a/src/clib/Make.mach.nasa-aitken-rome
+++ b/src/clib/Make.mach.nasa-aitken-rome
@@ -1,0 +1,101 @@
+#=======================================================================
+#
+# FILE:        Make.mach.nasa-aitken-rome
+#
+# DESCRIPTION: Makefile settings for NASA's Aikten Rome nodes
+#
+#    modules: module use -a /nasa/modulefiles/testing 
+#            comp-intel/2020.4.304 and
+#            hdf5/1.8.18_serial
+#
+#
+# AUTHOR:      Molly Peeples
+# DATE:        2021-06-02
+#=======================================================================
+
+MACH_TEXT  = NASA Aitken Rome
+MACH_VALID = 0
+MACH_FILE  = Make.mach.nasa-aitken-rome
+
+MACHINE_NOTES = ""
+
+#-----------------------------------------------------------------------
+# Compiler settings
+#-----------------------------------------------------------------------
+
+MACH_CPP       = icpc
+MACH_LIBTOOL = /usr/bin/libtool 
+
+# Without MPI
+
+MACH_CC_NOMPI  = icc
+MACH_CXX_NOMPI = icpc
+MACH_FC_NOMPI  = ifort
+MACH_F90_NOMPI = ifort
+MACH_LD_NOMPI  = icc
+
+#-----------------------------------------------------------------------
+# Install paths (local variables)
+#-----------------------------------------------------------------------
+
+LOCAL_HDF5_INSTALL   = /nasa/modulefiles/sles15/hdf5/1.8.18_serial
+LOCAL_PYTHON_INSTALL = $(YT_DEST)
+LOCAL_COMPILER_DIR    = /nasa/modulefiles/testing/comp-intel/2020.4.304
+
+#-----------------------------------------------------------------------
+# Machine-dependent defines
+#-----------------------------------------------------------------------
+
+MACH_DEFINES = -DLINUX -DH5_USE_16_API -fPIC
+
+#-----------------------------------------------------------------------
+# Compiler flag settings
+#-----------------------------------------------------------------------
+
+MACH_OMPFLAGS = # OpenMP flags
+MACH_CPPFLAGS = -P -traditional
+MACH_CFLAGS   = -mp1 -prec_div -fp_port -align # C compiler flags
+MACH_CXXFLAGS = -mp1 -prec_div -fp_port -align # C++ compiler flags
+MACH_FFLAGS   = # Fortran 77 compiler flags
+MACH_F90FLAGS = -mp1 -prec_div -fp_port -align -save -zero # Fortran 90 compiler flags
+MACH_LDFLAGS  = -lifcore -lifport -lpthread -ldl # Linker flags
+
+#-----------------------------------------------------------------------
+# Optimization flags
+#-----------------------------------------------------------------------
+
+MACH_OPT_WARN        =
+MACH_OPT_DEBUG       = -g
+MACH_OPT_HIGH        = -O2 -axAVX -xSSE4.1 -ip -ipo
+# use -xSSE4.2, if you're using Pleiades/Nehalem-EP cores
+MACH_OPT_AGGRESSIVE  = -O3 -axAVX -ip -ipo -xSSE4.1
+
+#-----------------------------------------------------------------------
+# Includes
+#-----------------------------------------------------------------------
+
+LOCAL_INCLUDES_HDF5   = -I$(LOCAL_HDF5_INSTALL)/include
+
+MACH_INCLUDES         = $(LOCAL_INCLUDES_HDF5)
+
+#-----------------------------------------------------------------------
+# Libraries
+#-----------------------------------------------------------------------
+#
+
+LOCAL_LIBS_HDF5   = -L$(LOCAL_HDF5_INSTALL)/lib -lhdf5 -lz
+LOCAL_LIBS_FC     = -L$(LOCAL_COMPILER_DIR)/lib/intel64
+
+LOCAL_LIBS_MACH = -L$(LOCAL_COMPILER_DIR)/lib/intel64 -lm -lifcore -lifport
+
+MACH_LIBS         = $(LOCAL_LIBS_HDF5) $(LOCAL_LIBS_MACH) #$(LOCAL_LIBS_PYTHON)
+
+#-----------------------------------------------------------------------
+# Installation
+#-----------------------------------------------------------------------
+
+# if $(HOME)/local does not exist, mkdir before `make install`
+
+MACH_INSTALL_PREFIX = $(HOME)/local
+MACH_INSTALL_LIB_DIR =
+MACH_INSTALL_INCLUDE_DIR =

--- a/src/clib/Make.mach.nasa-pleiades
+++ b/src/clib/Make.mach.nasa-pleiades
@@ -57,6 +57,7 @@ MACH_DEFINES = -DLINUX -DH5_USE_16_API -fPIC
 # Compiler flag settings
 #-----------------------------------------------------------------------
 
+MACH_LIBTOOL = /usr/bin/libtool 
 MACH_OMPFLAGS = # OpenMP flags
 MACH_CPPFLAGS = -P -traditional
 MACH_CFLAGS   = -mp1 -prec_div -fp_port -align # C compiler flags

--- a/src/clib/Make.mach.nasa-pleiades
+++ b/src/clib/Make.mach.nasa-pleiades
@@ -4,8 +4,8 @@
 #
 # DESCRIPTION: Makefile settings for NASA's pleiades
 #
-#    modules: comp-intel/2013.5.192,
-#	      A local serial hdf5 install (e.g. the one that comes with yt)
+#    modules: comp-intel/2020.4.304,
+#	       hdf5/1.8.18_serial 
 #
 # AUTHOR:      Nathan Goldbaum
 # DATE:        2014-04-24
@@ -43,7 +43,7 @@ MACH_LD_NOMPI  = icc
 # Install paths (local variables)
 #-----------------------------------------------------------------------
 
-LOCAL_HDF5_INSTALL   = $(YT_DEST)
+LOCAL_HDF5_INSTALL   = /nasa/hdf5/1.8.18_serial
 LOCAL_PYTHON_INSTALL = $(YT_DEST)
 LOCAL_COMPILER_DIR    = /nasa/intel/Compiler/2020.2.254/
 


### PR DESCRIPTION
Updated the modules and paths for the Pleiades machine file, created a new machine file for the Aitken Rome nodes (https://www.nas.nasa.gov/hecc/support/kb/preparing-to-run-on-aitken-rome-nodes_657.html). I couldn't get the `MACHINE_NOTES` to work (?!) so wound up leaving it as an empty string to get it to compile.