### PR TITLE
Add missing fields to pygrackle.

### DIFF
--- a/src/python/pygrackle/fluid_container.py
+++ b/src/python/pygrackle/fluid_container.py
@@ -32,7 +32,7 @@ _nd_fields   = ["energy",
                 "x-velocity", "y-velocity", "z-velocity",
                 "temperature", "dust_temperature", "pressure",
                 "gamma", "cooling_time", "mu", "nH",
-                "mean_molecular_weight",
+                "mean_molecular_weight", "isrf_habing",
                 "temperature_floor"]
 
 _fluid_names = {}
@@ -49,7 +49,7 @@ _rad_trans_names = ['RT_heating_rate', 'RT_HI_ionization_rate',
                     'RT_H2_dissociation_rate']
 
 _extra_fields = {}
-_extra_fields[2] = ["H2_self_shielding_length"]
+_extra_fields[2] = ["H2_self_shielding_length", "H2_custom_shielding_factor"]
 _extra_fields[3] = _extra_fields[2] + []
 
 class FluidContainer(dict):

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -166,6 +166,7 @@ cdef extern from "grackle_types.h":
       gr_float *RT_HeII_ionization_rate;
       gr_float *RT_H2_dissociation_rate;
       gr_float *H2_self_shielding_length;
+      gr_float *H2_custom_shielding_factor;
       gr_float *isrf_habing;
 
     ctypedef struct c_grackle_version "grackle_version":

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -702,11 +702,6 @@ cdef c_field_data setup_field_data(object fc, int[::1] buf,
     my_fields.grid_end = grid_end
 
     my_fields.density = get_field(fc, "density")
-    my_fields.internal_energy = get_field(fc, "energy")
-    if include_velocity:
-        my_fields.x_velocity = get_field(fc, "x-velocity")
-        my_fields.y_velocity = get_field(fc, "y-velocity")
-        my_fields.z_velocity = get_field(fc, "z-velocity")
     my_fields.HI_density = get_field(fc, "HI")
     my_fields.HII_density = get_field(fc, "HII")
     my_fields.HM_density = get_field(fc, "HM")
@@ -721,10 +716,22 @@ cdef c_field_data setup_field_data(object fc, int[::1] buf,
     my_fields.e_density = get_field(fc, "de")
     my_fields.metal_density = get_field(fc, "metal")
     my_fields.dust_density = get_field(fc, "dust")
-    my_fields.RT_heating_rate = get_field(fc, "RT_heating_rate")
+    my_fields.internal_energy = get_field(fc, "energy")
+    if include_velocity:
+        my_fields.x_velocity = get_field(fc, "x-velocity")
+        my_fields.y_velocity = get_field(fc, "y-velocity")
+        my_fields.z_velocity = get_field(fc, "z-velocity")
     my_fields.volumetric_heating_rate = get_field(fc, "volumetric_heating_rate")
     my_fields.specific_heating_rate = get_field(fc, "specific_heating_rate")
     my_fields.temperature_floor = get_field(fc, "temperature_floor")
+    my_fields.RT_heating_rate = get_field(fc, "RT_heating_rate")
+    my_fields.RT_HI_ionization_rate = get_field(fc, "RT_HI_ionization_rate")
+    my_fields.RT_HeI_ionization_rate = get_field(fc, "RT_HeI_ionization_rate")
+    my_fields.RT_HeII_ionization_rate = get_field(fc, "RT_HeII_ionization_rate")
+    my_fields.RT_H2_dissociation_rate = get_field(fc, "RT_H2_dissociation_rate")
+    my_fields.H2_self_shielding_length = get_field(fc, "H2_self_shielding_length")
+    my_fields.H2_custom_shielding_factor = get_field(fc, "H2_custom_shielding_factor")
+    my_fields.isrf_habing = get_field(fc, "isrf_habing")
     return my_fields
 
 def solve_chemistry(fc, my_dt):


### PR DESCRIPTION
Following an issue reported on the mailing list, this adds some fields that were missing from the pygrackle interface. I also did a little reordering for consistency between the various places these are defined.