### PR TITLE
Deprecating functions

### DIFF
--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -222,6 +222,8 @@ of using comoving units, see the `cosmological unit system
 <https://github.com/enzo-project/enzo-dev/blob/main/src/enzo/CosmologyGetUnits.C>`__
 in the `Enzo <http://enzo-project.org/>`_ code.
 
+.. _setup_data-storage:
+
 Chemistry Data
 --------------
 
@@ -713,7 +715,7 @@ Clearing the memory
 
 .. code-block:: c++
 
-  _free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data(my_grackle_data, &grackle_rates);
 
 Grackle is using global structures and therefore the global structure ``grackle_rates`` needs also to be released.
 

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -715,7 +715,7 @@ Clearing the memory
 
 .. code-block:: c++
 
-  free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data();
 
 Grackle is using global structures and therefore the global structure ``grackle_rates`` needs also to be released.
 

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -192,15 +192,15 @@ For the sake of argument let's imagine that the user is storing the chemistry da
 
    .. code-block:: c++
 
-      chemistry_data * my_chemistry_data = new chemistry_data;
-      if (local_initialize_chemistry_parameters(my_chemistry_data) == 0) {
+      chemistry_data *my_chemistry = new chemistry_data;
+      if (local_initialize_chemistry_parameters(my_chemistry) == 0) {
          fprintf(stderr, "Error in local_initialize_chemistry_parameters.\n");
       }
 
 2. Next, the user can configure the stored parameters.
    They can do this by directly modifying the stored parameters (e.g. ``my_chemistry->use_grackle = 1``) or by using the :ref:`dynamic-api`.
 
-After the user has finished initializing ``my_chemistry``, and have configured an instance of :c:data:`code_units` (more detail provided :ref:`here <code-units>`), they can initialize an instance of :c:data:`chemistry_data_storage` with 
+After the user has finished initializing ``my_chemistry``, and has configured an instance of :c:data:`code_units` (more detail provided :ref:`here <code-units>`), they can initialize an instance of :c:data:`chemistry_data_storage` with 
 :c:func:`local_initialize_chemistry_data`:
 
 .. code-block:: c++

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -41,6 +41,14 @@ Primary Functions
    :rtype: int
    :returns: 1 (success) or 0 (failure)
 
+.. c:function:: int free_chemistry_data ();
+
+   Deallocates all data allocations made during the call to :c:func:`initialize_chemistry_data`.
+   Issues may arise if the global ``grackle_data`` data structure was mutated between the call to :c:func:`initialize_chemistry_data` and the call to this function.
+
+   :rtype: int
+   :returns: 1 (success) or 0 (failure)
+
 .. c:function:: void set_velocity_units(code_units *my_units);
 
    Sets the :c:data:`velocity_units` value of the input ``my_units``
@@ -253,12 +261,14 @@ Configuration/Cleanup Functions
       In addition to modifying the contents of ``my_rates``, this function may also mutate the values stored in ``my_chemistry`` to set them to "more sensible" values (based on other values stored in ``my_chemistry``).
 
 
-.. c:function:: int free_chemistry_data \
+.. c:function:: int local_free_chemistry_data \
                 (chemistry_data *my_chemistry, \
                 chemistry_data_storage *my_rates);
 
    Deallocates all data held by the members of ``my_rates`` allocated during its initialization in :c:func:`local_initialize_chemistry_data` (or :c:func:`initialize_chemistry_data`).
    Issues may arise if ``my_chemistry`` was mutated between the initialization of ``my_rates`` and the call to this function.
+
+   This is the "local" counterpart to :c:func:`free_chemistry_data`.
 
    :param chemistry_data \*my_chemistry: :ref:`fully configured <local_setup_data-storage>` run-time parameters
    :param chemistry_data_storage \*my_rates: previously initialized chemistry and cooling rate data structure

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -246,8 +246,8 @@ Configuration/Cleanup Functions
    This function should only be called after the user has finished configuring both ``my_chemistry`` and ``my_units``.
    This function assumes that none of ``my_rates``'s members of pointer type hold valid memory addresses (i.e. where applicable, the function allocates fresh storage and makes no attempts to deallocate/reuse storage).
 
-   After calling this function, the user should avoid modifying any of the fields of ``my_chemistry`` or ``my_units``.
-   The **only** exception to this rule is that ``my_units``'s :c:var:`a_value` field may be mutated when using comoving units (i.e. ``my_units``'s :c:var:`comoving_coordinates` field is ``1``).
+   After calling this function, the user should avoid modifying any of the fields of ``my_chemistry``.
+   The user should also avoid modifying ``my_units`` in a way that modifies the internal cooling units (e.g. it's fine to mutate ``my_units``'s :c:var:`a_value` field when its :c:var:`comoving_coordinates` field is ``1``).
 
    To deallocate any storage allocated by this function, use :c:func:`free_chemistry_data`.
 

--- a/src/clib/Make.config.assemble
+++ b/src/clib/Make.config.assemble
@@ -193,7 +193,8 @@
     LDOUTPUT_FLAGS = $(ASSEMBLE_LDOUTPUT_FLAGS)
 
     DEFINES = $(MACH_DEFINES) \
-              $(ASSEMBLE_IO_DEFINES)
+              $(ASSEMBLE_IO_DEFINES) \
+              $(OTHER_DEFINES)
 
     INCLUDES = $(MACH_INCLUDES) \
                $(MAKEFILE_INCLUDES)   -I.

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -73,6 +73,13 @@ include $(MAKE_CONFIG_OVERRIDE)
 -include $(HOME)/.grackle/Make.mach.$(CONFIG_MACHINE)
 
 #-----------------------------------------------------------------------
+# OTHER_DEFINES is used to specify a macro indicating that legacy
+# functions defined inline in the main header file should be omitted
+# while compiling the library
+#-----------------------------------------------------------------------
+OTHER_DEFINES = -DOMIT_LEGACY_INTERNAL_GRACKLE_FUNC
+
+#-----------------------------------------------------------------------
 # Make.config.assemble takes the settings in the Make.config.settings
 # and Make.config.override, and generates the appropriate make variables
 # required by this makefile.  E.g. $(CXX), $(CXXFLAGS), etc.

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -30,13 +30,13 @@ double get_temperature_units(code_units *my_units);
 
 int set_default_chemistry_parameters(chemistry_data *my_grackle);
 
-chemistry_data _set_default_chemistry_parameters(void);
+int local_initialize_chemistry_parameters(chemistry_data *my_chemistry);
 
 int initialize_chemistry_data(code_units *my_units);
 
-int _initialize_chemistry_data(chemistry_data *my_chemistry, 
-                               chemistry_data_storage *my_rates,
-                               code_units *my_units);
+int local_initialize_chemistry_data(chemistry_data *my_chemistry, 
+                                    chemistry_data_storage *my_rates,
+                                    code_units *my_units);
 
 int* local_chemistry_data_access_int(chemistry_data* my_chemistry,
                                      const char* param_name);
@@ -180,8 +180,36 @@ int _calculate_temperature(chemistry_data *my_chemistry,
                            gr_float *e_density, gr_float *metal_density,
                            gr_float *temperature) __attribute__ ((deprecated));
 
-int _free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
+int free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
 grackle_version get_grackle_version(void);
+
+// Below, we conditionally define a handful of deprecated functions to maintain
+// backwards compatibility. These functions were deprecated because externally
+// visible identifiers that begin with an underscore invoke undefined behavior
+
+#ifndef OMIT_LEGACY_INTERNAL_GRACKLE_FUNC
+
+#warning "The legacy functions, _initialize_chemistry_data, _set_default_chemistry_parameters & _free_chemistry_data will be removed after version 3.2. To avoid defining these function (and this message) define the OMIT_LEGACY_INTERNAL_GRACKLE_FUNC macro."
+
+inline __attribute__((deprecated)) chemistry_data
+_set_default_chemistry_parameters(void) {
+  chemistry_data my_chemistry;
+  local_initialize_chemistry_parameters(&my_chemistry);
+  return my_chemistry;
+}
+
+inline __attribute__((deprecated)) int
+_initialize_chemistry_data(chemistry_data *my_chemistry,
+                           chemistry_data_storage *my_rates,
+                           code_units *my_units)
+{ return local_initialize_chemistry_data(my_chemistry, my_rates, my_units); }
+
+inline __attribute__((deprecated)) int
+_free_chemistry_data (chemistry_data *my_chemistry,
+                      chemistry_data_storage *my_rates)
+{ return free_chemistry_data(my_chemistry, my_rates); }
+
+#endif /* OMIT_LEGACY_INTERNAL_GRACKLE_FUNC */
 
 #endif

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -183,7 +183,9 @@ int _calculate_temperature(chemistry_data *my_chemistry,
                            gr_float *e_density, gr_float *metal_density,
                            gr_float *temperature) __attribute__ ((deprecated));
 
-int free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
+int free_chemistry_data(void);
+
+int local_free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
 grackle_version get_grackle_version(void);
 
@@ -211,7 +213,7 @@ _initialize_chemistry_data(chemistry_data *my_chemistry,
 inline __attribute__((deprecated)) int
 _free_chemistry_data (chemistry_data *my_chemistry,
                       chemistry_data_storage *my_rates)
-{ return free_chemistry_data(my_chemistry, my_rates); }
+{ return local_free_chemistry_data(my_chemistry, my_rates); }
 
 #endif /* OMIT_LEGACY_INTERNAL_GRACKLE_FUNC */
 

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -275,9 +275,16 @@ void show_parameters(FILE *fp, chemistry_data *my_chemistry){
   #undef ENTRY
 }
 
+int free_chemistry_data(void){
+  if (local_free_chemistry_data(grackle_data, &grackle_rates) == FAIL) {
+    fprintf(stderr, "Error in local_free_chemistry_data.\n");
+    return FAIL;
+  }
+  return SUCCESS;
+}
 
-int free_chemistry_data(chemistry_data *my_chemistry,
-			chemistry_data_storage *my_rates) {
+int local_free_chemistry_data(chemistry_data *my_chemistry,
+                              chemistry_data_storage *my_rates) {
   if (my_chemistry->primordial_chemistry > 0) {
     GRACKLE_FREE(my_rates->ceHI);
     GRACKLE_FREE(my_rates->ceHeI);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -57,9 +57,9 @@ static void show_version(FILE *fp)
   fprintf (fp, "\n");
 }
 
-int _initialize_chemistry_data(chemistry_data *my_chemistry,
-                               chemistry_data_storage *my_rates,
-                               code_units *my_units)
+int local_initialize_chemistry_data(chemistry_data *my_chemistry,
+                                    chemistry_data_storage *my_rates,
+                                    code_units *my_units)
 {
 
   if (grackle_verbose) {
@@ -249,15 +249,17 @@ int _initialize_chemistry_data(chemistry_data *my_chemistry,
 
 int initialize_chemistry_data(code_units *my_units)
 {
-  if (_initialize_chemistry_data(grackle_data, &grackle_rates,
-                                 my_units) == FAIL) {
-    fprintf(stderr, "Error in _initialize_chemistry_data.\n");
+  if (local_initialize_chemistry_data(grackle_data, &grackle_rates,
+                                      my_units) == FAIL) {
+    fprintf(stderr, "Error in local_initialize_chemistry_data.\n");
     return FAIL;
   }
   return SUCCESS;
 }
 
 // Define helpers for the show_parameters function
+// NOTE: it's okay that these functions all begin with an underscore since they
+//       each have internal linkage (i.e. they are each declared static)
 static void _show_field_INT(FILE *fp, const char* field, int val)
 { fprintf(fp, "%-33s = %d\n", field, val); }
 static void _show_field_DOUBLE(FILE *fp, const char* field, double val)
@@ -274,8 +276,8 @@ void show_parameters(FILE *fp, chemistry_data *my_chemistry){
 }
 
 
-int _free_chemistry_data(chemistry_data *my_chemistry,
-			 chemistry_data_storage *my_rates) {
+int free_chemistry_data(chemistry_data *my_chemistry,
+			chemistry_data_storage *my_rates) {
   if (my_chemistry->primordial_chemistry > 0) {
     GRACKLE_FREE(my_rates->ceHI);
     GRACKLE_FREE(my_rates->ceHeI);

--- a/src/clib/set_default_chemistry_parameters.c
+++ b/src/clib/set_default_chemistry_parameters.c
@@ -24,21 +24,20 @@ int grackle_verbose = FALSE;
 chemistry_data *grackle_data = NULL;
 chemistry_data_storage grackle_rates;
 
-chemistry_data _set_default_chemistry_parameters(void);
-
-int set_default_chemistry_parameters(chemistry_data *my_grackle)
+int local_initialize_chemistry_parameters(chemistry_data *my_chemistry)
 {
-  *my_grackle = _set_default_chemistry_parameters();
-  grackle_data = my_grackle;
+  if (my_chemistry == NULL){
+    return FAIL;
+  }
+  // assign the default value to each field of my_chemistry
+  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) my_chemistry->FIELD = DEFAULT_VAL;
+  #include "grackle_chemistry_data_fields.def"
+  #undef ENTRY
   return SUCCESS;
 }
 
-chemistry_data _set_default_chemistry_parameters(void)
+int set_default_chemistry_parameters(chemistry_data *my_grackle)
 {
-  chemistry_data my_chemistry;
-  // assign the default value to each field of my_chemistry
-  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) my_chemistry.FIELD = DEFAULT_VAL;
-  #include "grackle_chemistry_data_fields.def"
-  #undef ENTRY
-  return my_chemistry;
+  grackle_data = my_grackle;
+  return local_initialize_chemistry_parameters(my_grackle);
 }

--- a/src/example/cxx_example.C
+++ b/src/example/cxx_example.C
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 
   fprintf(stderr, "dust_temperature = %g K.\n", dust_temperature[0]);
 
-  _free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data(my_grackle_data, &grackle_rates);
 
   return EXIT_SUCCESS;
 }

--- a/src/example/cxx_example.C
+++ b/src/example/cxx_example.C
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 
   fprintf(stderr, "dust_temperature = %g K.\n", dust_temperature[0]);
 
-  free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data();
 
   return EXIT_SUCCESS;
 }

--- a/src/example/cxx_grid_example.C
+++ b/src/example/cxx_grid_example.C
@@ -361,7 +361,7 @@ int check_if_grackle_mutates_ghost_zone(int primordial_chemistry,
     }
   }
 
-  _free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data(my_grackle_data, &grackle_rates);
   delete my_grackle_data;
 
   delete[] my_fields.grid_dimension;

--- a/src/example/cxx_grid_example.C
+++ b/src/example/cxx_grid_example.C
@@ -361,7 +361,7 @@ int check_if_grackle_mutates_ghost_zone(int primordial_chemistry,
     }
   }
 
-  free_chemistry_data(my_grackle_data, &grackle_rates);
+  free_chemistry_data();
   delete my_grackle_data;
 
   delete[] my_fields.grid_dimension;

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -248,7 +248,7 @@ cdef extern from "grackle.h":
                 c_field_data *my_fields,
                 gr_float *dust_temperature)
 
-    int c_free_chemistry_data "free_chemistry_data" (
+    int c_local_free_chemistry_data "local_free_chemistry_data" (
         c_chemistry_data *my_chemistry,
         c_chemistry_data_storage *my_rates)
 

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -169,8 +169,14 @@ cdef extern from "grackle_types.h":
       const char* branch;
       const char* revision;
 
+# define a macro to omit legacy grackle function defined in grackle.h
+cdef extern from *:
+    """
+    #define OMIT_LEGACY_INTERNAL_GRACKLE_FUNC
+    """
+
 cdef extern from "grackle.h":
-    c_chemistry_data _set_default_chemistry_parameters()
+    int local_initialize_chemistry_parameters(c_chemistry_data *my_chemistry)
 
     void set_velocity_units(c_code_units *my_units)
 
@@ -178,9 +184,9 @@ cdef extern from "grackle.h":
 
     double get_temperature_units(c_code_units *my_units)
 
-    int _initialize_chemistry_data(c_chemistry_data *my_chemistry,
-                                   c_chemistry_data_storage *my_rates,
-                                   c_code_units *my_units)
+    int local_initialize_chemistry_data(c_chemistry_data *my_chemistry,
+                                        c_chemistry_data_storage *my_rates,
+                                        c_code_units *my_units)
 
     int* local_chemistry_data_access_int(c_chemistry_data *my_chemistry,
                                          const char* param_name)

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -41,7 +41,7 @@ cdef class chemistry_data:
         if self.data_copy_from_init is None:
             return # nothing to uninitialize
 
-        c_free_chemistry_data(
+        c_local_free_chemistry_data(
             &((<_wrapped_c_chemistry_data?>self.data_copy_from_init).data),
             &self.rates)
 

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -28,8 +28,8 @@ cdef class chemistry_data:
         self.data = _wrapped_c_chemistry_data()
 
     def initialize(self):
-        ret =  _initialize_chemistry_data(&self.data.data, &self.rates,
-                                          &self.units)
+        ret =  local_initialize_chemistry_data(&self.data.data, &self.rates,
+                                               &self.units)
         if ret is None:
             raise RuntimeError("Error initializing chemistry")
         return ret
@@ -958,7 +958,7 @@ cdef class _wrapped_c_chemistry_data:
     #   by a null character (the Python interface just hides if from users)
 
     def __cinit__(self):
-        self.data = _set_default_chemistry_parameters()
+        local_initialize_chemistry_parameters(&self.data)
         self._string_buffers = {}
 
     def _access_struct_field(self, key, val = None):


### PR DESCRIPTION
This addresses the changes highlighted in Issue #138. Specifically, we have renamed some functions to drop the leading underscore in the names.

## Main Changes:

As discussed in that issue, I have renamed the following functions:

- `_set_default_chemistry_parameters` -> `local_initialize_chemistry_parameters`
- `_initialize_chemistry_data` -> `local_initialize_chemistry_data`

I also renamed `_free_chemistry_data` to be called `free_chemistry_data`. However, there's a piece of me that wonders whether it should really be called `local_free_chemistry_data`. **What do you think about that?**

## Secondary Changes:
I had to make a few tweaks to the python wrapper and the code examples to make use of the new function names.

I also updated some of the documentation that relates to these functions. While doing that, I tried to add slightly more detail about how the local functions get used. We can definitely clip this if you dislike it

## Backwards compatibility:

As discussed in issue #138, we maintain backwards compatibility, we include the following section (within the spoiler tag) in the ``grackle.h`` header.

<details> 
  <summary>Backwards compatible function declaration/definitions </summary>
  
   ```c++
// Below, we conditionally define a handful of deprecated functions to maintain
// backwards compatibility. These functions were deprecated because externally
// visible identifiers that begin with an underscore invoke undefined behavior

#ifndef OMIT_LEGACY_INTERNAL_GRACKLE_FUNC

#warning "The legacy functions, _initialize_chemistry_data, _set_default_chemistry_parameters & _free_chemistry_data will be removed in version 3.3. To avoid defining these function (and this message) define the OMIT_LEGACY_INTERNAL_GRACKLE_FUNC macro."

inline __attribute__((deprecated)) chemistry_data
_set_default_chemistry_parameters(void) {
  chemistry_data my_chemistry;
  local_initialize_chemistry_parameters(&my_chemistry);
  return my_chemistry;
}

inline __attribute__((deprecated)) int
_initialize_chemistry_data(chemistry_data *my_chemistry,
                           chemistry_data_storage *my_rates,
                           code_units *my_units)
{ return local_initialize_chemistry_data(my_chemistry, my_rates, my_units); }

inline __attribute__((deprecated)) int
_free_chemistry_data (chemistry_data *my_chemistry,
                      chemistry_data_storage *my_rates)
{ return free_chemistry_data(my_chemistry, my_rates); }

#endif /* OMIT_LEGACY_INTERNAL_GRACKLE_FUNC */
   ```
</details>

In short, the user can opt-out of defining these functions by defining the ``OMIT_LEGACY_INTERNAL_GRACKLE_FUNC`` macro. While doing this, I realized that it made sense for us to pass `-DOMIT_LEGACY_INTERNAL_GRACKLE_FUNC` to the compiler while building the Grackle-library. By doing this, we avoid including definitions of these functions within the Grackle-library itself (the deprecated functions are **only** defined in external user applications). This required 2 tweaks to the Makefile. Let me know if you don't like this choice - we can definitely work around that.

As an aside, let me know if you want do something similar for the other deprecated functions (e.g. `_solve_chemistry`, `_calculate_temperature`, etc.). I'm not so sure that is worth doing, and it might make more sense to discuss that outside of the PR. For reference, I included example of what that might look like in the following spoiler-tag (there might be bugs - I haven't tested it)

<details>
  <summary>Other deprecated functions </summary>
  
   ```c++
inline __attribute__((deprecated)) grackle_field_data
_legacy_make_field_data(double dx_value,
                        int grid_rank, int *grid_dimension,
                        int *grid_start, int *grid_end,
                        gr_float *density, gr_float *internal_energy,
                        gr_float *x_velocity, gr_float *y_velocity, gr_float *z_velocity,
                        gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                        gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                        gr_float *H2I_density, gr_float *H2II_density,
                        gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                        gr_float *e_density, gr_float *metal_density, gr_float *dust_density,
                        gr_float *volumetric_heating_rate, gr_float *specific_heating_rate,
                        gr_float *RT_heating_rate, gr_float *RT_HI_ionization_rate, gr_float *RT_HeI_ionization_rate,
                        gr_float *RT_HeII_ionization_rate, gr_float *RT_H2_dissociation_rate,
                        gr_float *H2_self_shielding_length)
{
  grackle_field_data my_fields;
  my_fields.grid_dx                  = dx_value;
  my_fields.grid_rank                = grid_rank;
  my_fields.grid_dimension           = grid_dimension;
  my_fields.grid_start               = grid_start;
  my_fields.grid_end                 = grid_end;
  my_fields.density                  = density;
  my_fields.internal_energy          = internal_energy;
  my_fields.x_velocity               = x_velocity;
  my_fields.y_velocity               = y_velocity;
  my_fields.z_velocity               = z_velocity;
  my_fields.HI_density               = HI_density;
  my_fields.HII_density              = HII_density;
  my_fields.HM_density               = HM_density;
  my_fields.HeI_density              = HeI_density;
  my_fields.HeII_density             = HeII_density;
  my_fields.HeIII_density            = HeIII_density;
  my_fields.H2I_density              = H2I_density;
  my_fields.H2II_density             = H2II_density;
  my_fields.DI_density               = DI_density;
  my_fields.DII_density              = DII_density;
  my_fields.HDI_density              = HDI_density;
  my_fields.e_density                = e_density;
  my_fields.metal_density            = metal_density;
  my_fields.dust_density             = dust_density;
  my_fields.volumetric_heating_rate  = volumetric_heating_rate;
  my_fields.specific_heating_rate    = specific_heating_rate;
  my_fields.RT_heating_rate          = RT_heating_rate;
  my_fields.RT_HI_ionization_rate    = RT_HI_ionization_rate;
  my_fields.RT_HeI_ionization_rate   = RT_HeI_ionization_rate;
  my_fields.RT_HeII_ionization_rate  = RT_HeII_ionization_rate;
  my_fields.RT_H2_dissociation_rate  = RT_H2_dissociation_rate;
  my_fields.H2_self_shielding_length = H2_self_shielding_length;
  return my_fields;
}

#include <stdio.h> // for error-reporting in the following inline functions

inline __attribute__((deprecated)) int
_solve_chemistry(chemistry_data *my_chemistry,
                 chemistry_data_storage *my_rates,
                 code_units *my_units, double dt_value, double dx_value,
                 int grid_rank, int *grid_dimension,
                 int *grid_start, int *grid_end,
                 gr_float *density, gr_float *internal_energy,
                 gr_float *x_velocity, gr_float *y_velocity, gr_float *z_velocity,
                 gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                 gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                 gr_float *H2I_density, gr_float *H2II_density,
                 gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                 gr_float *e_density, gr_float *metal_density, gr_float *dust_density,
                 gr_float *volumetric_heating_rate, gr_float *specific_heating_rate,
                 gr_float *RT_heating_rate, gr_float *RT_HI_ionization_rate, gr_float *RT_HeI_ionization_rate,
                 gr_float *RT_HeII_ionization_rate, gr_float *RT_H2_dissociation_rate,
                 gr_float *H2_self_shielding_length)
{
  grackle_field_data my_fields = _legacy_make_field_data
    (dx_value,grid_rank,grid_dimension,grid_start,grid_end,
     density,internal_energy,x_velocity,y_velocity,z_velocity,
     HI_density,HII_density,HM_density,HeI_density,HeII_density,HeIII_density,
     H2I_density,H2II_density,DI_density,DII_density,HDI_density,
     e_density,metal_density,dust_density,
     volumetric_heating_rate,specific_heating_rate,
     RT_heating_rate,RT_HI_ionization_rate,RT_HeI_ionization_rate,
     RT_HeII_ionization_rate,RT_H2_dissociation_rate,H2_self_shielding_length);
  if (local_solve_chemistry(my_chemistry, my_rates,
                            my_units, &my_fields, dt_value) == FAIL) {
    fprintf(stderr, "Error in local_solve_chemistry.\n");
    return FAIL;
  }
  return SUCCESS;
}

inline __attribute__ ((deprecated)) int
_calculate_cooling_time(chemistry_data *my_chemistry,
                        chemistry_data_storage *my_rates,
                        code_units *my_units,
                        int grid_rank, int *grid_dimension,
                        int *grid_start, int *grid_end,
                        gr_float *density, gr_float *internal_energy,
                        gr_float *x_velocity, gr_float *y_velocity, gr_float *z_velocity,
                        gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                        gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                        gr_float *H2I_density, gr_float *H2II_density,
                        gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                        gr_float *e_density, gr_float *metal_density, gr_float *dust_density,
                        gr_float *cooling_time, gr_float *RT_heating_rate,
                        gr_float *volumetric_heating_rate, gr_float *specific_heating_rate)
{
  grackle_field_data my_fields = _legacy_make_field_data
    (/* dx_value = */0.0,grid_rank,grid_dimension,grid_start,grid_end,
     density,internal_energy,x_velocity,y_velocity,z_velocity,
     HI_density,HII_density,HM_density,HeI_density,HeII_density,HeIII_density,
     H2I_density,H2II_density,DI_density,DII_density,HDI_density,
     e_density,metal_density,dust_density,
     volumetric_heating_rate,specific_heating_rate,
     RT_heating_rate, NULL,NULL,NULL,NULL,NULL);

  if (local_calculate_cooling_time(my_chemistry, my_rates, my_units,
                                   &my_fields, cooling_time) == FAIL) {
    fprintf(stderr, "Error in local_calculate_cooling_time.\n");
    return FAIL;
  }
  return SUCCESS;
}

inline __attribute__((deprecated)) int
_calculate_gamma(chemistry_data *my_chemistry,
                 chemistry_data_storage *my_rates,
                 code_units *my_units,
                 int grid_rank, int *grid_dimension,
                 int *grid_start, int *grid_end,
                 gr_float *density, gr_float *internal_energy,
                 gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                 gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                 gr_float *H2I_density, gr_float *H2II_density,
                 gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                 gr_float *e_density, gr_float *metal_density,
                 gr_float *my_gamma)
{
  grackle_field_data my_fields = _legacy_make_field_data
    (/* dx_value = */0.0, grid_rank,grid_dimension,grid_start,grid_end,
     density,internal_energy, /* velocities: */ NULL,NULL,NULL,
     HI_density,HII_density,HM_density,HeI_density,HeII_density,HeIII_density,
     H2I_density,H2II_density,DI_density,DII_density,HDI_density,
     e_density,metal_density,
     NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);

  if (local_calculate_gamma(my_chemistry, my_rates, my_units,
                            &my_fields, my_gamma) == FAIL) {
    fprintf(stderr, "Error in local_calculate_gamma.\n");
    return FAIL;
  }
  return SUCCESS;
}

inline __attribute__ ((deprecated)) int
_calculate_pressure(chemistry_data *my_chemistry,
                    chemistry_data_storage *my_rates,
                    code_units *my_units,
                    int grid_rank, int *grid_dimension,
                    int *grid_start, int *grid_end,
                    gr_float *density, gr_float *internal_energy,
                    gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                    gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                    gr_float *H2I_density, gr_float *H2II_density,
                    gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                    gr_float *e_density, gr_float *metal_density,
                    gr_float *pressure)
{
  grackle_field_data my_fields = _legacy_make_field_data
    (/* dx_value = */0.0, grid_rank,grid_dimension,grid_start,grid_end,
     density,internal_energy, /* velocities: */ NULL,NULL,NULL,
     HI_density,HII_density,HM_density,HeI_density,HeII_density,HeIII_density,
     H2I_density,H2II_density,DI_density,DII_density,HDI_density,
     e_density,metal_density,
     NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);

  if (local_calculate_pressure(my_chemistry, my_rates, my_units,
                               &my_fields, pressure) == FAIL) {
    fprintf(stderr, "Error in local_calculate_pressure.\n");
    return FAIL;
  }
  return SUCCESS;
}

inline __attribute__((deprecated)) int
_calculate_temperature(chemistry_data *my_chemistry,
                       chemistry_data_storage *my_rates,
                       code_units *my_units,
                       int grid_rank, int *grid_dimension,
                       int *grid_start, int *grid_end,
                       gr_float *density, gr_float *internal_energy,
                       gr_float *HI_density, gr_float *HII_density, gr_float *HM_density,
                       gr_float *HeI_density, gr_float *HeII_density, gr_float *HeIII_density,
                       gr_float *H2I_density, gr_float *H2II_density,
                       gr_float *DI_density, gr_float *DII_density, gr_float *HDI_density,
                       gr_float *e_density, gr_float *metal_density,
                       gr_float *temperature)
{
  grackle_field_data my_fields = _legacy_make_field_data
    (/* dx_value = */0.0, grid_rank,grid_dimension,grid_start,grid_end,
     density,internal_energy, /* velocities: */ NULL,NULL,NULL,
     HI_density,HII_density,HM_density,HeI_density,HeII_density,HeIII_density,
     H2I_density,H2II_density,DI_density,DII_density,HDI_density,
     e_density,metal_density,
     NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);

  if (local_calculate_temperature(my_chemistry, my_rates, my_units,
                                  &my_fields, temperature) == FAIL) {
    fprintf(stderr, "Error in local_calculate_temperature.\n");
    return FAIL;
  }
  return SUCCESS;
}
   ```
</details>