### PR TITLE
Use later ubuntu image on circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ executors:
       tag:
         type: string
         default: latest
-    docker:
+    machine:
       - image: ubuntu-2204
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ executors:
         type: string
         default: latest
     machine:
-      image: ubuntu-2204
+      image: ubuntu-2204:current
 
 jobs:
   test-suite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,8 +131,6 @@ executors:
       tag:
         type: string
         default: latest
-    machine:
-      - image: ubuntu-2204
 
 jobs:
   test-suite:
@@ -140,9 +138,8 @@ jobs:
       tag:
         type: string
         default: latest
-    executor:
-      name: python
-      tag: << parameters.tag >>
+    machine:
+      image: ubuntu-2204
 
     working_directory: ~/grackle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,8 @@ executors:
       tag:
         type: string
         default: latest
+    machine:
+      - image: ubuntu-2204
 
 jobs:
   test-suite:
@@ -138,8 +140,9 @@ jobs:
       tag:
         type: string
         default: latest
-    machine:
-      image: ubuntu-2204
+    executor:
+      name: python
+      tag: << parameters.tag >>
 
     working_directory: ~/grackle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,9 @@ jobs:
       name: python
       tag: << parameters.tag >>
 
+
+    resource_class: large
+
     working_directory: ~/grackle
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ commands:
             git submodule update --init --remote
             source $BASH_ENV
             sudo apt update
-            sudo apt install -y libhdf5-serial-dev gfortran libtool-bin
-            python3 -m venv $HOME/venv
+            sudo apt install -y python3.8 python3-pip libhdf5-serial-dev gfortran libtool-bin
+            python3.8 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel
@@ -71,7 +71,7 @@ commands:
       - run:
           name: "Install dependencies for docs build."
           command: |
-            python3 -m venv $HOME/venv
+            python3.8 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel
@@ -132,7 +132,7 @@ executors:
         type: string
         default: latest
     docker:
-      - image: cimg/python:<< parameters.tag >>
+      - image: ubuntu-2204
 
 jobs:
   test-suite:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ executors:
         type: string
         default: latest
     machine:
-      - image: ubuntu-2204
+      image: ubuntu-2204
 
 jobs:
   test-suite:


### PR DESCRIPTION
This is an attempt to upgrade to a later version of ubuntu for circleci, which should allow us to use some later versions of gcc.