### PR TITLE
testing and python packaging updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,7 @@ commands:
             pip install --upgrade pip
             pip install --upgrade wheel
             pip install --upgrade setuptools
-            pip install Cython numpy
-            pip install 'matplotlib<3.3.0'
-            pip install h5py fastcache flake8 pytest yt
+            pip install flake8
 
   lint:
     description: "Lint."
@@ -64,7 +62,7 @@ commands:
             make
             make install
             cd ../python
-            python setup.py develop
+            pip install -e .[dev]
 
   install-docs-dependencies:
     description: "Install dependencies for docs build."
@@ -133,7 +131,7 @@ executors:
         type: string
         default: latest
     docker:
-      - image: circleci/python:<< parameters.tag >>
+      - image: cimg/python:<< parameters.tag >>
 
 jobs:
   test-suite:
@@ -150,22 +148,8 @@ jobs:
     steps:
       - checkout
       - set-env
-
-      - restore_cache:
-          name: "Restore dependencies cache."
-          key: dependencies-python-<< parameters.tag >>-v3
-
       - install-dependencies
-
-      - save_cache:
-          name: "Save dependencies cache"
-          key: dependencies-python-<< parameters.tag >>-v3
-          paths:
-            - ~/.cache/pip
-            - ~/venv
-
       - lint
-
       - download-test-data
 
       - install-grackle:
@@ -202,16 +186,12 @@ workflows:
    tests:
      jobs:
        - test-suite:
-           name: "Python 3.6 tests"
-           tag: "3.6.11"
-
-       - test-suite:
-           name: "Python 3.8 tests"
-           tag: "3.8.5"
+           name: "Python 3.7 tests"
+           tag: "3.7.12"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.8.5"
+           tag: "3.7.12"
 
    weekly:
      triggers:
@@ -223,17 +203,9 @@ workflows:
                 - master
      jobs:
        - test-suite:
-           name: "Python 3.6 tests"
-           tag: "3.6.11"
-
-       - test-suite:
            name: "Python 3.7 tests"
-           tag: "3.7.8"
-
-       - test-suite:
-           name: "Python 3.8 tests"
-           tag: "3.8.5"
+           tag: "3.7.12"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.8.5"
+           tag: "3.7.12"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -46,6 +46,11 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('pygrackle', 'pygrackle')
     return config
 
+dev_requirements = [
+    'flake8',
+    'pytest',
+    'sphinx',
+]
 
 setup(
     name="pygrackle",
@@ -57,14 +62,17 @@ setup(
         'cython',
     ],
     install_requires=[
+        'cython',
         'h5py',
-        'setuptools',
         'numpy',
         'matplotlib',
-        'yt>=3.4.0',
+        'yt>=4.0.2',
     ],
     cmdclass={'build_ext': build_ext},
     license="BSD 3-clause",
     ext_modules=cython_extensions,
-    python_requires='>=3.6'
+    extras_require={
+          'dev': dev_requirements,
+    },
+    python_requires='>=3.7'
 )


### PR DESCRIPTION
This does a few things to update and simplify the testing:

- limit to a single python version. This should minimize version-specific differences in testing answers.
- use the oldest version of python supported by current yt. This is a sensible way to set the oldest allowed version.
- update circleci docker images
- ~~get rid of numbered cache versioning since we cannot actually return to earlier versions.~~
- remove dependencies cache entirely as dependencies take about 20s to install