### PR TITLE
Avoid use of uninitialized variables when setting the timestep in dense gas

### DIFF
--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -590,7 +590,8 @@
      &              dt-ttot(i), 0.5_DKIND*dt)
 
                if (d(i,j,k)*dom .gt. 1e8_DKIND .and. 
-     &              edot(i) .gt. 0._DKIND) then
+     &              edot(i) .gt. 0._DKIND      .and.
+     &             ispecies .gt. 1) then
 !              Equilibrium value for H is:
 !              H = (-1._DKIND / (4*k22)) * (k13 - sqrt(8 k13 k22 rho + k13^2))
 !              We now want this to change by 10% or less, but we're only


### PR DESCRIPTION
Only use the H2 formation & destruction rates to set the timestep in dense gas if we're running with a chemical network that contains H2. Without this check, the code uses k13 and k22, even though they are only initialized when ispecies > 1. 