### PR TITLE
Increment python testing version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,12 +187,12 @@ workflows:
    tests:
      jobs:
        - test-suite:
-           name: "Python 3.7 tests"
-           tag: "3.7.12"
+           name: "Python 3.8 tests"
+           tag: "3.8.14"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.7.12"
+           tag: "3.8.14"
 
    weekly:
      triggers:
@@ -204,9 +204,9 @@ workflows:
                 - master
      jobs:
        - test-suite:
-           name: "Python 3.7 tests"
-           tag: "3.7.12"
+           name: "Python 3.8 tests"
+           tag: "3.8.14"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.7.12"
+           tag: "3.8.14"

--- a/src/python/pygrackle/yt_fields.py
+++ b/src/python/pygrackle/yt_fields.py
@@ -71,7 +71,7 @@ _field_map = {
     'x-velocity': (('gas', 'velocity_x'), 'code_velocity'),
     'y-velocity': (('gas', 'velocity_y'), 'code_velocity'),
     'z-velocity': (('gas', 'velocity_z'), 'code_velocity'),
-    'energy': (('gas', 'thermal_energy'), 'code_velocity**2'),
+    'energy': (('gas', 'specific_thermal_energy'), 'code_velocity**2'),
     'RT_heating_rate': (('gas', 'photo_gamma'), 'erg/s')
 }
 


### PR DESCRIPTION
This updates the python version used on circleci to 3.8, which is now the minimum supported version by yt.

Edit, the "thermal_energy" field was deprecated and now removed in yt in favor of "specific_thermal_energy". This updates pygrackle for that change.