### PR TITLE
Replaced ``size_t`` with ``unsigned int`` in the dynamic api functions.

### DIFF
--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -359,7 +359,7 @@ Chemistry Functions
 Dynamic Configuration Functions
 +++++++++++++++++++++++++++++++
 
-.. c:function:: size_t grackle_num_params(const char* type_name)
+.. c:function:: unsigned int grackle_num_params(const char* type_name)
 
    Returns the number of parameters of a given type that are stored as members of the :c:data:`chemistry_data` struct.
    The argument is expected to be ``"int"``, ``"double"``, or ``"string"``.
@@ -393,33 +393,33 @@ The following functions are used to provide dynamic access to members of the :c:
 
 The following functions are used to query the name of the ith field of the :c:data:`chemistry_data` struct of a particular type.
 
-.. c:function:: const char* param_name_int(size_t i);
+.. c:function:: const char* param_name_int(unsigned int i);
 
    Query the name of the ith ``int`` field from :c:data:`chemistry_data`.
 
    .. warning:: The order of parameters may change between different versions of Grackle.
 
-   :param size_t i: The index of the accessed parameter
+   :param unsigned int i: The index of the accessed parameter
    :rtype: const char*
    :returns: Pointer to the string-literal specifying the name. This is ``NULL``, if :c:data:`chemistry_data` has ``i`` or fewer ``int`` members
    
-.. c:function:: const char* param_name_double(size_t i);
+.. c:function:: const char* param_name_double(unsigned int i);
 
    Query the name of the ith ``double`` field from :c:data:`chemistry_data`.
 
    .. warning:: The order of parameters may change between different versions of Grackle.
 
-   :param size_t i: The index of the accessed parameter
+   :param unsigned int i: The index of the accessed parameter
    :rtype: const char*
    :returns: Pointer to the string-literal specifying the name. This is ``NULL``, if :c:data:`chemistry_data` has ``i`` or fewer ``double`` members.
 
-.. c:function:: const char* param_name_string(size_t i);
+.. c:function:: const char* param_name_string(unsigned int i);
 
    Query the name of the ith ``string`` field from :c:data:`chemistry_data`.
 
    .. warning:: The order of parameters may change between different versions of Grackle.
 
-   :param size_t i: The index of the accessed parameter
+   :param unsigned int i: The index of the accessed parameter
    :rtype: const char*
    :returns: Pointer to the string-literal specifying the name. This is ``NULL``, if :c:data:`chemistry_data` has ``i`` or fewer ``string`` members.
 

--- a/src/clib/dynamic_api.c
+++ b/src/clib/dynamic_api.c
@@ -116,14 +116,21 @@ char** local_chemistry_data_access_string(chemistry_data* my_chemistry,
 static const char* _param_name(size_t i, const param_list my_param_list)
 { return (i < my_param_list.len) ? my_param_list.entries[i].name : NULL; }
 
-const char* param_name_int(size_t i)    {return _param_name(i,_int_param_l);}
-const char* param_name_double(size_t i) {return _param_name(i,_double_param_l);}
-const char* param_name_string(size_t i) {return _param_name(i,_string_param_l);}
+const char* param_name_int(unsigned int i)
+{return _param_name(i,_int_param_l);}
+const char* param_name_double(unsigned int i)
+{return _param_name(i,_double_param_l);}
+const char* param_name_string(unsigned int i)
+{return _param_name(i,_string_param_l);}
 
 // function to query the number of parameters of chemistry_data of a given type
-size_t grackle_num_params(const char* type_name){
-  if (strcmp(type_name, "int") == 0)         { return _int_param_l.len; }
-  else if (strcmp(type_name, "double") == 0) { return _double_param_l.len; }
-  else if (strcmp(type_name, "string") == 0) { return _string_param_l.len; }
+unsigned int grackle_num_params(const char* type_name){
+  if (strcmp(type_name, "int") == 0) {
+    return (unsigned int)_int_param_l.len;
+  } else if (strcmp(type_name, "double") == 0) {
+    return (unsigned int) _double_param_l.len;
+  } else if (strcmp(type_name, "string") == 0) {
+    return (unsigned int) _string_param_l.len;
+  }
   return 0;
 }

--- a/src/clib/grackle.h
+++ b/src/clib/grackle.h
@@ -16,7 +16,6 @@
 
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
-#include <stddef.h>
 
 extern int grackle_verbose;
 
@@ -46,11 +45,11 @@ double* local_chemistry_data_access_double(chemistry_data* my_chemistry,
 char** local_chemistry_data_access_string(chemistry_data* my_chemistry,
                                           const char* param_name);
 
-const char* param_name_int(size_t i);
-const char* param_name_double(size_t i);
-const char* param_name_string(size_t i);
+const char* param_name_int(unsigned int i);
+const char* param_name_double(unsigned int i);
+const char* param_name_string(unsigned int i);
 
-size_t grackle_num_params(const char* type_name);
+unsigned int grackle_num_params(const char* type_name);
 
 int solve_chemistry(code_units *my_units,
                     grackle_field_data *my_fields,

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -200,11 +200,11 @@ cdef extern from "grackle.h":
     char** local_chemistry_data_access_string(c_chemistry_data *my_chemistry,
                                               const char* param_name)
 
-    const char* param_name_int(size_t i)
+    const char* param_name_int(unsigned int i)
 
-    const char* param_name_double(size_t i)
+    const char* param_name_double(unsigned int i)
 
-    const char* param_name_string(size_t i)
+    const char* param_name_string(unsigned int i)
 
     int c_local_solve_chemistry "local_solve_chemistry"(
                 c_chemistry_data *my_chemistry,

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -796,12 +796,12 @@ def get_grackle_version():
             "branch" : version_struct.branch.decode('UTF-8'),
             "revision" : version_struct.revision.decode('UTF-8')}
 
-cdef list _get_parameter_name_list(const char*(*get_param)(size_t)):
+cdef list _get_parameter_name_list(const char*(*get_param)(unsigned int)):
     # the arg should be param_name_int, param_name_double, or param_name_string
 
     cdef list out = []
     cdef const char* tmp
-    cdef size_t i = 0
+    cdef unsigned int i = 0
     while True:
         tmp = get_param(i)
         if tmp is NULL:


### PR DESCRIPTION
This lets us drop the ``#include <stddef.h>`` line from the public header file. This is not a super important change. I don't think this is a necessary change, but it conforms with previous conventions (that avoid including c standard library headers). Feel free to ignore this.