### PR TITLE
Dev

### DIFF
--- a/src/clib/Make.mach.linux-gnu
+++ b/src/clib/Make.mach.linux-gnu
@@ -13,7 +13,7 @@
 #
 #=======================================================================
 
-MACH_TEXT  = Use apt-get to install libhdf5-serial-dev gfortran
+MACH_TEXT  = Use apt-get to install libhdf5-dev gfortran
 MACH_VALID = 1
 MACH_FILE  = Make.mach.linux-gnu
 

--- a/src/clib/Make.mach.linux-gnu
+++ b/src/clib/Make.mach.linux-gnu
@@ -8,12 +8,12 @@
 #
 # DATE:        2008-09-16
 #
-# This configuration assumes that build-essentials, gfortran, 
+# This configuration assumes that build-essentials, gfortran, xutils-dev
 # OpenMPI and HDF5 have been installed using apt-get.
 #
 #=======================================================================
 
-MACH_TEXT  = Use apt-get to install libhdf5-dev gfortran
+MACH_TEXT  = Use apt-get to install libhdf5-dev gfortran xutils-dev
 MACH_VALID = 1
 MACH_FILE  = Make.mach.linux-gnu
 


### PR DESCRIPTION
I applied two changes to the make machine files for linux-gnu distribution. 
The first simply changes the occurrences of  `libhdf5-serial-dev` to `libhdf5-dev` in the informations, since `libhdf5-serial-dev` is not available anymore.
 
The second change addresses a problem occurring after running `make`  in `grackle/src/clib`, which returns
` /bin/bash: line 1: makedepend: command not found`
a number of times unless the `xutils-dev` package is installed.