### PR TITLE
Use apt instead of apt-get in circleci script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ commands:
           command: |
             git submodule update --init
             source $BASH_ENV
-            sudo apt-get update
-            sudo apt-get install -y libhdf5-serial-dev gfortran libtool-bin
+            sudo apt update
+            sudo apt install -y libhdf5-serial-dev gfortran libtool-bin
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip


### PR DESCRIPTION
This should fix the circleci build issues.