### PR TITLE
Changing _inner_range to `static inline` to avoid undefined reference

### DIFF
--- a/src/clib/index_helper.c
+++ b/src/clib/index_helper.c
@@ -14,6 +14,20 @@
 #include "grackle_types.h"
 #include "index_helper.h"
 
+// to help the compiler optimize the associated for-loops, this function:
+//   - is implemented inline
+//   - returns results as a struct rather than by modifying pointer arguments
+grackle_index_range _inner_range(int outer_index,
+                                        const grackle_index_helper* ind_helper)
+{
+  int k = (outer_index / ind_helper->num_j_inds) + ind_helper->k_start;
+  int j = (outer_index % ind_helper->num_j_inds) + ind_helper->j_start;
+  int outer_offset = ind_helper->i_dim * (j + ind_helper->j_dim * k);
+  grackle_index_range out = {ind_helper->i_start + outer_offset,
+                             ind_helper->i_end + outer_offset};
+  return out;
+}
+
 grackle_index_helper _build_index_helper(const grackle_field_data *my_fields)
 {
   grackle_index_helper out;

--- a/src/clib/index_helper.c
+++ b/src/clib/index_helper.c
@@ -14,20 +14,6 @@
 #include "grackle_types.h"
 #include "index_helper.h"
 
-// to help the compiler optimize the associated for-loops, this function:
-//   - is implemented inline
-//   - returns results as a struct rather than by modifying pointer arguments
-grackle_index_range _inner_range(int outer_index,
-                                        const grackle_index_helper* ind_helper)
-{
-  int k = (outer_index / ind_helper->num_j_inds) + ind_helper->k_start;
-  int j = (outer_index % ind_helper->num_j_inds) + ind_helper->j_start;
-  int outer_offset = ind_helper->i_dim * (j + ind_helper->j_dim * k);
-  grackle_index_range out = {ind_helper->i_start + outer_offset,
-                             ind_helper->i_end + outer_offset};
-  return out;
-}
-
 grackle_index_helper _build_index_helper(const grackle_field_data *my_fields)
 {
   grackle_index_helper out;

--- a/src/clib/index_helper.h
+++ b/src/clib/index_helper.h
@@ -54,8 +54,16 @@ typedef struct
 // to help the compiler optimize the associated for-loops, this function:
 //   - is implemented inline
 //   - returns results as a struct rather than by modifying pointer arguments
-inline grackle_index_range _inner_range(int outer_index,
-                                        const grackle_index_helper* ind_helper);
+static inline grackle_index_range _inner_range(int outer_index, 
+                                               const grackle_index_helper* ind_helper)
+{
+  int k = (outer_index / ind_helper->num_j_inds) + ind_helper->k_start;
+  int j = (outer_index % ind_helper->num_j_inds) + ind_helper->j_start;
+  int outer_offset = ind_helper->i_dim * (j + ind_helper->j_dim * k);
+  grackle_index_range out = {ind_helper->i_start + outer_offset,
+                             ind_helper->i_end + outer_offset};
+  return out;
+}
 
 grackle_index_helper _build_index_helper(const grackle_field_data *my_fields);
 

--- a/src/clib/index_helper.h
+++ b/src/clib/index_helper.h
@@ -55,15 +55,7 @@ typedef struct
 //   - is implemented inline
 //   - returns results as a struct rather than by modifying pointer arguments
 inline grackle_index_range _inner_range(int outer_index,
-                                        const grackle_index_helper* ind_helper)
-{
-  int k = (outer_index / ind_helper->num_j_inds) + ind_helper->k_start;
-  int j = (outer_index % ind_helper->num_j_inds) + ind_helper->j_start;
-  int outer_offset = ind_helper->i_dim * (j + ind_helper->j_dim * k);
-  grackle_index_range out = {ind_helper->i_start + outer_offset,
-                             ind_helper->i_end + outer_offset};
-  return out;
-}
+                                        const grackle_index_helper* ind_helper);
 
 grackle_index_helper _build_index_helper(const grackle_field_data *my_fields);
 


### PR DESCRIPTION
I'm not sure why the new `_inner_range` function wasn't being included in the library, but I needed to move it from the header file to the .c file. When grackle was linked from enzo, it raised a linking error saying that `_inner_range` was undefined. I confirmed that it was not present in the library. I am using GCC v9.4.0.

```console
$ nm -D .libs/libgrackle.so
[...]
U _inner_range
[...]
```