### PR TITLE
Revert PR #179

### DIFF
--- a/src/clib/grackle_chemistry_data.h
+++ b/src/clib/grackle_chemistry_data.h
@@ -17,7 +17,7 @@
 /**********************************
  *** Grackle runtime parameters ***
  **********************************/
-typedef struct chemistry_data
+typedef struct
 {
 
   /* grackle on/off flag
@@ -254,7 +254,7 @@ typedef struct
 /******************************************
  *** Chemistry and cooling data storage ***
  ******************************************/
-typedef struct chemistry_data_storage
+typedef struct
 {
 
   /**********************************

--- a/src/clib/grackle_types.h
+++ b/src/clib/grackle_types.h
@@ -33,7 +33,7 @@
 #error "Both GRACKLE_FLOAT_4 and GRACKLE_FLOAT_8 are defined. Only one can be defined."
 #endif
 
-typedef struct grackle_field_data
+typedef struct
 {
 
   int grid_rank;
@@ -82,7 +82,7 @@ typedef struct grackle_field_data
 
 } grackle_field_data;
 
-typedef struct code_units
+typedef struct
 {
 
   int comoving_coordinates;


### PR DESCRIPTION
Overview
--------
This commit (mostly)[^1] reverts PR #179. When I originally wrote #179 I didn't give the side effects a ton of thought.

I actually don't think the "problem" is a huge deal. But I do think that we should probably make this reversion quickly before people start depending on the feature added by #179.

Refresher
---------
As a quick refresher about PR #179:
- Previously we declared the types `chemistry_data`, `chemistry_data_storage`, `code_units`, and `grackle_field_data` as aliases of anonymous structs.
- In that PR, I modified the code so that those types are aliases of `struct chemistry_data`, `struct chemistry_data_storage`, `struct code_units`, and `struct grackle_field_data`.
- That PR was submitted with the express purpose of allowing downstream applications to forward declare these types (I still think that this is a **very** good thing).

The "problem"
-------------

An important consequence of that PR is that it makes renaming types more difficult (while maintaining backwards compatibility).
- previously if we wanted to change the name (say `code_units` to `my_code_units`) we could just add a typedef to define an alias between the new typename and the old typename (to maintain backwards compatibility while we give downstream applications time to make the switch). And then after a couple of grackle releases we could remove the old typenames.
- But now, if we downstream application refers to `struct code_units`, I don't think there's any way for us to gracefully change the name of that struct while maintaining backwards compatibility

To be clear, if we are confident that the names `chemistry_data`, `chemistry_data_storage`, `code_units`, and `grackle_field_data`  are perfect names that we never want to change, this isn't actually a problem at all. But I'm not sure that's the case.
- In particular, `code_units` is a generic enough name that we may want to rename it `grackle_code_units` (or `gr_code_units`)
- This may warrant further conversation beyond the scope of this PR

[^1]: I left the changes to the python test machinery intact. Strictly speaking, that change was an improvement (it considered an additional valid state).