### PR TITLE
documentation fixes for later sphinx versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
             pip install --upgrade pip
             pip install --upgrade wheel
             pip install --upgrade setuptools
-            pip install 'sphinx<3.0' 'Jinja2<3.1'
+            pip install sphinx
 
   download-test-data:
     description: "Download test data."

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -703,7 +703,7 @@ git revision.
    This structure is used to organize version information for the
    library.
 
-.. c:var:: const* char version
+.. c:var:: const char* version
 
    Specifies the version of the library using this template:
    ``<MAJOR>.<MINOR>(.<MICRO>)(.dev<DEV_NUM>)``. In this template
@@ -714,12 +714,12 @@ git revision.
    provided in increasing order: ``"3.0"``, ``"3.1"``, ``"3.1.1"``,
    ``"3.1.2"``, ``"3.2.dev1"``, ``"3.2.dev2"``, ``"3.2"``.
 
-.. c:var:: const* char branch
+.. c:var:: const char* branch
 
    Specifies the name of the git branch that the library was compiled
    from.
 
-.. c:var:: const* char revision
+.. c:var:: const char* revision
 
    Specifies the hash identifying the git commit that the library was
    compiled from.

--- a/doc/source/RateFunctions.rst
+++ b/doc/source/RateFunctions.rst
@@ -4,7 +4,7 @@
    :language: c
 
 Rate Functions
-=========================
+==============
 
 Grackle supports the calculation of individual rate coefficients at specific temperatures.
 When running Grackle's chemistry solving schemes, these coefficients are computed internally,
@@ -19,228 +19,179 @@ within the ``grackle/src/clib/`` directory. The vast majority of the rate coeffi
 of the same general form, however there are exceptions which will be discussed individually.
 
 The General Rate Function
----------------------------
+-------------------------
 
 Structure
-^^^^^^^^^^
+^^^^^^^^^
 
-As mentioned previously, most rate functions have the same structure and can therefore be called
-identically:
+As mentioned previously, most rate functions have the same structure
+and can therefore be called identically as below, where RATE_NAME is
+the name of the coefficient you wish to calculate.
 
-.. code-block:: c
+.. c:function:: double RATE_NAME_rate(double T, double units, chemistry_data *my_chemistry); 
 
-    double {RATE_NAME}_rate(double T, double units, chemistry_data *my_chemistry);
+   This returns the value of the rate at a given temperature. The
+   calculated rate will be divided through by the value given in the
+   `units` argument. If set to 1, the rate will be returned in CGS
+   units.
 
-where {RATE_NAME} is the name of the coefficient you wish to calculate.
-
-Inputs
-""""""""
-
-.. c:var:: double T
-
-    Gas temperature at which you would like the coefficient to be calculated.
-
-.. c:var:: double units
-
-    The calculated rate will be divided through by this number; thereby facilitating
-    the use of arbitrary units. If set to 1, the rate will be calculated in CGS units
-    -- the units in which the rate equation is defined.
-
-.. c:var:: chemistry_data *my_chemistry
-
-    Pointer to the chemistry_data struct containing the parameters for your calculations.
-
-Outputs
-"""""""""
-
-.. c:var:: double rate
-
-    Rate coefficient calculated for the specified input parameters.
+   :param double T: gas temperature
+   :param double units: units
+   :param chemistry_data \*my_chemistry: pointer to chemistry_data struct containing parameters.
+   :rtype: double
+   :returns: value of rate coefficient
 
 Examples
-^^^^^^^^^^
+^^^^^^^^
 
 Example 1
-""""""""""
+"""""""""
 
-Suppose we wish to print the value of the ``k1`` rate coefficient at a temperature of 1000 K.
-Given we have already configured our chemistry parameters within a ``chemistry_data`` struct
-named ``my_chemistry``, we can obtain the result by simply calling the function as follows:
+Suppose we wish to print the value of the ``k1`` rate coefficient at a
+temperature of 1000 K. Given we have already configured our chemistry
+parameters within a :c:data:`chemistry_data` struct named
+``my_chemistry``, we can obtain the result by simply calling the
+function as follows:
 
 .. code-block:: c 
 
-    #include "grackle_rate_functions.h"
+   #include "grackle_rate_functions.h"
 
-    double result = k1_rate(1e3, 1., &my_chemistry);
-    printf("k1 %e", result);
+   double result = k1_rate(1e3, 1., &my_chemistry);
+   printf("k1 %e", result);
 
 where our result is in cgs units.
 
 Example 2
-""""""""""
+"""""""""
 
-The rate coefficient ``reHII`` can be calculated via two different methods depending on the
-status of the :c:data:`CaseBRecombination` parameter within the ``chemistry_data`` struct (named
-``my_chemistry`` in this example), which can take values of either 0 or 1. Suppose we wish to compare
-the results of each calculation method over an arbitrary temperature range, we can achieve this by
-the following:
+The rate coefficient ``reHII`` can be calculated via two different
+methods depending on the status of the :c:data:`CaseBRecombination`
+parameter within the :c:data:`chemistry_data` struct (named
+``my_chemistry`` in this example), which can take values of either 0
+or 1. Suppose we wish to compare the results of each calculation
+method over an arbitrary temperature range, we can achieve this by the
+following:
 
 .. code-block:: c
 
-    #include "grackle_rate_functions.h"
+   #include "grackle_rate_functions.h"
 
-    /// Define temperature range to calculate coefficients over
-    double tempStart = 1e1;
-    double tempEnd = 1e8;
-    double numTemps = 1e3;
-    double tempSpacing = (tempEnd - tempStart) / numTemps;
+   // Define temperature range to calculate coefficients over
+   double tempStart = 1e1;
+   double tempEnd = 1e8;
+   double numTemps = 1e3;
+   double tempSpacing = (tempEnd - tempStart) / numTemps;
 
-    // Create arrays for results storage
-    double caseAResults[(int) numTemps];
-    double caseBResults[(int) numTemps];
+   // Create arrays for results storage
+   double caseAResults[(int) numTemps];
+   double caseBResults[(int) numTemps];
 
-    // Set value of my_chemistry.CaseBRecombination
-    for (int caseB = 0; caseB < 2; caseB++) {
-        my_chemistry.CaseBRecombination = caseB;
-        // Iterate over temperature range
-        for (int i = 0; i < numTemps; i++) {
-            double temp = tempStart + i*tempSpacing;
-            // Store results in appropriate array
-            if (caseB == 0) {
-                caseAResults[i] = reHII_rate(temp, 1., &my_chemistry);
-            } else {
-                caseBResults[i] = reHII_rate(temp, 1., &my_chemistry);
-            }
-        }
-    }
+   // Set value of my_chemistry.CaseBRecombination
+   for (int caseB = 0; caseB < 2; caseB++) {
+       my_chemistry.CaseBRecombination = caseB;
+       // Iterate over temperature range
+       for (int i = 0; i < numTemps; i++) {
+           double temp = tempStart + i*tempSpacing;
+           // Store results in appropriate array
+           if (caseB == 0) {
+               caseAResults[i] = reHII_rate(temp, 1., &my_chemistry);
+           } else {
+               caseBResults[i] = reHII_rate(temp, 1., &my_chemistry);
+           }
+       }
+   }
 
-where we have created an array of reHII coefficients for both settings of ``chemistry_data.CaseBRecombination``
-over the same temperature range.
+where we have created an array of ``reHII`` coefficients for both
+settings of ``chemistry_data.CaseBRecombination`` over the same
+temperature range.
 
 The k13dd Rate Function
--------------------------
+-----------------------
 
 Structure
-^^^^^^^^^^
+^^^^^^^^^
 
-The ``k13dd`` rate function, which describes the density-dependent dissociation of molecular hydrogen, is similar
-in form to the general rate functions, the only difference being its additional input parameter. This is a pointer
-to an array of length ``14 * sizeof(double)``, which will hold the outputs of the function. The function
-always calculates fourteen rate parameters, the first seven of which correspond to direct collisional dissociation,
-whilst the latter seven correspond to dissociative tunneling -- please see
-`Martin, Schwarz & Mandy, 1996 <http://adsabs.harvard.edu/pdf/1996ApJ...461..265M>`_ for further details on how 
-these are calculated. The structure of the function is then:
+The ``k13dd`` rate function, which describes the density-dependent
+dissociation of molecular hydrogen, is similar in form to the general
+rate functions, the only difference being its additional input
+parameter. This is a pointer to an array of length ``14 *
+sizeof(double)``, which will hold the outputs of the function. The
+function always calculates fourteen rate parameters, the first seven
+of which correspond to direct collisional dissociation, whilst the
+latter seven correspond to dissociative tunneling -- please see
+`Martin, Schwarz & Mandy, 1996
+<http://adsabs.harvard.edu/pdf/1996ApJ...461..265M>`_ for further
+details on how these are calculated. The structure of the function is
+then:
 
-.. code-block:: c
+.. c:function:: void k13dd_rate(double T, double units, double *results_array, chemistry_data *my_chemistry);
 
-    void k13dd_rate(double T, double units, double *results_array, chemistry_data *my_chemistry);
+   Calculates the density-dependent molecular hydrogen dissociation
+   rate. The calculated rate will be divided through by the value
+   given in the `units` argument. If set to 1, the units will be CGS.
 
-Inputs
-""""""""
-
-.. c:var:: double T
-
-    Gas temperature at which you would like the coefficient to be calculated.
-
-.. c:var:: double units
-
-    The calculated rate will be divided through by this number; thereby facilitating
-    the use of arbitrary units. If set to 1, the rate will be calculated in CGS units
-    -- the units in which the rate equation is defined.
-
-.. c:var:: double *results_array
-
-    Pointer to array of length :c_inline:`14 * sizeof(double)` in which the calculated rate coefficients will
-    be stored.
-
-.. c:var:: chemistry_data *my_chemistry
-
-    Pointer to the chemistry_data struct containing the parameters for your calculations.
-
-Outputs
-"""""""""
-
-.. c:var:: None
-
-    Results are stored within results_array, function itself is void.
+   :param double T: gas temperature
+   :param double units: units
+   :param double \*results_array: pointer to array of length :c_inline:`14 * sizeof(double)` in which the calculated rate coefficients will be stored.
+   :param chemistry_data \*my_chemistry: pointer to chemistry_data struct containing parameters.
+   :rtype: void
+   :returns: Nothing is returned, but values are set for the array pointed to by the ``results_array`` pointer.
 
 Examples
-^^^^^^^^^^
+^^^^^^^^
 
-Example 1
-""""""""""
-
-Suppose we would like to print the rate coefficients for the dissociation of molecular hydrogen via the 
-tunneling process at a temperature of 1e5 K. Given we have already configured our chemistry parameters
-within a ``chemistry_data`` struct named ``my_chemistry``, we can obtain the coefficients by the following:
+Suppose we would like to print the rate coefficients for the
+dissociation of molecular hydrogen via the tunneling process at a
+temperature of 1e5 K. Given we have already configured our chemistry
+parameters within a :c:data:`chemistry_data` struct named
+``my_chemistry``, we can obtain the coefficients by the following:
 
 .. code-block:: c
 
-    #include "grackle_rate_functions.h"
+   #include "grackle_rate_functions.h"
 
-    // Create an array of the correct size for result storage.
-    double results[14];
+   // Create an array of the correct size for result storage.
+   double results[14];
 
-    // Call the function at the desired temperature, getting results in cgs units.
-    k13dd_rate(1e5, 1., &results, &my_chemistry);
+   // Call the function at the desired temperature, getting results in cgs units.
+   k13dd_rate(1e5, 1., &results, &my_chemistry);
 
-    // Print the results corresponding to dissociative tunneling.
-    for (int i = 7; i < 14; i++) {
-        printf("k13dd %e", results[i]);
-    }
+   // Print the results corresponding to dissociative tunneling.
+   for (int i = 7; i < 14; i++) {
+       printf("k13dd %e", results[i]);
+   }
 
 The h2dust Rate Function
--------------------------
+------------------------
 
 Structure
-^^^^^^^^^^
+^^^^^^^^^
 
-The ``h2dust`` rate function, which describes the formation of molecular hydrogen on dust grains, is similar
-in form to the general rate functions, the only difference being its additional input parameter; a
-``double`` which represents the dust temperature. The function returns a ``double`` just as the
-general rate function, its structure is then:
+The ``h2dust`` rate function, which describes the formation of
+molecular hydrogen on dust grains, is similar in form to the general
+rate functions, the only difference being its additional input
+parameter; a ``double`` which represents the dust temperature. The
+function returns a ``double`` just as the general rate function, its
+structure is then:
 
-.. code-block:: c
+.. c:function:: double h2dust_rate(double T, double T_dust, double units, chemistry_data *my_chemistry);
 
-    double h2dust_rate(double T, double T_dust, double units, chemistry_data *my_chemistry);
-
-Inputs
-""""""""
-
-.. c:var:: double T
-
-    Gas temperature at which you would like the coefficient to be calculated.
-
-.. c:var:: double T_dust
-
-    Dust temperature at which you would like the coefficient to be calculated.
-
-.. c:var:: double units
-
-    The calculated rate will be divided through by this number; thereby facilitating
-    the use of arbitrary units. If set to 1, the rate will be calculated in CGS units
-    -- the units in which the rate equation is defined.
-
-.. c:var:: chemistry_data *my_chemistry
-
-    Pointer to the chemistry_data struct containing the parameters for your calculations.
-
-Outputs
-"""""""""
-
-.. c:var:: double rate
-
-    The rate coefficient for the h2dust reaction at the specified input parameters.
+   :param double T: gas temperature
+   :param double T_gas: dust temperature
+   :param double units: units
+   :param chemistry_data \*my_chemistry: pointer to chemistry_data struct containing parameters.
+   :rtype: double
+   :returns: value of rate coefficient
 
 Examples
-^^^^^^^^^^
+^^^^^^^^
 
-Example 1
-""""""""""
-
-Suppose we would like to calculate the ``h2dust`` rate coefficients for a gas temperature of 1e4 K, with a 
-varying dust temperature. Given we have already configured our chemistry parameters within a ``chemistry_data``
-struct named ``my_chemistry``, we can obtain the coefficients by the following:
+Suppose we would like to calculate the ``h2dust`` rate coefficients
+for a gas temperature of 1e4 K, with a varying dust temperature. Given
+we have already configured our chemistry parameters within a
+:c:data`chemistry_data` struct named ``my_chemistry``, we can obtain
+the coefficients by the following:
 
 .. code-block:: c
 
@@ -262,39 +213,26 @@ struct named ``my_chemistry``, we can obtain the coefficients by the following:
     }
     
 The Scalar Rate Functions
----------------------------
+-------------------------
 
 Structure
-^^^^^^^^^^
-The scalar rate functions (``comp``, ``gammah``, ``gamma_isrf``) are simpler than the general rate functions
-due to their temperature independence. They require only two inputs and return a single ``double``,
-their structure is as follows:
+^^^^^^^^^
+The scalar rate functions (``comp``, ``gammah``, ``gamma_isrf``) are
+simpler than the general rate functions due to their temperature
+independence. They require only two inputs and return a single
+``double``, their structure is as below, where SCALAR_NAME is the name
+of the scalar rate coefficient you wish to calculate. These are called
+in the same way as the general rate functions, ignoring the
+temperature dependancy -- please see their documentation for basic
+examples.
 
-.. code-block:: c
+.. c:function:: double SCALAR_NAME_rate(double units, chemistry_data *my_chemistry);
 
-    double {SCALAR_NAME}_rate(double units, chemistry_data *my_chemistry);
+   This returns the value of the rate. The calculated rate will be
+   divided through by the value given in the `units` argument. If set
+   to 1, the rate will be returned in CGS units.
 
-where {SCALAR_NAME} is the name of the scalar rate coefficient you wish to calculate. These are
-called in the same way as the general rate functions, ignoring the temperature dependancy -- 
-please see their documentation for basic examples.
-
-Inputs
-""""""""
-
-.. c:var:: double units
-
-    The calculated rate will be divided through by this number; thereby facilitating
-    the use of arbitrary units. If set to 1, the rate will be calculated in CGS units
-    -- the units in which the rate equation is defined.
-
-.. c:var:: chemistry_data *my_chemistry
-
-    Pointer to the chemistry_data struct containing the parameters for your calculations.
-
-Outputs
-"""""""""
-
-.. c:var:: double rate
-
-    The rate coefficient for the specified chemistry parameters.
-
+   :param double units: units
+   :param chemistry_data \*my_chemistry: pointer to chemistry_data struct containing parameters.
+   :rtype: double
+   :returns: value of rate coefficient

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -13,10 +13,10 @@ Grackle has three versions of most functions.
    and :c:data:`chemistry_data_storage` instances to be provided as
    arguments. These are explicity thread-safe as they use no global data.
 
-3. (Deprecated) :ref:`internal_functions` take pointers to individual field arrays
-   instead of using the :c:data:`grackle_field_data` struct. These are
-   mainly used by the Python interface. These functions have been deprecated
-   and will be removed in a future version.
+3. (Deprecated) :ref:`internal_functions` take pointers to individual
+   field arrays instead of using the :c:data:`grackle_field_data`
+   struct. These functions have been deprecated and will be removed in
+   versions of Grackle later than 3.2.
 
 .. _primary_functions:
 
@@ -270,7 +270,8 @@ described here can be used in conjunction with the :ref:`local_functions`.
 
 .. c:function:: int _solve_chemistry(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, double dt_value, int grid_rank, int *grid_dimension, int *grid_start, int *grid_end, gr_float *density, gr_float *internal_energy, gr_float *x_velocity, gr_float *y_velocity, gr_float *z_velocity, gr_float *HI_density, gr_float *HII_density, gr_float *HM_density, gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density, gr_float *H2I_density, gr_float *H2II_density, gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density, gr_float *e_density, gr_float *metal_density);
 
-   This function has been deprecated. Please use solve_chemistry or local_solve_chemistry.
+   This function has been deprecated and will be removed in versions
+   of Grackle later than 3.2. Please use solve_chemistry or local_solve_chemistry.
 
    Evolves the species densities and internal energies over a given timestep
    by solving the chemistry and cooling rate equations.
@@ -306,7 +307,8 @@ described here can be used in conjunction with the :ref:`local_functions`.
 
 .. c:function:: int _calculate_cooling_time(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, int grid_rank, int *grid_dimension, int *grid_start, int *grid_end, gr_float *density, gr_float *internal_energy, gr_float *x_velocity, gr_float *y_velocity, gr_float *z_velocity, gr_float *HI_density, gr_float *HII_density, gr_float *HM_density, gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density, gr_float *H2I_density, gr_float *H2II_density, gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density, gr_float *e_density, gr_float *metal_density, gr_float *cooling_time);
 
-   This function has been deprecated. Please use calculate_cooling_time or local_calculate_cooling_time.
+   This function has been deprecated and will be removed in versions
+   of Grackle later than 3.2. Please use calculate_cooling_time or local_calculate_cooling_time.
 
    Calculates the instantaneous cooling time.
 
@@ -341,7 +343,8 @@ described here can be used in conjunction with the :ref:`local_functions`.
 
 .. c:function:: int _calculate_gamma(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, int grid_rank, int *grid_dimension, int *grid_start, int *grid_end, gr_float *density, gr_float *internal_energy, gr_float *HI_density, gr_float *HII_density, gr_float *HM_density, gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density, gr_float *H2I_density, gr_float *H2II_density, gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density, gr_float *e_density, gr_float *metal_density, gr_float *my_gamma);
 
-   This function has been deprecated. Please use calculate_gamma or local_calculate_gamma.
+   This function has been deprecated and will be removed in versions
+   of Grackle later than 3.2. Please use calculate_gamma or local_calculate_gamma.
 
    Calculates the effective adiabatic index. This is only useful with
    :c:data:`primordial_chemistry` >= 2 as the only thing that alters gamma from the single 
@@ -375,7 +378,8 @@ described here can be used in conjunction with the :ref:`local_functions`.
 
 .. c:function:: int _calculate_pressure(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, int grid_rank, int *grid_dimension, int *grid_start, int *grid_end, gr_float *density, gr_float *internal_energy, gr_float *HI_density, gr_float *HII_density, gr_float *HM_density, gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density, gr_float *H2I_density, gr_float *H2II_density, gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density, gr_float *e_density, gr_float *metal_density, gr_float *pressure);
 
-   This function has been deprecated. Please use calculate_pressure or local_calculate_pressure.
+   This function has been deprecated and will be removed in versions
+   of Grackle later than 3.2. Please use calculate_pressure or local_calculate_pressure.
 
    Calculates the gas pressure.
 
@@ -433,6 +437,7 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :rtype: int
    :returns: 1 (success) or 0 (failure)
 
-   This function has been deprecated. Please use calculate_temperature or local_calculate_temperature.
+   This function has been deprecated and will be removed in versions
+   of Grackle later than 3.2. Please use calculate_temperature or local_calculate_temperature.
 
    Calculates the gas temperature.

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -11,10 +11,10 @@ Grackle has three versions of most functions.
 
 2. :ref:`local_functions` require pointers to :c:data:`chemistry_data`
    and :c:data:`chemistry_data_storage` instances to be provided as
-   arguments.  These are explicity thread-safe as they use no global data.
+   arguments. These are explicity thread-safe as they use no global data.
 
 3. (Deprecated) :ref:`internal_functions` take pointers to individual field arrays
-   instead of using the :c:data:`grackle_field_data` struct.  These are
+   instead of using the :c:data:`grackle_field_data` struct. These are
    mainly used by the Python interface. These functions have been deprecated
    and will be removed in a future version.
 
@@ -25,7 +25,7 @@ Primary Functions
 
 .. c:function:: int set_default_chemistry_parameters(chemistry_data *my_grackle_data);
 
-   Initializes the ``grackle_data`` data structure.  This must be called 
+   Initializes the ``grackle_data`` data structure. This must be called
    before run-time parameters can be set.
 
    :param chemistry_data* my_grackle_data: run-time parameters
@@ -101,7 +101,7 @@ Primary Functions
 
 .. c:function:: int calculate_gamma(code_units *my_units, grackle_field_data *my_fields, gr_float *my_gamma);
 
-   Calculates the effective adiabatic index.  This is only useful with
+   Calculates the effective adiabatic index. This is only useful with
    :c:data:`primordial_chemistry` >= 2 as the only thing that alters gamma from the single
    value is H\ :sub:`2`.
 
@@ -162,7 +162,7 @@ Local Functions
 
 These can be used to create explicitly thread-safe code or to call
 the various functions with different parameter values within a
-single code.  The :c:data:`chemistry_data` and
+single code. The :c:data:`chemistry_data` and
 :c:data:`chemistry_data_storage` structs should be setup using the
 initialization functions discussed in :ref:`internal_functions`.
 
@@ -193,7 +193,7 @@ initialization functions discussed in :ref:`internal_functions`.
 
 .. c:function:: int local_calculate_gamma(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, grackle_field_data *my_fields, gr_float *my_gamma);
 
-   Calculates the effective adiabatic index.  This is only useful with
+   Calculates the effective adiabatic index. This is only useful with
    :c:data:`primordial_chemistry` >= 2 as the only thing that alters gamma from the single
    value is H\ :sub:`2`.
 
@@ -246,12 +246,12 @@ initialization functions discussed in :ref:`internal_functions`.
 Internal Functions
 ------------------
 
-These functions are mostly for internal use.  The initialization functions
+These functions are mostly for internal use. The initialization functions
 described here can be used in conjunction with the :ref:`local_functions`.
 
 .. c:function:: chemistry_data _set_default_chemistry_parameters(void);
 
-   Initializes and returns :c:type:`chemistry_data` data structure.  This must be
+   Initializes and returns :c:type:`chemistry_data` data structure. This must be
    called before run-time parameters can be set.
 
    :returns: data structure containing all run-time parameters and all chemistry and cooling data arrays
@@ -281,26 +281,26 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :param double dt_value: the integration timestep in code units
    :param int grid_rank: the dimensionality of the grid
    :param int* grid_dimension: array holding the size of the baryon field in each dimension
-   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones
-   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones.
+   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones
+   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones.
    :param gr_float* density: array containing the density values in code units
    :param gr_float* internal_energy: array containing the specific internal energy values in code units corresponding to *erg/g*
    :param gr_float* x_velocity: array containing the x velocity values in code units
    :param gr_float* y_velocity: array containing the y velocity values in code units
    :param gr_float* z_velocity: array containing the z velocity values in code units
-   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 2.
-   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 2.
-   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` >= 2.
-   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` = 3.
-   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` = 3.
-   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array.  Used with :c:data:`primordial_chemistry` = 3.
-   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass.  Used with :c:data:`primordial_chemistry` >= 1.
-   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array.  Used with :c:data:`metal_cooling` = 1.
+   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array. Used with :c:data:`metal_cooling` = 1.
    :rtype: int
    :returns: 1 (success) or 0 (failure)
 
@@ -315,12 +315,26 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :param code_units* my_units: code units conversions
    :param int grid_rank: the dimensionality of the grid
    :param int* grid_dimension: array holding the size of the baryon field in each dimension
-   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones
-   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones.
+   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones
+   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones.
    :param gr_float* density: array containing the density values in code units
    :param gr_float* internal_energy: array containing the specific internal energy values in code units corresponding to *erg/g*
-   :param gr_float* x_velocity, y_velocity, z_velocity: arrays containing the x, y, and z velocity values in code units
-   :param gr_float* HI_density, HII_density, HM_density, HeI_density, HeII_density, HeIII_density, H2I_density, H2II_density, DI_density, DII_density, HDI_density, e_density, metal_density: arrays containing the species densities in code units equivalent those of the density array
+   :param gr_float* x_velocity: array containing the x velocity values in code units
+   :param gr_float* y_velocity: array containing the y velocity values in code units
+   :param gr_float* z_velocity: array containing the z velocity values in code units
+   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array. Used with :c:data:`metal_cooling` = 1.
    :param gr_float* cooling_time: array which will be filled with the calculated cooling time values
    :rtype: int
    :returns: 1 (success) or 0 (failure)
@@ -329,7 +343,7 @@ described here can be used in conjunction with the :ref:`local_functions`.
 
    This function has been deprecated. Please use calculate_gamma or local_calculate_gamma.
 
-   Calculates the effective adiabatic index.  This is only useful with 
+   Calculates the effective adiabatic index. This is only useful with
    :c:data:`primordial_chemistry` >= 2 as the only thing that alters gamma from the single 
    value is H\ :sub:`2`.
 
@@ -338,11 +352,23 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :param code_units* my_units: code units conversions
    :param int grid_rank: the dimensionality of the grid
    :param int* grid_dimension: array holding the size of the baryon field in each dimension
-   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones
-   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones.
+   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones
+   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones.
    :param gr_float* density: array containing the density values in code units
    :param gr_float* internal_energy: array containing the specific internal energy values in code units corresponding to *erg/g*
-   :param gr_float* HI_density, HII_density, HM_density, HeI_density, HeII_density, HeIII_density, H2I_density, H2II_density, DI_density, DII_density, HDI_density, e_density, metal_density: arrays containing the species densities in code units equivalent those of the density array
+   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array. Used with :c:data:`metal_cooling` = 1.
    :param gr_float* my_gamma: array which will be filled with the calculated gamma values
    :rtype: int
    :returns: 1 (success) or 0 (failure)
@@ -358,11 +384,23 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :param code_units* my_units: code units conversions
    :param int grid_rank: the dimensionality of the grid
    :param int* grid_dimension: array holding the size of the baryon field in each dimension
-   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones
-   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones.
+   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones
+   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones.
    :param gr_float* density: array containing the density values in code units
    :param gr_float* internal_energy: array containing the specific internal energy values in code units corresponding to *erg/g*
-   :param gr_float* HI_density, HII_density, HM_density, HeI_density, HeII_density, HeIII_density, H2I_density, H2II_density, DI_density, DII_density, HDI_density, e_density, metal_density: arrays containing the species densities in code units equivalent those of the density array
+   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array. Used with :c:data:`metal_cooling` = 1.
    :param gr_float* pressure: array which will be filled with the calculated pressure values
    :rtype: int
    :returns: 1 (success) or 0 (failure)
@@ -374,11 +412,23 @@ described here can be used in conjunction with the :ref:`local_functions`.
    :param code_units* my_units: code units conversions
    :param int grid_rank: the dimensionality of the grid
    :param int* grid_dimension: array holding the size of the baryon field in each dimension
-   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones
-   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields.  This is used to ignore ghost zones.
+   :param int* grid_start: array holding the starting indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones
+   :param int* grid_end: array holding the ending indices in each dimension of the active portion of the baryon fields. This is used to ignore ghost zones.
    :param gr_float* density: array containing the density values in code units
    :param gr_float* internal_energy: array containing the specific internal energy values in code units corresponding to *erg/g*
-   :param gr_float* HI_density, HII_density, HM_density, HeI_density, HeII_density, HeIII_density, H2I_density, H2II_density, DI_density, DII_density, HDI_density, e_density, metal_density: arrays containing the species densities in code units equivalent those of the density array
+   :param gr_float* HI_density: array containing the HI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HII_density: array containing the HII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HM_density: array containing the H\ :sup:`-`\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* HeI_density: array containing the HeI densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeII_density: array containing the HeII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* HeIII_density: array containing the HeIII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* H2I_density: array containing the H\ :sub:`2`:\  densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* H2II_density: array containing the H\ :sub:`2`:sup:`+`\ densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` >= 2.
+   :param gr_float* DI_density: array containing the DI (deuterium) densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* DII_density: array containing the DII densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* HDI_density: array containing the HD densities in code units equivalent those of the density array. Used with :c:data:`primordial_chemistry` = 3.
+   :param gr_float* e_density: array containing the e\ :sup:`-`\  densities in code units equivalent those of the density array but normalized to the ratio of the proton to electron mass. Used with :c:data:`primordial_chemistry` >= 1.
+   :param gr_float* metal_density: array containing the metal densities in code units equivalent those of the density array. Used with :c:data:`metal_cooling` = 1.
    :param gr_float* temperature: array which will be filled with the calculated temperature values
    :rtype: int
    :returns: 1 (success) or 0 (failure)


### PR DESCRIPTION
Grackle has required a version of sphinx prior to 3.0 to build warning/error free. This fixes the various issues that popped up after sphinx 3.0 and should now allow the docs to be compiled without warnings or errors on the latest version of sphinx. I had to restructure the section on reaction rates to avoid duplicate definitions, but the content is largely the same. There were a handful of other syntax issues as well.