### PR TITLE
Add example to make clean list.

### DIFF
--- a/src/example/Makefile
+++ b/src/example/Makefile
@@ -257,7 +257,7 @@ help:
 #-----------------------------------------------------------------------
 
 clean:
-	-@rm -f *.o *.mod *.f *.f90 *~ *.exe $(OUTPUT) cxx_example cxx_omp_example cxx_grid_example c_example fortran_example
+	-@rm -f *.o *.mod *.f *.f90 *~ *.exe $(OUTPUT) cxx_example cxx_omp_example cxx_grid_example c_example c_local_example fortran_example
 
 #-----------------------------------------------------------------------
 # Include configuration targets


### PR DESCRIPTION
This adds c_local_example to the list of executables to remove with make clean.