### PR TITLE
Add ability to query the Grackle Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ commands:
             pip install --upgrade wheel
             pip install --upgrade setuptools
             pip install flake8
+            pip install packaging
 
   lint:
     description: "Lint."

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ Make.config.override
 
 src/clib/auto_show_config.c
 src/clib/auto_show_flags.c
-src/clib/auto_show_version.c
+src/clib/auto_get_version.c
 src/clib/libgrackle.so
 src/example/cxx_example
 src/example/cxx_table_example

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -669,3 +669,49 @@ Cleaning the memory
   _free_chemistry_data(my_grackle_data, &grackle_rates);
 
 Grackle is using global structures and therefore the global structure ``grackle_rates`` needs also to be released.
+
+Querying library version information
+------------------------------------
+
+A struct of type :c:data:`grackle_version` is used to hold version
+information about the version of Grackle that is being used. The
+struct contains information about the version number and particular
+git revision.
+
+.. c:type:: grackle_version
+
+   This structure is used to organize version information for the
+   library.
+
+.. c:var:: const* char version
+
+   Specifies the version of the library using this template:
+   ``<MAJOR>.<MINOR>(.<MICRO>)(.dev<DEV_NUM>)``. In this template
+   ``<MAJOR>``, ``<MINOR>``, and ``<MICRO>`` correspond to a major,
+   minor, and micro version numbers (the micro version number is
+   omitted if it's zero). The final section can specify a
+   development version. For concreteness, some example versions are
+   provided in increasing order: ``"3.0"``, ``"3.1"``, ``"3.1.1"``,
+   ``"3.1.2"``, ``"3.2.dev1"``, ``"3.2.dev2"``, ``"3.2"``.
+
+.. c:var:: const* char branch
+
+   Specifies the name of the git branch that the library was compiled
+   from.
+
+.. c:var:: const* char revision
+
+   Specifies the hash identifying the git commit that the library was
+   compiled from.
+
+The :c:func:`get_grackle_version` function is used to retrieve a
+properly intialized :c:data:`grackle_version` object. The following
+code snippet illustrates how one might query and print this
+information:
+
+.. code-block:: c++
+
+  grackle_version gversion = get_grackle_version();
+  printf ("The Grackle Version: %s\n", gversion.version);
+  printf ("Git Branch:   %s\n", gversion.branch);
+  printf ("Git Revision: %s\n", gversion.revision);

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -17,6 +17,8 @@ Python packages:
 
  - `NumPy <https://www.numpy.org/>`__
 
+ - packaging (only required for the test suite)
+
  - py.test (only required for the test suite)
 
  - `yt <https://yt-project.org/>`__

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -148,6 +148,13 @@ Primary Functions
    :rtype: int
    :returns: 1 (success) or 0 (failure)
 
+.. c:function:: grackle_version get_grackle_version();
+
+   Constructs and returns a :c:type:`grackle_version` struct that
+   encodes the version information for the library.
+
+   :rtype: `grackle_version`
+
 .. _local_functions:
 
 Local Functions

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -14,7 +14,7 @@
 OBJS_CONFIG_LIB = \
         auto_show_config.lo \
         auto_show_flags.lo \
-        auto_show_version.lo \
+        auto_get_version.lo \
         calculate_cooling_time.lo \
         calculate_dust_temperature.lo \
         calculate_gamma.lo \

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -194,7 +194,7 @@ verbose: VERBOSE = 1
 #-----------------------------------------------------------------------
 
 .PHONY: autogen
-autogen: auto_show_config.c auto_show_flags.c auto_show_version.c
+autogen: auto_show_config.c auto_show_flags.c auto_get_version.c
 
 # Force update of auto_show_config.c
 
@@ -210,12 +210,12 @@ auto_show_flags.c:
 	-@$(MAKE) -s show-flags  >& temp.show-flags
 	-@awk 'BEGIN {print "#include <stdio.h>\nvoid auto_show_flags(FILE *fp) {"}; {print "   fprintf (fp,\""$$0"\\n\");"}; END {print "}"}' < temp.show-flags > auto_show_flags.c
 
-# Force update of auto_show_version.c
+# Force update of auto_get_version.c
 
-.PHONY: auto_show_version.c
-auto_show_version.c:
+.PHONY: auto_get_version.c
+auto_get_version.c:
 	-@$(MAKE) -s show-version  >& temp.show-version
-	-@awk 'BEGIN {print "#include <stdio.h>\nvoid auto_show_version(FILE *fp) {"}; {print "   fprintf (fp,\""$$0"\\n\");"}; END {print "}"}' < temp.show-version > auto_show_version.c
+	-@awk 'BEGIN {print "#include <stdio.h>\n#include \"grackle_types.h\"\n\ngrackle_version get_grackle_version() {\n  grackle_version out;" }; { if (NF > 0) { print "  out." tolower($$(NF-1)) " = \"" $$(NF) "\";" } }; END { print "  return out;\n}"}' < temp.show-version > auto_get_version.c
 
 #-----------------------------------------------------------------------
 # Generate dependency file

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -215,7 +215,28 @@ auto_show_flags.c:
 .PHONY: auto_get_version.c
 auto_get_version.c:
 	-@$(MAKE) -s show-version  >& temp.show-version
-	-@awk 'BEGIN {print "#include <stdio.h>\n#include \"grackle_types.h\"\n\ngrackle_version get_grackle_version() {\n  grackle_version out;" }; { if (NF > 0) { print "  out." tolower($$(NF-1)) " = \"" $$(NF) "\";" } }; END { print "  return out;\n}"}' < temp.show-version > auto_get_version.c
+	-@(if [ -f $@ ]; then rm $@; fi) # delete the file if it already exists
+
+	-@echo '#include <stdio.h>'                                                             >> $@
+	-@echo '#include "grackle_types.h"'                                                     >> $@
+	-@echo ''                                                                               >> $@
+	-@echo '// the following macros are auto-generated:'                                    >> $@
+
+	-@awk '{ if (NF > 0) { print "#define AUTO_" toupper($$(NF-1)) " \"" $$(NF) "\"" } };' < temp.show-version >> auto_get_version.c
+
+	-@echo ''                                                                               >> $@
+	-@echo '// test that ensures that all macros were correctly defined:'                   >> $@
+	-@echo '#if !(defined(AUTO_VERSION) && defined(AUTO_BRANCH) && defined(AUTO_REVISION))' >> $@
+	-@echo '#error "Something went wrong while auto-generating macros"'                     >> $@
+	-@echo '#endif'                                                                         >> $@
+	-@echo ''                                                                               >> $@
+	-@echo 'grackle_version get_grackle_version() {'                                        >> $@
+	-@echo '  grackle_version out;'                                                         >> $@
+	-@echo '  out.version = AUTO_VERSION;'                                                  >> $@
+	-@echo '  out.branch = AUTO_BRANCH;'                                                    >> $@
+	-@echo '  out.revision = AUTO_REVISION;'                                                >> $@
+	-@echo '  return out;'                                                                  >> $@
+	-@echo '}'                                                                              >> $@
 
 #-----------------------------------------------------------------------
 # Generate dependency file

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -171,4 +171,6 @@ int _calculate_temperature(chemistry_data *my_chemistry,
 
 int _free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
+grackle_version get_grackle_version();
+
 #endif

--- a/src/clib/grackle_types.h
+++ b/src/clib/grackle_types.h
@@ -87,4 +87,13 @@ typedef struct
 
 } code_units;
 
+typedef struct
+{
+
+  const char* version;
+  const char* branch;
+  const char* revision;
+
+} grackle_version;
+
 #endif

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -31,7 +31,7 @@ extern chemistry_data_storage grackle_rates;
 
 void auto_show_config(FILE *fp);
 void auto_show_flags(FILE *fp);
-void auto_show_version(FILE *fp);
+grackle_version get_grackle_version();
 void show_parameters(FILE *fp, chemistry_data *my_chemistry);
 
 int _free_cloudy_data(cloudy_data *my_cloudy, chemistry_data *my_chemistry, int primordial);
@@ -47,6 +47,15 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
 int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, 
                 double co_length_units, double co_density_units);
 
+static void show_version(FILE *fp)
+{
+  grackle_version gversion = get_grackle_version();
+  fprintf (fp, "\n");
+  fprintf (fp, "The Grackle Version %s\n", gversion.version);
+  fprintf (fp, "Git Branch   %s\n", gversion.branch);
+  fprintf (fp, "Git Revision %s\n", gversion.revision);
+  fprintf (fp, "\n");
+}
 
 int _initialize_chemistry_data(chemistry_data *my_chemistry,
                                chemistry_data_storage *my_rates,
@@ -54,7 +63,7 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
 {
 
   if (grackle_verbose) {
-    auto_show_version(stdout);
+    show_version(stdout);
     fprintf(stdout, "Initializing grackle data.\n");
   }
 
@@ -201,7 +210,7 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
 
     FILE *fptr = fopen("GRACKLE_INFO", "w");
     fprintf(fptr, "%s\n", tstr);
-    auto_show_version(fptr);
+    show_version(fptr);
     fprintf(fptr, "Grackle build options:\n");
     auto_show_config(fptr);
     fprintf(fptr, "Grackle build flags:\n");

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -215,6 +215,11 @@ cdef extern from "grackle_types.h":
       gr_float *H2_self_shielding_length;
       gr_float *isrf_habing;
 
+    ctypedef struct c_grackle_version "grackle_version":
+      const char* version;
+      const char* branch;
+      const char* revision;
+
 cdef extern from "grackle.h":
     c_chemistry_data _set_default_chemistry_parameters()
 
@@ -269,3 +274,5 @@ cdef extern from "grackle.h":
                 c_code_units *my_units,
                 c_field_data *my_fields,
                 gr_float *dust_temperature)
+
+    c_grackle_version c_get_grackle_version "get_grackle_version"()

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -1204,3 +1204,10 @@ def calculate_dust_temperature(fc):
         &my_units,
         &my_fields,
         dust_temperature)
+
+def get_grackle_version():
+    cdef c_grackle_version version_struct = c_get_grackle_version()
+    # all members of version_struct are string literals (i.e. don't call free)
+    return {"version" : version_struct.version.decode('UTF-8'),
+            "branch" : version_struct.branch.decode('UTF-8'),
+            "revision" : version_struct.revision.decode('UTF-8')}

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -50,6 +50,7 @@ dev_requirements = [
     'flake8',
     'pytest',
     'sphinx',
+    'packaging'
 ]
 
 setup(

--- a/src/python/tests/test_get_grackle_version.py
+++ b/src/python/tests/test_get_grackle_version.py
@@ -1,0 +1,90 @@
+########################################################################
+#
+# Volumetric heating rate tests
+#
+#
+# Copyright (c) Grackle Development Team. All rights reserved.
+#
+# Distributed under the terms of the Enzo Public Licence.
+#
+# The full license is in the file LICENSE, distributed with this
+# software.
+########################################################################
+
+from pygrackle.grackle_wrapper import get_grackle_version
+
+import os
+import subprocess
+
+def query_grackle_version_props():
+    # retrieve the current version information with git
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    # get the name of the most recent tag preceeding this commit:
+    _rslt = subprocess.run(["git", "describe", "--abbrev=0", "--tags"],
+                           check = True, capture_output = True)
+    most_recent_tag = _rslt.stdout.decode().rstrip()
+    if 'grackle-' == most_recent_tag[:8]:
+        latest_tagged_version = most_recent_tag[8:]
+    else:
+        raise RuntimeError(
+            "expected the first 8 characters of the most recent git-tag to be "
+            "equal to 'grackle-'"
+        )
+
+    # get the actual revision when most_recent tag was introduced
+    _rslt = subprocess.run(["git", "rev-parse", "-n", "1", most_recent_tag],
+                           check = True, capture_output = True)
+    revision_of_tag = _rslt.stdout.decode().rstrip()
+
+    # get the branch name and current revision
+    _rslt = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                           check = True, capture_output = True)
+    branch = _rslt.stdout.decode().rstrip()
+
+    _rslt = subprocess.run(["git", "rev-parse", "HEAD"],
+                           check = True, capture_output = True)
+    revision = _rslt.stdout.decode().rstrip()
+
+    tagged_on_current_revision = revision == revision_of_tag
+    return latest_tagged_version, branch, revision, tagged_on_current_revision
+
+def test_get_grackle_version():
+    # this test assumes that Grackle was compiled with the currently checked
+    # out version of the repository
+
+    latest_tagged_version, branch, revision, tagged_on_current_revision \
+        = query_grackle_version_props()
+
+    # perform the easy checks
+    results = get_grackle_version()
+    if (len(results) != 3):
+        raise ValueError(
+            "get_grackle_version should return a dictionary with the 3 items"
+        )
+    elif results['branch'] != branch:
+        raise ValueError(
+            f"expected get_grackle_version()['branch'] to be '{branch}', not "
+            f"'{results['branch']}'"
+        )
+    elif results['revision'] != revision:
+        raise ValueError(
+            f"expected get_grackle_version()['revision'] to be '{revision}', "
+            f"not '{results['revision']}'"
+        )
+
+    # now compare version numbers (currently we just check that both versions
+    # are identical if the git-tag was updated in the most recent release. in
+    # all other cases we simply require that the versions are different)
+    if tagged_on_current_revision:
+        if results['version'] != latest_tagged_version:
+            raise ValueError(
+                "expected get_grackle_version()['version'] to be "
+                "'{latest_tagged_version}', not '{results['version']}'"
+            )
+    elif results['version'] == latest_tagged_version:
+        raise ValueError(
+            f"expected get_grackle_version()['version'] to be different from "
+            f"'{latest_tagged_version}', since that version is associated with "
+            "a different commit."
+        )

--- a/src/python/tests/test_get_grackle_version.py
+++ b/src/python/tests/test_get_grackle_version.py
@@ -66,19 +66,21 @@ def test_get_grackle_version():
     elif results['branch'] != branch:
         raise RuntimeError(
             f"expected get_grackle_version()['branch'] to be '{branch}', not "
-            f"'{results['branch']}'"
+            f"'{results['branch']}'. Was a different branch of the repository "
+            "checked out when the c library was compiled?"
         )
     elif results['revision'] != revision:
         raise RuntimeError(
             f"expected get_grackle_version()['revision'] to be '{revision}', "
-            f"not '{results['revision']}'"
+            f"not '{results['revision']}'. Was a different revision of the "
+            "repository checked out when the c library was compiled?"
         )
 
     # Check the formatting of the version strings (given by the tag of the most
     # recently tagged commit and given by get_grackle_version()['version'])
 
     description_string_pairs = [
-        ("get_grackle_version()['version']", results['revision']),
+        ("get_grackle_version()['version']", results['version']),
         ("the tag of the most recently tagged commit", latest_tagged_version)
     ]
 


### PR DESCRIPTION
This PR adds the ability to query the Grackle Version to the public API. This feature is useful for external simulations that want to compare grackle versions before and after a restart.

If you would prefer not to expand the public API, just let me know and we can close this PR. In hindsight, it may have been better to gauge interest in this feature before I created this PR (I was encouraged by the fact that the version information was already encoded within the library - I was just making it more easily accessible).

Overview
-------------
This PR consists of the following changes:
- I introduced the following struct declaration to `grackle_types.h`:
  ```c++
  typedef struct { const char* version; const char* branch; const char* revision; } grackle_version;
  ```
- I replaced the `auto_get_version.c` auto-generated target with the `auto_get_version.c` auto-generated target in `Makefile`. The former which defined the following function:
  ```c++
  void auto_show_version(FILE *fp);
  ```
  The new target defines the following signature:
  ```c++
  grackle_version get_grackle_version();
  ```
  Just like the old target, the results of the  `make show-version` command are used in the definition.
- I replaced all uses of `auto_show_version` in `initialize_chemistry_data.c` with a new local function called `show_version` that produces identical output, but internally employs the new `get_grackle_version()`.
- I added some documentation to explain how to use this functionality to query the grackle version. The basic example is the following:
  ```c++
  grackle_version gversion = get_grackle_version();
  printf ("The Grackle Version: %s\n", gversion.version);
  printf ("Git Branch:   %s\n", gversion.branch);
  printf ("Git Revision: %s\n", gversion.revision);
  ```
  In this description of `grackle_version`'s fields, I tried to explain the expected format for the version number. Let me know if this is wrong.
- I also added a new test for this function (which involved the creation of a python wrapper function (that is not currently part of the public API). This performs a very basic comparison of the results of this function against the version information determined with `git` commands. 
    - We could make this test more robust by using the `packaging` module to parse and compare version numbers from both approaches (since the versioning conventions seem consistent with python convention) as explained [here](https://stackoverflow.com/a/11887885). But, I just wanted to check first, since this would technically add another development dependency (albeit a dependency shared with `setuptools`)

Alternatives
----------------
I'm more than happy to rework the implementation based on any preferences. Some examples include:
- we could remove the `grackle_version` struct altogether (i.e. if you aren't a fan of introducing new structs). In this case we modify `get_grackle_version` to have the following signature
  ```c++
  void get_grackle_version(const char** version, const char** branch, const char** revision);
  ```
  so that it can be used like so:
  ```c++
  const char *version, *branch, *revision;
  get_grackle_version(&version, &branch, &revision);
  ```
- we could remove `get_grackle_version` and store the grackle information in a global variable (in that case we might want to change the name of the struct).
- we could replace the `version` fields with more specific fields that encode the major number, minor number, patch number, ... etc.