### PR TITLE
 Address #142 - Grackle now defines ``GRACKLE_USE_OMP`` macro in the header file

### DIFF
--- a/src/clib/Make.config.assemble
+++ b/src/clib/Make.config.assemble
@@ -138,12 +138,14 @@
 #-----------------------------------------------------------------------
 
     ERROR_OMP = 1
+    GRACKLE_USE_OMP = 0
 
     # Settings for enabling OpenMP
 
     ifeq ($(CONFIG_OMP),on)
         ERROR_OMP = 0
         ASSEMBLE_OMP_FLAGS = $(MACH_OMPFLAGS)
+        GRACKLE_USE_OMP = 1
     endif
 
     # Settings for disabling OpenMP
@@ -151,6 +153,7 @@
     ifeq ($(CONFIG_OMP),off)
         ERROR_OMP = 0
         ASSEMBLE_OMP_FLAGS =
+        GRACKLE_USE_OMP = 0
     endif
 
     # error if CONFIG_OMP is incorrect

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -205,6 +205,7 @@ config_header:
 	-@echo "#ifndef __GRACKLE_CONFIG_H__" > grackle_config.h
 	-@echo "#define __GRACKLE_CONFIG_H__" >> grackle_config.h
 	-@echo "#define $(PRECISION_DEFINE)" >> grackle_config.h
+	-@echo "#define GRACKLE_USE_OMP $(GRACKLE_USE_OMP)" >> grackle_config.h
 	-@echo "#endif" >> grackle_config.h
 
 # Force update of auto_show_config.c

--- a/src/clib/Makefile
+++ b/src/clib/Makefile
@@ -198,14 +198,14 @@ verbose: VERBOSE = 1
 #-----------------------------------------------------------------------
 
 .PHONY: autogen
-autogen: config_type auto_show_config.c auto_show_flags.c auto_get_version.c
+autogen: config_header auto_show_config.c auto_show_flags.c auto_get_version.c
 
-.PHONY: config_type
-config_type:
-	-@echo "#ifndef __GRACKLE_FLOAT_H__" > grackle_float.h
-	-@echo "#define __GRACKLE_FLOAT_H__" >> grackle_float.h
-	-@echo "#define $(PRECISION_DEFINE)" >> grackle_float.h
-	-@echo "#endif" >> grackle_float.h
+.PHONY: config_header
+config_header:
+	-@echo "#ifndef __GRACKLE_CONFIG_H__" > grackle_config.h
+	-@echo "#define __GRACKLE_CONFIG_H__" >> grackle_config.h
+	-@echo "#define $(PRECISION_DEFINE)" >> grackle_config.h
+	-@echo "#endif" >> grackle_config.h
 
 # Force update of auto_show_config.c
 
@@ -297,7 +297,7 @@ install:
 	@(if [ ! -d $(INSTALL_INCLUDE_DIR) ]; then \
 		mkdir $(INSTALL_INCLUDE_DIR); \
 	fi)
-	@cp grackle.h grackle_macros.h grackle_float.h grackle_types.h grackle_chemistry_data.h grackle_rate_functions.h grackle.def grackle_fortran_types.def grackle_fortran_interface.def $(INSTALL_INCLUDE_DIR)
+	@cp grackle.h grackle_macros.h grackle_config.h grackle_types.h grackle_chemistry_data.h grackle_rate_functions.h grackle.def grackle_fortran_types.def grackle_fortran_interface.def $(INSTALL_INCLUDE_DIR)
 	@(if [ ! -d $(INSTALL_LIB_DIR) ]; then \
 		mkdir $(INSTALL_LIB_DIR); \
 	fi)
@@ -307,7 +307,7 @@ install:
 #-----------------------------------------------------------------------
 
 clean:
-	-@rm -f *.la .libs/* *.o *.lo DEPEND.bak *~ $(OUTPUT) grackle_float.h *.exe auto_show*.c DEPEND out.make.DEPEND
+	-@rm -f *.la .libs/* *.o *.lo DEPEND.bak *~ $(OUTPUT) grackle_config.h *.exe auto_show*.c DEPEND out.make.DEPEND
 	-@touch DEPEND
 
 #-----------------------------------------------------------------------

--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -14,6 +14,12 @@
 #ifndef __CHEMISTRY_DATA_H__
 #define __CHEMISTRY_DATA_H__
 
+#include "grackle_config.h"
+
+#ifndef GRACKLE_USE_OMP
+#error "Something is wrong... The GRACKLE_USE_OMP macro is not defined. It should always have a value of 0 or 1"
+#endif
+
 /**********************************
  *** Grackle runtime parameters ***
  **********************************/
@@ -171,7 +177,7 @@ typedef struct
   int exit_after_iterations_exceeded;
 
   /* number of OpenMP threads, if supported */
-# ifdef _OPENMP
+# if GRACKLE_USE_OMP == 1
   int omp_nthreads;
 # endif
 

--- a/src/clib/grackle_chemistry_data_fields.def
+++ b/src/clib/grackle_chemistry_data_fields.def
@@ -199,6 +199,6 @@ ENTRY(max_iterations, INT, 10000)
 ENTRY(exit_after_iterations_exceeded, INT, FALSE)
 
 /* number of OpenMP threads, if supported */
-# ifdef _OPENMP
+# if GRACKLE_USE_OMP == 1
 ENTRY(omp_nthreads, INT, omp_get_max_threads())
 # endif

--- a/src/clib/grackle_fortran_types.def
+++ b/src/clib/grackle_fortran_types.def
@@ -12,7 +12,7 @@
 ! software.
 !=======================================================================
 
-#include "grackle_float.h"
+#include "grackle_config.h"
 
 #ifdef GRACKLE_FLOAT_4
 #define tiny 1.e-20

--- a/src/clib/grackle_types.h
+++ b/src/clib/grackle_types.h
@@ -19,7 +19,7 @@
 /
 ************************************************************************/
 
-#include "grackle_float.h"
+#include "grackle_config.h"
 
 #ifdef GRACKLE_FLOAT_4
 #define gr_float float

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -24,6 +24,28 @@
 #include <omp.h>
 #endif
 
+// note: the _OPENMP macro is automatically defined by the compiler when OpenMP
+// is being used. However, this is only guaranteed to be defined while
+// compiling the Grackle libraries source files.
+//
+// In order to inform external programs linking agains Grackle whether Grackle
+// was configured with OpenMP (and to ensure that the fields of chemistry_data
+// structure that are conditionally defined when using Grackle are properly
+// defined in the external program), we also define GRACKLE_USE_OMP macro (with
+// a value of 0 or 1).
+//
+// For lack of a better place to do this, we perform a test here at compile
+// time to ensure that GRACKLE_USE_OMP has a value consistent with the presence
+// or absence of _OPENMP
+
+#ifndef GRACKLE_USE_OMP
+#error "The GRACKLE_USE_OMP macro is not defined. It should always have a value of 0 or 1."
+#elif defined(_OPENMP) && (GRACKLE_USE_OMP != 1)
+#error "when the _OPENMP macro is defined, the GRACKLE_USE_OMP macro must be equal to 1"
+#elif !defined(_OPENMP) && (GRACKLE_USE_OMP != 0)
+#error "when the _OPENMP macro isn't defined, the GRACKLE_USE_OMP macro must be equal to 0"
+#endif
+
 extern int grackle_verbose;
 
 extern chemistry_data *grackle_data;

--- a/src/clib/phys_const.def
+++ b/src/clib/phys_const.def
@@ -1,4 +1,4 @@
-#include "grackle_float.h"
+#include "grackle_config.h"
 
 #ifdef GRACKLE_FLOAT_4
 


### PR DESCRIPTION
This PR resolves #142.

Specifically, this PR defines the ``GRACKLE_USE_OMP`` macro in an automatically generated header file called ``grackle_config.h``. That header file also defined information about the size of floating point values (it was previously called ``grackle_float.h``.

``GRACKLE_USE_OMP`` is always defined with a value of ``1`` or ``0`` to indicate whether Grackle was compiled with OpenMP. This macro has 2 uses:
- external programs can use it to check at compile-time whether Grackle was compiled with openmp
- it is used to conditionally control whether the ``omp_nthreads`` is defined as a field of the ``chemistry_data`` struct. 

Previously, the ``omp_nthreads`` field was defined as a field of the ``chemistry_data`` based on whether the ``_OPENMP`` macro was defined. The OpenMP Specification guarantees that compilers will define the ``_OPENMP`` macro when the compiler is making use of OpenMP[^1]. This means that before this PR, external applications would use the wrong definition of ``chemistry_data`` in two cases (which could theoretically lead to subtle, silent errors):
1. If Grackle was not compiled with OpenMP, but the external application was compiled with OpenMP
2. If Grackle was compiled with OpenMP, but the external application was not compiled with OpenMP

In issue #142, I had floated the idea of always defining ``omp_nthreads`` as a field of ``chemistry_data``. But, based on @brittonsmith's response, I elected not to do this so that external programs will fail when if they try to modify ``omp_nthreads`` and Grackle was not compiled with OpenMP.

Finally I want to mention 2 brief asides:
- I did not go through and change all occurrences of ``#ifdef _OPENMP`` within Grackle to ``#if GRACKLE_USE_OMP == 1``. I'm  happy to pursue that for this PR, if you think it would be useful (I would just have to add ``-DGRACKLE_USE_OMP=1`` as a compiler flag to make sure we get the right behavior)
- ~I suspect that the changes introduced in this PR may pave the way for using the ``pygrackle`` bindings with a version of Grackle that was compiled with OpenMP. This is something that may be worth testing in the future (Since the pygrackle bindings now access all fields of ``chemistry_data`` through the dynamic api, this would be super-easy to test - the python bindings automatically provide access to ``omp_nthreads`` when it's a field of ``chemistry_data``). But, let me know if you think there could be other problems...~ EDIT: so I gave this a quick try, and there's slightly more to this... Python complains about missing symbols (we probably need to tell the linker something about openmp -- maybe pass it ``-fopenmp`` or something. That's a problem for another day)

[^1]: I hadn't totally appreciated this when I opened issue #142 - I only figured that out while working on this PR.