### PR TITLE
Add error-check on `grackle_field_data.grid_dx`

### DIFF
--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -415,7 +415,9 @@ electron mass density in :c:data:`density_units` (see :ref:`density-note`).
    This is the grid cell width in :c:data:`length_units`. This is currently
    used only in computing approximate H2 self-shielding when H2 is tracked
    (:c:data:`primordial_chemistry` >= 2) and :c:data:`H2_self_shielding` is
-   set to 1.
+   set to 1. If this can't be assigned a meaningful value (e.g. the field data
+   does not organized on a grid or the grid cells aren't perfect cubes), we
+   recommend assigning it a value of -1 (so that error-handling works properly)
 
 .. c:var:: gr_float* density
 
@@ -610,6 +612,9 @@ not intend to use.
   my_fields.grid_start = new int[3];
   my_fields.grid_end = new int[3];
   my_fields.grid_dx  = 1.0; // only matters if H2 self-shielding is used
+                            // we recommend assigning it a value of -1 if your
+                            // simulation doesn't have a meaningful value for
+                            // it (so that error-handling works properly)
   for (int i = 0;i < 3;i++) {
     my_fields.grid_dimension[i] = 1;
     my_fields.grid_start[i] = 0;

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -40,4 +40,5 @@ OBJS_CONFIG_LIB = \
         solve_rate_cool_g.lo \
         update_UVbackground_rates.lo \
         rate_functions.lo \
-        initialize_rates.lo
+        initialize_rates.lo \
+        utils.lo

--- a/src/clib/calculate_cooling_time.c
+++ b/src/clib/calculate_cooling_time.c
@@ -18,6 +18,7 @@
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
 #include "phys_constants.h"
+#include "utils.h"
 
 extern chemistry_data *grackle_data;
 extern chemistry_data_storage grackle_rates;
@@ -141,6 +142,12 @@ int local_calculate_cooling_time(chemistry_data *my_chemistry,
       my_units->a_value * my_units->a_units;
     co_density_units = my_units->density_units /
       POW(my_units->a_value * my_units->a_units, 3);
+  }
+
+  /* Error checking for H2 shielding approximation */
+  if (self_shielding_err_check(my_chemistry, my_fields,
+                               "local_calculate_temperature") == FAIL) {
+    return FAIL;
   }
 
   /* Calculate temperature units. */

--- a/src/clib/solve_chemistry.c
+++ b/src/clib/solve_chemistry.c
@@ -156,12 +156,8 @@ int local_solve_chemistry(chemistry_data *my_chemistry,
   }
 
   /* Error checking for H2 shielding approximation */
-  if (my_chemistry->H2_self_shielding == 1 && my_fields->grid_rank != 3){
-    fprintf(stderr, "Error in solve_chemistry: H2 self-shielding option 1 "
-                    "will only work for 3D Cartesian grids. Use option 2 "
-                    "to provide an array of shielding lengths with "
-                    "H2_self_shielding_length or option 3 to use the "
-                    "local Jeans length.");
+  if (self_shielding_err_check(my_chemistry, my_fields,
+                               "local_solve_chemistry") == FAIL) {
     return FAIL;
   }
 

--- a/src/clib/utils.c
+++ b/src/clib/utils.c
@@ -1,0 +1,40 @@
+/***********************************************************************
+/
+/ Implement utility functions used internally by Grackle (across routines)
+/
+/
+/ Copyright (c) 2013, Enzo/Grackle Development Team.
+/
+/ Distributed under the terms of the Enzo Public Licence.
+/
+/ The full license is in the file LICENSE, distributed with this 
+/ software.
+************************************************************************/
+
+#include "utils.h"
+#include <stdio.h> // fprintf, stderr
+#include "grackle_macros.h"
+
+int self_shielding_err_check(const chemistry_data *my_chemistry,
+                             const grackle_field_data *fields,
+                             const char* func_name) {
+  if (my_chemistry->H2_self_shielding == 1) {
+    if (fields->grid_rank != 3) {
+      fprintf(stderr, "Error in %s: H2 self-shielding option 1 "
+                      "will only work for 3D Cartesian grids. Use option 2 "
+                      "to provide an array of shielding lengths with "
+                      "H2_self_shielding_length or option 3 to use the "
+                      "local Jeans length.",
+              func_name);
+      return FAIL;
+    } else if (my_chemistry->primordial_chemistry >= 2 &&
+               fields->grid_dx <= 0) {
+      fprintf(stderr, "Error in %s: H2 self-shielding option 1 and primordial "
+                      "chemistry options of 2 or more require that grid_dx "
+                      "has a positive value.",
+              func_name);
+      return FAIL;
+    }
+  }
+  return SUCCESS;
+}

--- a/src/clib/utils.h
+++ b/src/clib/utils.h
@@ -1,0 +1,25 @@
+/***********************************************************************
+/
+/ Declare utility functions used internally by Grackle (across routines)
+/
+/
+/ Copyright (c) 2013, Enzo/Grackle Development Team.
+/
+/ Distributed under the terms of the Enzo Public Licence.
+/
+/ The full license is in the file LICENSE, distributed with this 
+/ software.
+************************************************************************/
+
+#include "grackle_chemistry_data.h"
+#include "grackle_types.h"
+
+/// Perform an error check related to self-shielding. If the check fails, the
+/// function returns FAIL and prints an error message to stderr
+///
+/// @param my_chemistry Holds configuration of chemistry solver
+/// @param fields Specify the field names
+/// @param func_name Name of the function that is calling the error check
+int self_shielding_err_check(const chemistry_data *my_chemistry,
+                             const grackle_field_data *fields,
+                             const char* func_name);


### PR DESCRIPTION
The `grid_dx` field is only needed for a subset of grackle operations and it sometimes doesn't make sense for a downstream application to properly set the value (e.g. where cells are not perfect cubes or if the code isn't grid-based).

I also tweaked the documentation to recommend that downstream applications set `grackle_field_data.grid_dx` to something `-1` in cases where it's not applicable (if the value is not initialized at all, the new error check might not work...)

As part of this commit, I actually factored the error-check out into it's own function (as well as another related check) in order to make sure that we apply the same test in both the `calculate_cooling_time` and `solve_chemistry` functions.

I placed that function inside of a newly created file called `utils.c`. I think that could be a good place to place functions that represent duplicated logic present in more than 1 c-routine (e.g. resetting the UVbackground rates, calculating comoving length/density units) and maybe some other basic error checks 