### PR TITLE
Add warnings about compiling in single precision.

### DIFF
--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -151,6 +151,13 @@ For example, to change the optimization to high, type:
 
     ~/grackle/src/clib $ make opt-high
 
+.. warning::
+   Compiling Grackle in single precision (with ``make precision-32``) is **not**
+   recommended. Because of the high dynamic range involved in calculating many
+   chemistry and cooling rates, running Grackle in single precision can produce
+   unreliable results. This is especially true when running with
+   :c:data:`primordial_chemistry` >= 1.
+
 Custom settings can be saved for later use by typing:
 
 .. highlight:: none

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -109,6 +109,10 @@ libgrackle.la: $(MODULES) autogen dep $(OBJS_LIB) MACHNOTES
 	else \
 	  $(LIBTOOL) --mode=link --tag=CC $(LD) $(LDFLAGS) -o $@ $(OBJS_LIB) $(LIBS) -rpath $(INSTALL_LIB_DIR) -release $(LIB_RELEASE_VERSION) ; \
 	fi)
+	@(if [ $(ASSEMBLE_PRECISION_NUMBER) == "4" ]; then \
+	  echo "WARNING: Grackle compiled with precision-32."; \
+	  echo "Using Grackle in single precision is known to produce unreliable results in certain conditions. Compiling in double precision (precision-64) is recommended."; \
+	fi)
 
 MACHNOTES: 
 	@echo $(MACHINE_NOTES)


### PR DESCRIPTION
This closes issue #14. I've added a warning to both the docs and to be printed at compile time.