### PR TITLE
Update branch name references from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ workflows:
            filters:
             branches:
               only:
-                - master
+                - main
      jobs:
        - test-suite:
            name: "Python 3.8 tests"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "grackle_data_files"]
 	path = grackle_data_files
 	url = https://github.com/grackle-project/grackle_data_files
-	branch = master
+	branch = main

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,17 +77,17 @@ directory.
 
    $ cd grackle
 
-Verify that you are on the master branch of Grackle by running:
+Verify that you are on the main branch of Grackle by running:
 
 .. code-block:: bash
 
    $ git branch
 
-If you're not on the master branch, you can get to it with:
+If you're not on the main branch, you can get to it with:
 
 .. code-block:: bash
 
-   $ git checkout master
+   $ git checkout main
 
 You can see any past state of the code by using the git log command.
 For example, the following command would show you the last 5 revisions
@@ -196,16 +196,16 @@ the main repository.
    You can verify that it has been added by doing ``git remote -v``. This
    only needs to be done once.
 
-#. Go back to the master branch and pull the changes::
+#. Go back to the main branch and pull the changes::
 
-      $ git checkout master
-      $ git pull grackle master
+      $ git checkout main
+      $ git pull grackle main
 
-#. Return to your branch and rebase your changes onto the head of the master
+#. Return to your branch and rebase your changes onto the head of the main
    branch::
 
       $ git checkout <branch name>
-      $ git rebase master
+      $ git rebase main
 
 This should go smoothly unless changes have been made to the same lines in
 the source, in which case you will need to fix conflicts. After rebasing,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Grackle
 
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://groups.google.com/forum/#!forum/grackle-cooling-users)
-[![CircleCI](https://circleci.com/gh/grackle-project/grackle/tree/master.svg?style=svg)](https://circleci.com/gh/grackle-project/grackle/tree/master)
+[![CircleCI](https://circleci.com/gh/grackle-project/grackle/tree/main.svg?style=svg)](https://circleci.com/gh/grackle-project/grackle/tree/main)
 [![Documentation Status](https://readthedocs.org/projects/grackle/badge/?version=latest)](https://grackle.readthedocs.io/en/latest/?badge=latest)
 
 Grackle is a chemistry and radiative cooling library for astrophysical


### PR DESCRIPTION
This reflects the change I just made in renaming the primary branch from master to main. I have also changed the primary branch name for the `grackle_data_files` repo accordingly. This will finish Issue #129.