### PR TITLE
Modified the ``chemistry_data`` struct so that the ``omp_nthreads`` is always a field

### DIFF
--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -171,9 +171,7 @@ typedef struct
   int exit_after_iterations_exceeded;
 
   /* number of OpenMP threads, if supported */
-# ifdef _OPENMP
   int omp_nthreads;
-# endif
 
 } chemistry_data;
 

--- a/src/clib/grackle_chemistry_data_fields.def
+++ b/src/clib/grackle_chemistry_data_fields.def
@@ -199,6 +199,4 @@ ENTRY(max_iterations, INT, 10000)
 ENTRY(exit_after_iterations_exceeded, INT, FALSE)
 
 /* number of OpenMP threads, if supported */
-# ifdef _OPENMP
-ENTRY(omp_nthreads, INT, omp_get_max_threads())
-# endif
+ENTRY(omp_nthreads, INT, 0)

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -105,7 +105,17 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
   }
 
 //initialize OpenMP
-# ifdef _OPENMP
+# ifndef _OPENMP
+  if (my_chemistry->omp_nthreads > 1) {
+    fprintf(stdout,
+            "omp_nthreads can't be set when Grackle isn't compiled with "
+            "OPENMP\n");
+  }
+# else _OPENMP
+  if (my_chemistry->omp_nthreads < 1) {
+    // this is the default behavior (unless the user intervenes)
+    my_chemistry->omp_nthreads = omp_get_max_threads();
+  }
 //number of threads
   omp_set_num_threads( my_chemistry->omp_nthreads );
 

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -110,6 +110,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
     fprintf(stdout,
             "omp_nthreads can't be set when Grackle isn't compiled with "
             "OPENMP\n");
+    return FAIL;
   }
 # else _OPENMP
   if (my_chemistry->omp_nthreads < 1) {

--- a/src/python/tests/test_chemistry_struct_synched.py
+++ b/src/python/tests/test_chemistry_struct_synched.py
@@ -183,10 +183,6 @@ def test_grackle_chemistry_field_synched():
 
         diff = ref_set.symmetric_difference(parameters)
         for parameter in diff:
-            if (parameter == 'omp_nthreads') and (param_type == 'int'):
-                # because omp_nthreads is only conditionally a field, handling
-                # it properly is more trouble than its worth...
-                continue
             if parameter in ref_set:
                 raise RuntimeError(
                     f"{parameter}, a {param_type} field of the chemistry_data "


### PR DESCRIPTION
Previously, ``omp_nthreads`` was conditionally included as a field when Grackle was compiled with ``OPENMP``. This replaces PR #145.

