### PR TITLE
initializing local_free_chemistry_data

### DIFF
--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -44,6 +44,8 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 int initialize_UVbackground_data(chemistry_data *my_chemistry,
                                  chemistry_data_storage *my_rates);
 
+int local_free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
+
 int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, 
                 double co_length_units, double co_density_units);
 


### PR DESCRIPTION
I'm compiling grackle on a Mac M1 with clang v14, and due to strict compilation standards, I was running into a compilation issue when trying to `make` inside `src/clib`. The specific error shown in `out.compile` is as follows: `initialize_chemistry_data.c:290:7: error: call to undeclared function 'local_free_chemistry_data'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]`. This seems to be a clang-specific issue.

I therefore initialized the variable near the top of the file and grackle is able to compile without issues.