### PR TITLE
explicitly initialize all struct members to solve plethora of issues

### DIFF
--- a/src/clib/initialize_UVbackground_data.c
+++ b/src/clib/initialize_UVbackground_data.c
@@ -7,7 +7,7 @@
 /
 / Distributed under the terms of the Enzo Public Licence.
 /
-/ The full license is in the file LICENSE, distributed with this 
+/ The full license is in the file LICENSE, distributed with this
 / software.
 ************************************************************************/
 
@@ -22,6 +22,30 @@ extern int grackle_verbose;
 
 // function prototypes
 int read_dataset(hid_t file_id, char *dset_name, double *buffer);
+
+/**
+ * Initializes an empty #UVBtable struct with zeros and NULLs.
+ */
+void initialize_empty_UVBtable_struct(UVBtable *table)
+{
+  table->Nz     = 0LL;
+  table->z      = NULL;
+  table->k24    = NULL;
+  table->k25    = NULL;
+  table->k26    = NULL;
+  table->k27    = NULL;
+  table->k28    = NULL;
+  table->k29    = NULL;
+  table->k30    = NULL;
+  table->k31    = NULL;
+  table->piHI   = NULL;
+  table->piHeI  = NULL;
+  table->piHeII = NULL;
+  table->crsHI  = NULL;
+  table->crsHeII = NULL;
+  table->crsHeI = NULL;
+}
+
 
 // Initialize UV Background data
 int initialize_UVbackground_data(chemistry_data *my_chemistry,
@@ -48,7 +72,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
   if (grackle_verbose)
     fprintf(stdout, "Reading UV background data from %s.\n",
             my_chemistry->grackle_data_file);
-  file_id = H5Fopen(my_chemistry->grackle_data_file, 
+  file_id = H5Fopen(my_chemistry->grackle_data_file,
                     H5F_ACC_RDONLY, H5P_DEFAULT);
 
 
@@ -73,7 +97,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
     return FAIL;
   }
 
-  H5Tclose(memtype); 
+  H5Tclose(memtype);
   H5Dclose(dset_id);
 
 
@@ -120,7 +144,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
     my_rates->UVbackground_table.k29 = malloc(Nz * sizeof(double));
     my_rates->UVbackground_table.k30 = malloc(Nz * sizeof(double));
     my_rates->UVbackground_table.k31 = malloc(Nz * sizeof(double));
-  }    
+  }
 
   my_rates->UVbackground_table.piHI = malloc(Nz * sizeof(double));
   my_rates->UVbackground_table.piHeII = malloc(Nz * sizeof(double));
@@ -175,7 +199,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
                       my_rates->UVbackground_table.k27) ) {
       fprintf(stderr, "Error reading dataset '/UVBRates/Chemistry/k27' in %s.\n",
               my_chemistry->grackle_data_file);
-      return FAIL;      
+      return FAIL;
     }
 
     // *** k28 ***
@@ -183,7 +207,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
                       my_rates->UVbackground_table.k28) ) {
       fprintf(stderr, "Error reading dataset '/UVBRates/Chemistry/k28' in %s.\n",
               my_chemistry->grackle_data_file);
-      return FAIL;      
+      return FAIL;
     }
 
     // *** k29 ***
@@ -191,7 +215,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
                       my_rates->UVbackground_table.k29) ) {
       fprintf(stderr, "Error reading dataset '/UVBRates/Chemistry/k29' in %s.\n",
               my_chemistry->grackle_data_file);
-      return FAIL;      
+      return FAIL;
     }
 
     // *** k30 ***
@@ -199,7 +223,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
                       my_rates->UVbackground_table.k30) ) {
       fprintf(stderr, "Error reading dataset '/UVBRates/Chemistry/k30' in %s.\n",
               my_chemistry->grackle_data_file);
-      return FAIL;      
+      return FAIL;
     }
 
     // *** k31 ***
@@ -207,9 +231,9 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
                       my_rates->UVbackground_table.k31) ) {
       fprintf(stderr, "Error reading dataset '/UVBRates/Chemistry/k31' in %s.\n",
               my_chemistry->grackle_data_file);
-      return FAIL;      
+      return FAIL;
     }
-    
+
   }
 
   // *** piHI ***
@@ -334,7 +358,7 @@ int read_dataset(hid_t file_id, char *dset_name, double *buffer) {
     fprintf(stderr, "Failed to read dataset 'z'.\n");
     return FAIL;
   }
- 
+
   H5Dclose(dset_id);
 
   return SUCCESS;

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -7,7 +7,7 @@
 /
 / Distributed under the terms of the Enzo Public Licence.
 /
-/ The full license is in the file LICENSE, distributed with this 
+/ The full license is in the file LICENSE, distributed with this
 / software.
 ************************************************************************/
 
@@ -46,7 +46,7 @@ int initialize_UVbackground_data(chemistry_data *my_chemistry,
 
 int local_free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
-int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units, 
+int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units,
                 double co_length_units, double co_density_units);
 
 static void show_version(FILE *fp)
@@ -59,10 +59,107 @@ static void show_version(FILE *fp)
   fprintf (fp, "\n");
 }
 
+/**
+ * Initializes an empty #chemistry_data_storage struct with zeros and NULLs.
+ */
+void init_empty_chemistry_data_storage_struct(chemistry_data_storage *my_rates)
+{
+  my_rates->k1 = NULL;
+  my_rates->k2 = NULL;
+  my_rates->k3 = NULL;
+  my_rates->k4 = NULL;
+  my_rates->k5 = NULL;
+  my_rates->k6 = NULL;
+  my_rates->k7 = NULL;
+  my_rates->k8 = NULL;
+  my_rates->k9 = NULL;
+  my_rates->k10 = NULL;
+  my_rates->k11 = NULL;
+  my_rates->k12 = NULL;
+  my_rates->k13 = NULL;
+  my_rates->k14 = NULL;
+  my_rates->k15 = NULL;
+  my_rates->k16 = NULL;
+  my_rates->k17 = NULL;
+  my_rates->k18 = NULL;
+  my_rates->k19 = NULL;
+  my_rates->k20 = NULL;
+  my_rates->k21 = NULL;
+  my_rates->k22 = NULL;
+  my_rates->k23 = NULL;
+  my_rates->k13dd = NULL;
+  my_rates->k24 = 0.;
+  my_rates->k25 = 0.;
+  my_rates->k26 = 0.;
+  my_rates->k27 = 0.;
+  my_rates->k28 = 0.;
+  my_rates->k29 = 0.;
+  my_rates->k30 = 0.;
+  my_rates->k31 = 0.;
+  my_rates->k50 = NULL;
+  my_rates->k51 = NULL;
+  my_rates->k52 = NULL;
+  my_rates->k53 = NULL;
+  my_rates->k54 = NULL;
+  my_rates->k55 = NULL;
+  my_rates->k56 = NULL;
+  my_rates->k57 = NULL;
+  my_rates->k58 = NULL;
+  my_rates->h2dust = NULL;
+  my_rates->n_cr_n = NULL;
+  my_rates->n_cr_d1 = NULL;
+  my_rates->n_cr_d2 = NULL;
+  my_rates->ceHI = NULL;
+  my_rates->ceHeI = NULL;
+  my_rates->ceHeII = NULL;
+  my_rates->ciHI = NULL;
+  my_rates->ciHeI = NULL;
+  my_rates->ciHeIS = NULL;
+  my_rates->ciHeII = NULL;
+  my_rates->reHII = NULL;
+  my_rates->reHeII1 = NULL;
+  my_rates->reHeII2 = NULL;
+  my_rates->reHeIII = NULL;
+  my_rates->brem = NULL;
+  my_rates->comp = 0.;
+  my_rates->comp_xray = 0.;
+  my_rates->temp_xray = 0.;
+  my_rates->piHI = 0.;
+  my_rates->piHeI = 0.;
+  my_rates->piHeII = 0.;
+  my_rates->crsHI = 0.;
+  my_rates->crsHeI = 0.;
+  my_rates->crsHeII = 0.;
+  my_rates->hyd01k = NULL;
+  my_rates->h2k01 = NULL;
+  my_rates->vibh = NULL;
+  my_rates->roth = NULL;
+  my_rates->rotl = NULL;
+  my_rates->GP99LowDensityLimit = NULL;
+  my_rates->GP99HighDensityLimit = NULL;
+  my_rates->GAHI = NULL;
+  my_rates->GAH2 = NULL;
+  my_rates->GAHe = NULL;
+  my_rates->GAHp = NULL;
+  my_rates->GAel = NULL;
+  my_rates->H2LTE = NULL;
+  my_rates->HDlte = NULL;
+  my_rates->HDlow = NULL;
+  my_rates->cieco = NULL;
+  my_rates->gammah = 0.;
+  my_rates->regr = NULL;
+  my_rates->gamma_isrf = 0.;
+  my_rates->gas_grain = NULL;
+  int cloudy_data_new = -1;
+}
+
 int local_initialize_chemistry_data(chemistry_data *my_chemistry,
                                     chemistry_data_storage *my_rates,
                                     code_units *my_units)
 {
+
+  /* Better safe than sorry: Initialize everything to NULL/0 */
+  init_empty_chemistry_data_storage_struct(my_rates);
 
   if (grackle_verbose) {
     show_version(stdout);
@@ -133,7 +230,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
 # endif
 
   /* Only allow a units to be one with proper coordinates. */
-  if (my_units->comoving_coordinates == FALSE && 
+  if (my_units->comoving_coordinates == FALSE &&
       my_units->a_units != 1.0) {
     fprintf(stderr, "ERROR: a_units must be 1.0 if comoving_coordinates is 0.\n");
     return FAIL;
@@ -151,6 +248,9 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
   if (my_chemistry->h2_on_dust > 0 || my_chemistry->dust_chemistry > 0 || my_chemistry->dust_recombination_cooling > 0) {
     my_rates->gas_grain = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
     my_rates->regr      = malloc(my_chemistry->NumberOfTemperatureBins * sizeof(double));
+  } else {
+    my_rates->gas_grain = NULL;
+    my_rates->regr = NULL;
   }
 
   double co_length_units, co_density_units;
@@ -373,7 +473,7 @@ int local_free_chemistry_data(chemistry_data *my_chemistry,
 
   _free_cloudy_data(&my_rates->cloudy_primordial, my_chemistry, /* primordial */ 1);
   _free_cloudy_data(&my_rates->cloudy_metal, my_chemistry, /* primordial */ 0);
-  
+
   GRACKLE_FREE(my_rates->UVbackground_table.z);
   GRACKLE_FREE(my_rates->UVbackground_table.k24);
   GRACKLE_FREE(my_rates->UVbackground_table.k25);
@@ -391,7 +491,7 @@ int local_free_chemistry_data(chemistry_data *my_chemistry,
   GRACKLE_FREE(my_rates->UVbackground_table.piHeII);
   GRACKLE_FREE(my_rates->UVbackground_table.piHeI);
 
-  if (my_chemistry->self_shielding_method > 0){    
+  if (my_chemistry->self_shielding_method > 0){
     GRACKLE_FREE(my_rates->UVbackground_table.crsHI);
     GRACKLE_FREE(my_rates->UVbackground_table.crsHeII);
     GRACKLE_FREE(my_rates->UVbackground_table.crsHeI);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -49,6 +49,8 @@ int local_free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_stora
 int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units,
                 double co_length_units, double co_density_units);
 
+void initialize_empty_UVBtable_struct(UVBtable *table);
+
 static void show_version(FILE *fp)
 {
   grackle_version gversion = get_grackle_version();
@@ -291,23 +293,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
   }
 
   /* Initialize UV Background data. */
-  my_rates->UVbackground_table.Nz     = 0;
-  my_rates->UVbackground_table.z      = NULL;
-  my_rates->UVbackground_table.k24    = NULL;
-  my_rates->UVbackground_table.k25    = NULL;
-  my_rates->UVbackground_table.k26    = NULL;
-  my_rates->UVbackground_table.k27    = NULL;
-  my_rates->UVbackground_table.k28    = NULL;
-  my_rates->UVbackground_table.k29    = NULL;
-  my_rates->UVbackground_table.k30    = NULL;
-  my_rates->UVbackground_table.k31    = NULL;
-  my_rates->UVbackground_table.piHI   = NULL;
-  my_rates->UVbackground_table.piHeII = NULL;
-  my_rates->UVbackground_table.piHeI  = NULL;
-  my_rates->UVbackground_table.crsHI  = NULL;
-  my_rates->UVbackground_table.crsHeII = NULL;
-  my_rates->UVbackground_table.crsHeI = NULL;
-
+  initialize_empty_UVBtable_struct(&(my_rates->UVbackground_table));
   if (initialize_UVbackground_data(my_chemistry, my_rates) == FAIL) {
     fprintf(stderr, "Error in initialize_UVbackground_data.\n");
     return FAIL;

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -152,7 +152,7 @@ void initialize_empty_chemistry_data_storage_struct(chemistry_data_storage *my_r
   my_rates->regr = NULL;
   my_rates->gamma_isrf = 0.;
   my_rates->gas_grain = NULL;
-  int cloudy_data_new = -1;
+  my_rates->cloudy_data_new = -1;
 }
 
 int local_initialize_chemistry_data(chemistry_data *my_chemistry,

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -62,7 +62,7 @@ static void show_version(FILE *fp)
 /**
  * Initializes an empty #chemistry_data_storage struct with zeros and NULLs.
  */
-void init_empty_chemistry_data_storage_struct(chemistry_data_storage *my_rates)
+void initialize_empty_chemistry_data_storage_struct(chemistry_data_storage *my_rates)
 {
   my_rates->k1 = NULL;
   my_rates->k2 = NULL;
@@ -159,7 +159,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
 {
 
   /* Better safe than sorry: Initialize everything to NULL/0 */
-  init_empty_chemistry_data_storage_struct(my_rates);
+  initialize_empty_chemistry_data_storage_struct(my_rates);
 
   if (grackle_verbose) {
     show_version(stdout);

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -58,7 +58,7 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
   my_cloudy->grid_parameters = malloc(CLOUDY_MAX_DIMENSION * sizeof(double *));
   my_cloudy->grid_dimension = malloc(CLOUDY_MAX_DIMENSION * sizeof(long long));
   for (q = 0;q < CLOUDY_MAX_DIMENSION;q++) {
-    my_cloudy->grid_dimension[q] = NULL;
+    my_cloudy->grid_dimension[q] = 0LL;
     my_cloudy->grid_parameters[q] = NULL;
   }
 

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -53,6 +53,7 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
   char parameter_name[MAX_LINE_LENGTH];
 
   // Initialize things needed even if cloudy cooling is not used.
+  initialize_empty_cloudy_data_struct(my_cloudy);
 
   my_cloudy->grid_parameters = malloc(CLOUDY_MAX_DIMENSION * sizeof(double *));
   my_cloudy->grid_dimension = malloc(CLOUDY_MAX_DIMENSION * sizeof(long long));

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -66,7 +66,6 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 
   if (read_data == 0) {
     my_cloudy->grid_rank = 0;
-    my_cloudy->cooling_data = NULL;
     my_cloudy->heating_data = NULL;
     my_cloudy->cooling_data = NULL;
     my_cloudy->mmw_data = NULL;

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -7,7 +7,7 @@
 /
 / Distributed under the terms of the Enzo Public Licence.
 /
-/ The full license is in the file LICENSE, distributed with this 
+/ The full license is in the file LICENSE, distributed with this
 / software.
 ************************************************************************/
 
@@ -24,6 +24,21 @@
 
 extern int grackle_verbose;
 
+
+/**
+ * Initializes an empty #cloudy_data struct with zeros and NULLs.
+ */
+void initialize_empty_cloudy_data_struct(cloudy_data *my_cloudy)
+{
+  my_cloudy->grid_rank = 0LL;
+  my_cloudy->grid_dimension = NULL;
+  my_cloudy->grid_parameters = NULL;
+  my_cloudy->heating_data = NULL;
+  my_cloudy->cooling_data = NULL;
+  my_cloudy->mmw_data = NULL;
+  my_cloudy->data_size = 0LL;
+}
+
 // Initialize Cloudy cooling data
 int initialize_cloudy_data(chemistry_data *my_chemistry,
                            chemistry_data_storage *my_rates,
@@ -39,16 +54,22 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 
   // Initialize things needed even if cloudy cooling is not used.
 
-  my_cloudy->grid_parameters = malloc(CLOUDY_MAX_DIMENSION * sizeof(double));
+  my_cloudy->grid_parameters = malloc(CLOUDY_MAX_DIMENSION * sizeof(double *));
   my_cloudy->grid_dimension = malloc(CLOUDY_MAX_DIMENSION * sizeof(long long));
   for (q = 0;q < CLOUDY_MAX_DIMENSION;q++) {
-    my_cloudy->grid_dimension[q] = 0;
+    my_cloudy->grid_dimension[q] = NULL;
+    my_cloudy->grid_parameters[q] = NULL;
   }
 
   // Zero arrays if cloudy cooling not used.
 
   if (read_data == 0) {
     my_cloudy->grid_rank = 0;
+    my_cloudy->cooling_data = NULL;
+    my_cloudy->heating_data = NULL;
+    my_cloudy->cooling_data = NULL;
+    my_cloudy->mmw_data = NULL;
+    my_cloudy->data_size = 0LL;
     return SUCCESS;
   }
 
@@ -81,12 +102,11 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
                     (POW(tbase1,3) * dbase1);
 
   // Read cooling data in from hdf5 file.
-
-  hid_t       file_id, dset_id, attr_id; 
+  hid_t       file_id, dset_id, attr_id;
   herr_t      status;
   herr_t      h5_error = -1;
 
-  file_id = H5Fopen(my_chemistry->grackle_data_file, 
+  file_id = H5Fopen(my_chemistry->grackle_data_file,
                     H5F_ACC_RDONLY, H5P_DEFAULT);
 
   if (H5Aexists(file_id, "old_style")) {
@@ -167,7 +187,7 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 
     attr_id = H5Aopen_name(dset_id, parameter_name);
     if (attr_id == h5_error) {
-      fprintf(stderr,"Failed to open %s attribute in Cooling dataset.\n", 
+      fprintf(stderr,"Failed to open %s attribute in Cooling dataset.\n",
               parameter_name);
       return FAIL;
     }


### PR DESCRIPTION
Dangling uninitialized pointers and arrays in data structures caused issues for me when using local (threadsafe) function calls. The issues range from causing segfaults to memory leaks to arithmetic exceptions to randomly massively slowing down the code by computing random junk on randomly large arrays which shouldn't exist in the first place.

This PR initializes all structs explicitly, and the issues have vanished for me.

Only thing I'm not 100% sure about is, as I wrote on slack already, is that you define the `cloudy_data struct` as:


```
typedef struct
{

  ...
  // Dataset parameter values.
  double **grid_parameters;

  ...

} cloudy_data;
```

but you initialize grid_parameters as

```
int initialize_cloudy_data(chemistry_data *my_chemistry,
                           chemistry_data_storage *my_rates,
                           cloudy_data *my_cloudy, char *group_name,
                           code_units *my_units, int read_data)
{

  ...

  my_cloudy->grid_parameters = malloc(CLOUDY_MAX_DIMENSION * sizeof(double));

```
i.e. an array with sizes of doubles. I've went with the assumption that it should be an array of pointers to double. Not 100% sure though, so confirmation from your side would be good, as I haven't really used grackle with cloudy thus far. The c/cxx examples run for me.