### PR TITLE
Fix minor oversight from #190

### DIFF
--- a/src/clib/solve_chemistry.c
+++ b/src/clib/solve_chemistry.c
@@ -17,6 +17,7 @@
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
 #include "phys_constants.h"
+#include "utils.h"
 
 extern chemistry_data *grackle_data;
 extern chemistry_data_storage grackle_rates;

--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -700,6 +700,7 @@ cdef c_field_data setup_field_data(object fc, int[::1] buf,
     my_fields.grid_dimension = grid_dimension
     my_fields.grid_start = grid_start
     my_fields.grid_end = grid_end
+    my_fields.grid_dx = -1
 
     my_fields.density = get_field(fc, "density")
     my_fields.HI_density = get_field(fc, "HI")


### PR DESCRIPTION
Adding a missing include-directive (that was forgotten in PR #190). This also sets `grackle_field_data`'s `grid_dx` value to -1 in `pygrackle` since that's what we now recommend when it's not in use (to facilitate the error-check from PR #190).