### PR TITLE
Fix velocity_units in freefall.py

### DIFF
--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -66,9 +66,7 @@ if __name__=="__main__":
     my_chemistry.density_units  = mass_hydrogen_cgs # rho = 1.0 is 1.67e-24 g
     my_chemistry.length_units   = cm_per_mpc        # 1 Mpc in cm
     my_chemistry.time_units     = sec_per_Myr       # 1 Myr in s
-    my_chemistry.velocity_units = my_chemistry.a_units * \
-        (my_chemistry.length_units / my_chemistry.a_value) / \
-        my_chemistry.time_units
+    my_chemistry.velocity_units = my_chemistry.length_units / my_chemistry.time_units
 
     # set initial density and temperature
     initial_temperature = 50000. # start the gas at this temperature


### PR DESCRIPTION
In the pygrackle example file freefall.py velocity_units were defined with a factor of a_value. This was not consistent with the units being input as proper coordinates. This factor of a_value is now removed so all unit definitions are consistent.