### PR TITLE
Add missing return value.

### DIFF
--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -395,4 +395,5 @@ int local_free_chemistry_data(chemistry_data *my_chemistry,
     GRACKLE_FREE(my_rates->UVbackground_table.crsHeI);
   }
 
+  return SUCCESS;
 }


### PR DESCRIPTION
This adds the expected return value to the end of `local_free_chemistry_data`.