### PR TITLE
Change get_grackle_version to explicitly accept zero arguments.

### DIFF
--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -230,7 +230,7 @@ auto_get_version.c:
 	-@echo '#error "Something went wrong while auto-generating macros"'                     >> $@
 	-@echo '#endif'                                                                         >> $@
 	-@echo ''                                                                               >> $@
-	-@echo 'grackle_version get_grackle_version() {'                                        >> $@
+	-@echo 'grackle_version get_grackle_version(void) {'                                    >> $@
 	-@echo '  grackle_version out;'                                                         >> $@
 	-@echo '  out.version = AUTO_VERSION;'                                                  >> $@
 	-@echo '  out.branch = AUTO_BRANCH;'                                                    >> $@

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -171,6 +171,6 @@ int _calculate_temperature(chemistry_data *my_chemistry,
 
 int _free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
-grackle_version get_grackle_version();
+grackle_version get_grackle_version(void);
 
 #endif


### PR DESCRIPTION
I was getting a compile error on various systems saying, "function declaration isn't a prototype". This seems to come from ambiguities in C around functions that accept no arguments.