### PR TITLE
Make public types refer to named structs

### DIFF
--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -17,7 +17,7 @@
 /**********************************
  *** Grackle runtime parameters ***
  **********************************/
-typedef struct
+typedef struct chemistry_data
 {
 
   /* grackle on/off flag
@@ -254,7 +254,7 @@ typedef struct
 /******************************************
  *** Chemistry and cooling data storage ***
  ******************************************/
-typedef struct
+typedef struct chemistry_data_storage
 {
 
   /**********************************

--- a/src/clib/grackle_types.h
+++ b/src/clib/grackle_types.h
@@ -33,7 +33,7 @@
 #error "Both GRACKLE_FLOAT_4 and GRACKLE_FLOAT_8 are defined. Only one can be defined."
 #endif
 
-typedef struct
+typedef struct grackle_field_data
 {
 
   int grid_rank;
@@ -82,7 +82,7 @@ typedef struct
 
 } grackle_field_data;
 
-typedef struct
+typedef struct code_units
 {
 
   int comoving_coordinates;

--- a/src/python/tests/test_chemistry_struct_synched.py
+++ b/src/python/tests/test_chemistry_struct_synched.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 import tempfile
 import warnings
-import xml.etree.ElementTree # may not be the optimal xml parsre
+import xml.etree.ElementTree # may not be the optimal xml parser
 
 import pytest
 
@@ -48,6 +48,20 @@ def _field_type_props(elem, root):
             pass # just ignore this
         else:
             return elem.attrib['name'] + (ptr_level * "*")
+
+def _unwrap_struct_from_typedef(elem, root):
+    # this is called when elem corresponds to a type declared with typedef
+    # -> this function returns the xml-object representing the underlying struct
+    #    that is aliased by the typedef
+    _tmp = _find_element_by_ids(elem.attrib['type'], root,
+                                expect_single = True)[0]
+    if _tmp.tag == 'ElaboratedType':
+        struct_elem = _find_element_by_ids(_tmp.attrib['type'], root,
+                                           expect_single = True)[0]
+    else:
+        struct_elem = _tmp
+    assert struct_elem.tag == 'Struct'  # <-- sanity check!
+    return struct_elem
 
 def query_struct_fields(struct_name, path):
     """
@@ -124,21 +138,34 @@ def query_struct_fields(struct_name, path):
         tree.getroot().findall(".//Struct[@name='" + struct_name + "']") +
         tree.getroot().findall(".//Typedef[@name='" + struct_name + "']")
     )
+
     if len(matches) == 0:
         raise RuntimeError(f"no struct name '{struct_name}' was found")
-    elif len(matches) > 1:
-        raise RuntimeError(f"found more than one match for '{struct_name}'")
-    elif matches[0].tag == 'Struct':
-        struct_elem = matches[0].tag
-    elif matches[0].tag == 'Typedef':
-        _tmp = _find_element_by_ids(matches[0].attrib['type'], root,
-                                    expect_single = True)[0]
-        if _tmp.tag == 'ElaboratedType':
-            struct_elem = _find_element_by_ids(_tmp.attrib['type'], root,
-                                               expect_single = True)[0]
-        else:
-            struct_elem = _tmp
-        assert struct_elem.tag == 'Struct'
+    elif len(matches) > 2:
+        raise RuntimeError(f"found more than 2 matches for '{struct_name}'")
+    elif (len(matches) == 1) and (matches[0].tag == 'Struct'):
+        # in this case, we defined a struct named {struct_name} and didn't
+        # use typedef to declare any type aliases of the struct
+        # -> in other words, we can only refer to the type in our C code as
+        #    `struct {struct_name}`
+        struct_elem = matches[0]
+    elif (len(matches) == 1) and (matches[0].tag == 'Typedef'):
+        # in this case, we used typedef to define a type called {struct_name}
+        # that aliases an "anonymous struct"
+        # -> in other words, we can only refer to the type in our C code as
+        #    `{struct_name}`
+        struct_elem = _unwrap_struct_from_typedef(matches[0], root)
+    elif ((len(matches) == 2) and (matches[0].tag == 'Struct') and
+          (matches[1].tag == 'Typedef')):
+        # in this case we probably defined a struct called {struct_name} and
+        # used typedef to declare an alias type called {struct_name}
+        # -> in other words, the types `struct {struct_name}` and
+        #    `{struct_name}` refer to the same type
+        struct_elem = matches[0]
+        # perform a sanity check to confirm that typedef indeed aliases the
+        # corresponding struct
+        # -> note: I'm not entirely sure this is always guaranteed to work
+        assert struct_elem == _unwrap_struct_from_typedef(matches[1], root)
     else:
         raise RuntimeError("SOMETHING WENT WRONG")
 


### PR DESCRIPTION
Prior to this PR, all types that alias structs alias anonymous structs. This is totally fine, but it prevents users from forward declaring types.

In this PR, we make:
- `chemistry_data` an alias for `struct chemistry_data`
- `code_units` an alias for `struct code_units`
- `chemistry_data_storage` an alias for `struct chemistry_data_storage`
- `grackle_field_data` an alias for `struct grackle_field_data`

By doing this, downstream codes can now forward declare types like `struct chemistry_data`, regardless of whether grackle is being linked in the current build.
- this is extremely useful for reducing pre-processor ifdef statements
- In Enzo-E, I'm looking to use this feature so that we don't have to rebuild the entire program if we decide to rebuild with/without linking against Grackle