### PR TITLE
Document optimization issues in Fortran example with gfortran 9.2.1 & 9.4.0

### DIFF
--- a/src/example/Makefile
+++ b/src/example/Makefile
@@ -200,6 +200,9 @@ fortran_example: $(MODULES) fortran_example.o
              exit 1; \
           fi)
 
+# the following target uses -O1 optimization because problems can arise with
+# higher levels of optimization. A comment in fortran_example.F provides more
+# details about the problems
 .F.o:
 	@rm -f $@
 	@echo "Compiling $<"

--- a/src/example/fortran_example.F
+++ b/src/example/fortran_example.F
@@ -1,3 +1,14 @@
+c     Problems relating to grackle_data%grackle_data_file arise when
+c     this program is compiled using certain versions of gfortran
+c     (including versions 9.2.1 & 9.4.0) with an optimization level of
+c     -O2 or higher.
+c
+c     In these cases, the compiler appears to make an aggressive
+c     optimization in which the program deallocates the `filename`
+c     variable before calls to certain grackle routines. This is
+c     problematic because grackle_data%grackle_data_file points to the
+c     address of the data held in `filename`
+
       program fortran_example
 
       USE ISO_C_BINDING


### PR DESCRIPTION
This resolves Issue #64

This changeset adds clarifying comments to `src/example/fortran_example.F` and `src/example/Makefile` explaining that problems arise when compiling the example with certain gfortran versions (including 9.2.1 & 9.4.0) with an optimization flag of -O2 or higher.