### PR TITLE
[Bugfix] Issue #113 - provide sensible version info without git

### DIFF
--- a/src/clib/Make.config.targets
+++ b/src/clib/Make.config.targets
@@ -86,9 +86,15 @@ suggest-clean:
 show-version:
 	@echo
 	@echo "The Grackle Version $(LIB_RELEASE_VERSION)"
-	@echo "Git Branch   `git rev-parse --abbrev-ref HEAD`"
-	@echo "Git Revision `git rev-parse HEAD`"
-	@echo
+	@USEGIT=`command -v git &> /dev/null && git status &> /dev/null && \
+	         echo "1"`; \
+	if [ "$${USEGIT}" == "1" ]; then \
+	     echo "Git Branch   `git rev-parse --abbrev-ref HEAD`"; \
+	     echo "Git Revision `git rev-parse HEAD`"; \
+	else \
+	     echo "Git Branch N/A"; \
+	     echo "Git Revision N/A"; \
+	fi
 
 #-----------------------------------------------------------------------
 


### PR DESCRIPTION
This addresses Issue #113, which documented a compilation error that occurred when Grackle is downloaded without the Git metadata. The errors occurred because `make show-version` produced output with an unexpected format.