### PR TITLE
Add ability to query the number of parameters of a given type

### DIFF
--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -246,6 +246,12 @@ initialization functions discussed in :ref:`internal_functions`.
 Dynamic Configuration Functions
 +++++++++++++++++++++++++++++++
 
+.. c:function:: size_t grackle_num_params(const char* type_name)
+
+   Returns the number of parameters of a given type that are stored as members of the :c:data:`chemistry_data` struct.
+   The argument is expected to be ``"int"``, ``"double"``, or ``"string"``.
+   This will return ``0`` for any other argument
+
 The following functions are used to provide dynamic access to members of the :c:data:`chemistry_data` struct. They will return ``NULL`` when ``my_chemistry`` is ``NULL``, ``param_name`` isn't a known parameter, or the ``param_name`` is not associated with the type mentioned in the function name.
 
 .. c:function:: int* local_chemistry_data_access_int(chemistry_data *my_chemistry, const char* param_name);

--- a/src/clib/dynamic_api.c
+++ b/src/clib/dynamic_api.c
@@ -20,40 +20,59 @@
 #include <string.h>
 #include "grackle_chemistry_data.h"
 
-// The following enum is only used internally
-enum param_type {INT_PARAM, DOUBLE_PARAM, STRING_PARAM};
+// initialize _int_param_l, _double_param_l & _string_param_l. They are sized
+// lists that respectively hold entries for each int, double, and string field
+// in chemistry_data. These are only used internally
+typedef struct { const size_t offset; const char * name; } param_entry;
+typedef struct { const size_t len; const param_entry * entries; } param_list;
 
-// initialize _param_list, which holds an entry for each field in
-// chemistry_data. This is only used internally
+#define INIT_PAR_LIST(ENTRIES) {sizeof(ENTRIES) / sizeof(param_entry), ENTRIES}
 
-typedef struct {
-  const enum param_type type;
-  const size_t offset;
-  const char * name;
-} param_entry;
+#define _LIST_INT_INT(FIELD) {offsetof(chemistry_data, FIELD), #FIELD},
+#define _LIST_INT_DOUBLE(FIELD) /* ... */
+#define _LIST_INT_STRING(FIELD) /* ... */
 
-static const param_entry _param_list[] =
-{
-  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) \
-    { TYPE ## _PARAM, offsetof(chemistry_data, FIELD), #FIELD },
+#define _LIST_DOUBLE_INT(FIELD) /* ... */
+#define _LIST_DOUBLE_DOUBLE(FIELD) {offsetof(chemistry_data, FIELD), #FIELD},
+#define _LIST_DOUBLE_STRING(FIELD) /* ... */
+
+#define _LIST_STRING_INT(FIELD) /* ... */
+#define _LIST_STRING_DOUBLE(FIELD) /* ... */
+#define _LIST_STRING_STRING(FIELD) {offsetof(chemistry_data, FIELD), #FIELD},
+
+static const param_entry _int_param_entries[] = {
+  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) _LIST_INT_ ## TYPE(FIELD)
   #include "grackle_chemistry_data_fields.def"
   #undef ENTRY
 };
+static const param_list _int_param_l = INIT_PAR_LIST(_int_param_entries);
 
-// This is only used internally
-static const size_t _n_params = sizeof(_param_list) / sizeof(param_entry);
+static const param_entry _double_param_entries[] = {
+  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) _LIST_DOUBLE_ ## TYPE(FIELD)
+  #include "grackle_chemistry_data_fields.def"
+  #undef ENTRY
+};
+static const param_list _double_param_l = INIT_PAR_LIST(_double_param_entries);
+
+static const param_entry _string_param_entries[] = {
+  #define ENTRY(FIELD, TYPE, DEFAULT_VAL) _LIST_STRING_ ## TYPE(FIELD)
+  #include "grackle_chemistry_data_fields.def"
+  #undef ENTRY
+};
+static const param_list _string_param_l = INIT_PAR_LIST(_string_param_entries);
 
 
 // define functions for accessing field values
-// - local_chemistry_data_access_double
 // - local_chemistry_data_access_int
+// - local_chemistry_data_access_double
+// - local_chemistry_data_access_string
 //
 // The current implementation has O(N) complexity where N is the number of
-// fields of chemistry_data. Since configuration just happens once, this
-// probably doesn't need to be very fast...
+// fields of a given type in chemistry_data. Since configuration just happens
+// once, this probably doesn't need to be very fast...
 //
 // A faster implementation that does a lot less work at runtime is definitely
-// possible (it would just involve more code). 
+// possible (it would just involve more code).
 
 
 // retrieves a pointer to the field of my_chemistry that's named ``name``.
@@ -61,56 +80,50 @@ static const size_t _n_params = sizeof(_param_list) / sizeof(param_entry);
 // This returns a NULL pointer if: my_chemistry is NULL, the field doesn't
 // exist, or the field doesn't have the specified type
 static void* _get_field_ptr(chemistry_data* my_chemistry, const char* name,
-                            enum param_type type)
+                            const param_list my_param_l)
 {
   if (my_chemistry == NULL) { return NULL; }
 
-  for (size_t param_index = 0; param_index < _n_params; param_index++){
-    const param_entry* entry = _param_list + param_index;
-    if ((strcmp(entry->name, name) == 0) & (entry->type == type)){
+  for (size_t param_index = 0; param_index < my_param_l.len; param_index++){
+    const param_entry* entry = my_param_l.entries + param_index;
+    if (strcmp(entry->name, name) == 0) {
       return (void*)( (char*)my_chemistry + entry->offset );
     }
   }
   return NULL;
 }
 
-double* local_chemistry_data_access_double(chemistry_data* my_chemistry,
-                                           const char* param_name)
-{ return (double*)_get_field_ptr(my_chemistry, param_name, DOUBLE_PARAM); }
-
 int* local_chemistry_data_access_int(chemistry_data* my_chemistry,
                                      const char* param_name)
-{ return (int*)_get_field_ptr(my_chemistry, param_name, INT_PARAM); }
+{ return (int*)_get_field_ptr(my_chemistry, param_name, _int_param_l); }
+
+double* local_chemistry_data_access_double(chemistry_data* my_chemistry,
+                                           const char* param_name)
+{ return (double*)_get_field_ptr(my_chemistry, param_name, _double_param_l); }
 
 char** local_chemistry_data_access_string(chemistry_data* my_chemistry,
                                           const char* param_name)
-{ return (char**)_get_field_ptr(my_chemistry, param_name, STRING_PARAM); }
+{ return (char**)_get_field_ptr(my_chemistry, param_name, _string_param_l); }
 
-// define functions for accessing the names of chemistry_data
-// - param_name_double
-// - param_name_int
+// define functions for accessing the names of chemistry_data:
+//   param_name_int, param_name_double, param_name_string
 //
 // These are primarily needed for testing purposes and can be used for
-// serialization. The current implementation is slow. A faster alternative
-// would define separate lists for int parameters and double parameters
+// serialization.
 
 // returns the name of the ``i``th parameter of the specified type. This returns
 // NULL when there are ``i`` or fewer parameters of the specified type
-static const char* _param_name(size_t i, enum param_type type)
-{
-  size_t type_count = 0; // # of parameters of type that have been encountered
-  for (size_t param_index = 0; param_index < _n_params; param_index++){
-    if (_param_list[param_index].type != type){
-      continue;
-    } else if (type_count == i){
-      return _param_list[param_index].name;
-    } else {
-      type_count++;
-    }
-  }
-  return NULL;
-}
+static const char* _param_name(size_t i, const param_list my_param_list)
+{ return (i < my_param_list.len) ? my_param_list.entries[i].name : NULL; }
 
-const char* param_name_double(size_t i){ return _param_name(i, DOUBLE_PARAM); }
-const char* param_name_int(size_t i){ return _param_name(i, INT_PARAM); }
-const char* param_name_string(size_t i){ return _param_name(i, STRING_PARAM); }
+const char* param_name_int(size_t i)    {return _param_name(i,_int_param_l);}
+const char* param_name_double(size_t i) {return _param_name(i,_double_param_l);}
+const char* param_name_string(size_t i) {return _param_name(i,_string_param_l);}
+
+// function to query the number of parameters of chemistry_data of a given type
+size_t grackle_num_params(const char* type_name){
+  if (strcmp(type_name, "int") == 0)         { return _int_param_l.len; }
+  else if (strcmp(type_name, "double") == 0) { return _double_param_l.len; }
+  else if (strcmp(type_name, "string") == 0) { return _string_param_l.len; }
+  return 0;
+}

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -49,6 +49,8 @@ const char* param_name_int(size_t i);
 const char* param_name_double(size_t i);
 const char* param_name_string(size_t i);
 
+size_t grackle_num_params(const char* type_name);
+
 int solve_chemistry(code_units *my_units,
                     grackle_field_data *my_fields,
                     double dt_value);


### PR DESCRIPTION
Introduce the ``grackle_num_params`` function to let users query the number of parameters of a given type that are stored in ``chemistry_data``.

### Motivation

When I first implemented the dynamic-api, I omitted this function because I didn't anticipate it being particularly useful and I wanted to avoid expanding the API by too much.

  - Indeed, I didn't really feel like I needed this function while refactoring Grackle's python bindings.

  - However, it turns out that this functionallity is VERY useful when using the dynamic-api to write code in a statically typed language like C/C++ (while trying to minimize the definition of global variables). It's especially useful to know the number of parameters of a given type, before iterating over the parameters of that type during serialization.

### Overview

The new function has the following signature:

```C
size_t grackle_num_params(const char* type_name);
```

This function returns the number of parameters of a given type when it is passed ``"int"``, ``"double"``, or ``"string"``. For any other argument, this returns ``0``. I opted NOT to define a separate function for each datatype to avoid introducing more functions than necessary to Grackle's public API. Furthermore the added cost of the string comparison is minimal.

While I was introducing this new functionallity, I refactored the rest of the dynamic API. All of the dynamic api functions are faster than they were previously. Notably, the complexity of the ``param_name_*`` functions was reduced from ``O(N)`` (where ``N`` is the total number of parameters) to ``O(1)``. As a point of reference, I had previously discussed this alternative implementation back when we first introduced the Dynamic API (PR #130). I made the change now because the older implementation approach did not lend itself to implementing ``grackle_num_params``.