### PR TITLE
Specifying an OS for RTDs to avoid an SSL issue with the newest urllib version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"


### PR DESCRIPTION
This issue is documented here: https://github.com/readthedocs/readthedocs.org/issues/10290

@jwise77 introduced the exact same change to Enzo as part of enzo-project/enzo-dev#210

Another option is just to wait for the ReadTheDocs people to fix this problem. I'm sure this problem will eventually be resolved on its own (since it affects everybody that uses the default-legacy build options)