### PR TITLE
Fixed inconsistencies in c_example

### DIFF
--- a/src/example/Makefile
+++ b/src/example/Makefile
@@ -133,7 +133,7 @@ cxx_grid_example: $(MODULES) cxx_grid_example.o
          fi)
 
 #-----------------------------------------------------------------------
-# PURE C EXAMPLE
+# PURE C EXAMPLE USING GLOBAL STRUCTS
 #-----------------------------------------------------------------------
 
 c_example: $(MODULES) c_example.o
@@ -144,6 +144,24 @@ c_example: $(MODULES) c_example.o
              echo "Success!"; \
          else \
              echo "$(LD) $(LDFLAGS) -o c_example c_example.o $(LIBS) $(GRACKLE_LIB)" >> temp1; \
+             cat temp1 $(OUTPUT) > temp2; \
+             rm -f temp1; \
+             mv -f temp2 $(OUTPUT); \
+             echo "Failed! See $(OUTPUT) for error messages"; \
+         fi)
+
+#-----------------------------------------------------------------------
+# PURE C EXAMPLE USING LOCAL STRUCTS
+#-----------------------------------------------------------------------
+
+c_local_example: $(MODULES) c_local_example.o
+	@rm -f $@
+	@echo "Linking"
+	-@$(LD) $(LDFLAGS) -o c_local_example c_local_example.o $(LIBS) $(GRACKLE_LIB) >& $(OUTPUT)
+	@(if [ -e $@ ]; then \
+             echo "Success!"; \
+         else \
+             echo "$(LD) $(LDFLAGS) -o c_local_example c_local_example.o $(LIBS) $(GRACKLE_LIB)" >> temp1; \
              cat temp1 $(OUTPUT) > temp2; \
              rm -f temp1; \
              mv -f temp2 $(OUTPUT); \

--- a/src/example/c_example.c
+++ b/src/example/c_example.c
@@ -57,18 +57,19 @@ int main(int argc, char *argv[])
   }
 
   // Set parameter values for chemistry.
-  // Access the parameter storage with the struct you've created
-  // or with the grackle_data pointer declared in grackle.h (see further below).
-  grackle_data->use_grackle = 1;            // chemistry on
-  grackle_data->with_radiative_cooling = 1; // cooling on
-  grackle_data->primordial_chemistry = 3;   // molecular network with H, He, D
-  grackle_data->dust_chemistry = 1;         // dust processes
-  grackle_data->metal_cooling = 1;          // metal cooling on
-  grackle_data->UVbackground = 1;           // UV background on
-  grackle_data->grackle_data_file = "../../input/CloudyData_UVB=HM2012.h5"; // data file
+  my_grackle_data->use_grackle = 1;            // chemistry on
+  my_grackle_data->with_radiative_cooling = 1; // cooling on
+  my_grackle_data->primordial_chemistry = 3;   // molecular network with H, He, D
+  my_grackle_data->dust_chemistry = 1;         // dust processes
+  my_grackle_data->metal_cooling = 1;          // metal cooling on
+  my_grackle_data->UVbackground = 1;           // UV background on
+  my_grackle_data->grackle_data_file = "../../input/CloudyData_UVB=HM2012.h5"; // data file
+
+  // Create chemistry data storage object to store rates.
+  chemistry_data_storage *my_grackle_rates;
 
   // Finally, initialize the chemistry object.
-  if (initialize_chemistry_data(&my_units) == 0) {
+  if (local_initialize_chemistry_data(my_grackle_data, &grackle_rates, &my_units) == 0) {
     fprintf(stderr, "Error in initialize_chemistry_data.\n");
     return EXIT_FAILURE;
   }
@@ -137,10 +138,10 @@ int main(int argc, char *argv[])
 
   for (i = 0;i < field_size;i++) {
     my_fields.density[i] = 1.0;
-    my_fields.HI_density[i] = grackle_data->HydrogenFractionByMass * my_fields.density[i];
+    my_fields.HI_density[i] = my_grackle_data->HydrogenFractionByMass * my_fields.density[i];
     my_fields.HII_density[i] = tiny_number * my_fields.density[i];
     my_fields.HM_density[i] = tiny_number * my_fields.density[i];
-    my_fields.HeI_density[i] = (1.0 - grackle_data->HydrogenFractionByMass) *
+    my_fields.HeI_density[i] = (1.0 - my_grackle_data->HydrogenFractionByMass) *
       my_fields.density[i];
     my_fields.HeII_density[i] = tiny_number * my_fields.density[i];
     my_fields.HeIII_density[i] = tiny_number * my_fields.density[i];
@@ -151,7 +152,7 @@ int main(int argc, char *argv[])
     my_fields.HDI_density[i] = tiny_number * my_fields.density[i];
     my_fields.e_density[i] = tiny_number * my_fields.density[i];
     // solar metallicity
-    my_fields.metal_density[i] = grackle_data->SolarMetalFractionByMass *
+    my_fields.metal_density[i] = my_grackle_data->SolarMetalFractionByMass *
       my_fields.density[i];
 
     my_fields.x_velocity[i] = 0.0;

--- a/src/example/c_local_example.c
+++ b/src/example/c_local_example.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
   my_units.a_value = 1. / (1. + initial_redshift) / my_units.a_units;
   set_velocity_units(&my_units);
 
-  // Second, create a chemistry object for parameters.  This needs to be a pointer.
+  // Second, create a chemistry object for parameters.
   chemistry_data *my_grackle_data;
   my_grackle_data = malloc(sizeof(chemistry_data));
   if (set_default_chemistry_parameters(my_grackle_data) == 0) {

--- a/src/python/tests/test_code_examples.py
+++ b/src/python/tests/test_code_examples.py
@@ -21,6 +21,7 @@ current_path = os.path.abspath(__file__)
 examples_path = os.path.join(os.path.dirname(current_path), "../..", "example")
 
 code_examples = ["c_example",
+                 "c_local_example",
                  "cxx_example",
                  "cxx_omp_example",
                  "cxx_grid_example",


### PR DESCRIPTION
Inconsistencies in c_example.c lead to using both the default and user-defined chemistry_data structs. I have changed this such that all structs are defined explicitly in the example. The local_ version of initialize_chemistry_data is now used.