### PR TITLE
add proper and comoving velocity units to python scripts

### DIFF
--- a/src/python/examples/cooling_cell.py
+++ b/src/python/examples/cooling_cell.py
@@ -61,9 +61,16 @@ if __name__ == "__main__":
     my_chemistry.density_units = mass_hydrogen_cgs # rho = 1.0 is 1.67e-24 g
     my_chemistry.length_units = cm_per_mpc         # 1 Mpc in cm
     my_chemistry.time_units = sec_per_Myr          # 1 Myr in s
-    my_chemistry.velocity_units = my_chemistry.a_units * \
-        (my_chemistry.length_units / my_chemistry.a_value) / \
-        my_chemistry.time_units
+
+    if my_chemistry.comoving_coordinates:
+        # velocity units for comoving coordinates
+        my_chemistry.velocity_units = my_chemistry.a_units * \
+          (my_chemistry.length_units / my_chemistry.a_value) / \
+          my_chemistry.time_units
+    else:
+        # velocity units for proper coordinates
+        my_chemistry.velocity_units = my_chemistry.length_units / \
+          my_chemistry.time_units
 
     rval = my_chemistry.initialize()
 

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -56,9 +56,16 @@ if __name__ == "__main__":
     my_chemistry.density_units = mass_hydrogen_cgs # rho = 1.0 is 1.67e-24 g
     my_chemistry.length_units = cm_per_mpc         # 1 Mpc in cm
     my_chemistry.time_units = sec_per_Myr          # 1 Gyr in s
-    my_chemistry.velocity_units = my_chemistry.a_units * \
-        (my_chemistry.length_units / my_chemistry.a_value) / \
-        my_chemistry.time_units
+
+    if my_chemistry.comoving_coordinates:
+        # velocity units for comoving coordinates
+        my_chemistry.velocity_units = my_chemistry.a_units * \
+          (my_chemistry.length_units / my_chemistry.a_value) / \
+          my_chemistry.time_units
+    else:
+        # velocity units for proper coordinates
+        my_chemistry.velocity_units = my_chemistry.length_units / \
+          my_chemistry.time_units
 
     # Call convenience function for setting up a fluid container.
     # This container holds the solver parameters, units, and fields.

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -66,7 +66,16 @@ if __name__=="__main__":
     my_chemistry.density_units  = mass_hydrogen_cgs # rho = 1.0 is 1.67e-24 g
     my_chemistry.length_units   = cm_per_mpc        # 1 Mpc in cm
     my_chemistry.time_units     = sec_per_Myr       # 1 Myr in s
-    my_chemistry.velocity_units = my_chemistry.length_units / my_chemistry.time_units
+
+    if my_chemistry.comoving_coordinates:
+        # velocity units for comoving coordinates
+        my_chemistry.velocity_units = my_chemistry.a_units * \
+          (my_chemistry.length_units / my_chemistry.a_value) / \
+          my_chemistry.time_units
+    else:
+        # velocity units for proper coordinates
+        my_chemistry.velocity_units = my_chemistry.length_units / \
+          my_chemistry.time_units
 
     # set initial density and temperature
     initial_temperature = 50000. # start the gas at this temperature


### PR DESCRIPTION
PR #92 fixed the velocity units in the freefall python script, but the same issue existed in a couple others. I've changed those as well now, but decided to add some code that does either to make it clearer to the user what should be done in either case.