### PR TITLE
Changed the type of ``chemistry_data``'s ``grackle_data_file`` field from ``char*`` to ``const char*``

### DIFF
--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -54,7 +54,7 @@ typedef struct
   int UVbackground;
 
   /* data file containing cooling and UV background tables */
-  char *grackle_data_file;
+  const char *grackle_data_file;
 
   /* Use a CMB temperature floor
      0) no, 1) yes */


### PR DESCRIPTION
My motivation for introducing this change is to allow C++ codes to store a C-style string literal in this field (the C++ standard forbids assignment of a string literal to a ``char*`` variable, a C-style string literal can only be assign to a ``const char*`` variable).

This change still allows users to freely assign different strings to this field. It mostly just makes the promise that Grackle won't make any mutations to a given string's contents (which isn't something I think there would ever be any reason to do -- especially since mutations may require reallocations of the string).