### PR TITLE
Remove duplicate precision definition during compile

### DIFF
--- a/src/clib/Make.config.assemble
+++ b/src/clib/Make.config.assemble
@@ -66,7 +66,6 @@
     endif
 
     PRECISION_DEFINE = GRACKLE_FLOAT_$(ASSEMBLE_PRECISION_NUMBER)
-    ASSEMBLE_PRECISION_DEFINES = -D$(PRECISION_DEFINE)
 
 #=======================================================================
 # COMPILERS
@@ -194,8 +193,7 @@
     LDOUTPUT_FLAGS = $(ASSEMBLE_LDOUTPUT_FLAGS)
 
     DEFINES = $(MACH_DEFINES) \
-              $(ASSEMBLE_IO_DEFINES) \
-              $(ASSEMBLE_PRECISION_DEFINES)
+              $(ASSEMBLE_IO_DEFINES)
 
     INCLUDES = $(MACH_INCLUDES) \
                $(MAKEFILE_INCLUDES)   -I.

--- a/src/clib/grackle_fortran_types.def
+++ b/src/clib/grackle_fortran_types.def
@@ -12,6 +12,8 @@
 ! software.
 !=======================================================================
 
+#include "grackle_float.h"
+
 #ifdef GRACKLE_FLOAT_4
 #define tiny 1.e-20
 #define huge 1.e+20

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -12,6 +12,7 @@
 ************************************************************************/
 
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 #include "hdf5.h"
 #include "grackle_macros.h"

--- a/src/clib/phys_const.def
+++ b/src/clib/phys_const.def
@@ -1,3 +1,4 @@
+#include "grackle_float.h"
 
 #ifdef GRACKLE_FLOAT_4
 


### PR DESCRIPTION
This fixes an issues reported on slack where intel compilers were picking up a duplicate definition of CONFIG_BFLOAT. This was introduced in PR #118 when this define was added to a header file but not removed from the compile flags. I also added a missing header that intel asked for.