### PR TITLE
Refactor the `cloudy_data` struct so that the `grid_{dimension,parameters}` members are fixed-size arrays

### DIFF
--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -178,6 +178,11 @@ typedef struct
 /*****************************
  *** Cooling table storage ***
  *****************************/
+
+// this is an implementation detail that may change in the future. Always rely
+// upon the grid_rank value stored in cloudy_data
+#define GRACKLE_CLOUDY_TABLE_MAX_DIMENSION 5
+
 typedef struct
 {
 
@@ -185,10 +190,10 @@ typedef struct
   long long grid_rank;
 
   // Dimension of dataset.
-  long long *grid_dimension;
+  long long grid_dimension[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
 
   // Dataset parameter values.
-  double **grid_parameters;
+  double *grid_parameters[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
 
   // Heating values
   double *heating_data;


### PR DESCRIPTION
Previously, `cloudy_data.grid_dimension` and `cloudy_data.grid_parameters` were assigned heap-allocated arrays of a fixed size (set by the maximum size of the `CLOUDY_MAX_DIMENSION`).

This changeset:
1. renames the `CLOUDY_MAX_DIMENSION` macro so it is now called `GRACKLE_CLOUDY_TABLE_MAX_DIMENSION` and moves it to the `grackle_chemistry_data.h` header.
2. changes the types of the `cloudy_data.grid_dimension` and `cloudy_data.grid_parameters` struct-members so that they are now arrays with ``GRACKLE_CLOUDY_TABLE_MAX_DIMENSION` entries.
3. simplifies the implementation of `initialize_cloudy_data`. 2 of the allocations are no longer necessary and the initialization of the array-values are moved into `initialize_empty_cloudy_data_struct`. **(This was the main motivation for this PR)**
4. Removed 2 calls to `GRACKLE_FREE` that are no longer necessary from `_free_cloudy_data`.

**Note:** this change has NO effect on any code that is used to access data stored in these struct-members.

In principle, this could break downstream application code. However, that can only really happen if users were initializing/allocating instances of the `cloudy_data` struct entirely on their own (which they have no reason for doing). *More importantly,* this changes a datastructure that is not a documented part of the user-facing API. We don't make (or at least we shouldn't) make any guarantees that this part of the library is stable.


This builds directly on the changes introduced by PR #166. Only the final commit introduces new changes. After that PR is accepted, I'll re-push these changes.