### PR TITLE
Better Describe Local Functions - with `"sphinx_tabs"`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
             pip install --upgrade pip
             pip install --upgrade wheel
             pip install --upgrade setuptools
-            pip install sphinx
+            pip install sphinx sphinx-tabs
 
   download-test-data:
     description: "Download test data."

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+python:
+   install:
+   - requirements: doc/source/requirements.txt

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -292,35 +292,75 @@ be set to their desired values by accessing ``grackle_data``.  See
    these. See the :ref:`c_local_example.c <examples>` sample code for an
    example of this implementation.
 
-.. code-block:: c++
+.. tabs::
 
-  chemistry_data *my_grackle_data;
-  my_grackle_data = new chemistry_data;
-  if (set_default_chemistry_parameters(my_grackle_data) == 0) {
-    fprintf(stderr, "Error in set_default_chemistry_parameters.\n");
-  }
+   .. code-tab:: c++ Primary Functions
 
-  // Set parameter values for chemistry.
-  // Now access the global copy of the chemistry_data struct (grackle_data).
-  grackle_data->use_grackle = 1;            // chemistry on
-  grackle_data->with_radiative_cooling = 1; // cooling on
-  grackle_data->primordial_chemistry = 3;   // molecular network with H, He, D
-  grackle_data->metal_cooling = 1;          // metal cooling on
-  grackle_data->UVbackground = 1;           // UV background on
-  grackle_data->grackle_data_file = "CloudyData_UVB=HM2012.h5"; // data file
+         chemistry_data *my_grackle_data;
+         my_grackle_data = new chemistry_data;
+         if (set_default_chemistry_parameters(my_grackle_data) == 0) {
+           fprintf(stderr, "Error in set_default_chemistry_parameters.\n");
+         }
+
+
+         // At this point, the developer can forget all about the my_grackle_data pointer
+         // since that has been copied to the global variable grackle_data
+
+
+         // Set parameter values for chemistry.
+         // Now access the global copy of the chemistry_data struct (grackle_data).
+         grackle_data->use_grackle = 1;            // chemistry on
+         grackle_data->with_radiative_cooling = 1; // cooling on
+         grackle_data->primordial_chemistry = 3;   // molecular network with H, He, D
+         grackle_data->metal_cooling = 1;          // metal cooling on
+         grackle_data->UVbackground = 1;           // UV background on
+         grackle_data->grackle_data_file = "CloudyData_UVB=HM2012.h5"; // data file
+
+   .. code-tab:: c++ Local Functions
+
+
+         chemistry_data *my_grackle_data;
+         my_grackle_data = new chemistry_data;
+         if (local_initialize_chemistry_parameters(my_grackle_data) == 0) {
+           fprintf(stderr, "Error in local_initialize_chemistry_parameters.\n");
+         }
+
+         // Set parameter values for chemistry.
+         // Now access the global copy of the chemistry_data struct (grackle_data).
+         my_grackle_data->use_grackle = 1;            // chemistry on
+         my_grackle_data->with_radiative_cooling = 1; // cooling on
+         my_grackle_data->primordial_chemistry = 3;   // molecular network with H, He, D
+         my_grackle_data->metal_cooling = 1;          // metal cooling on
+         my_grackle_data->UVbackground = 1;           // UV background on
+         my_grackle_data->grackle_data_file = "CloudyData_UVB=HM2012.h5"; // data file
+
 
 Once the desired parameters have been set, the chemistry and cooling rates 
 must be initialized by calling :c:func:`initialize_chemistry_data` with a
 pointer to the :c:data:`code_units` struct created earlier.  This function
 will return an integer indicating success (1) or failure (0).
 
-.. code-block:: c++
+.. tabs::
 
-  // Finally, initialize the chemistry object.
-  if (initialize_chemistry_data(&my_units) == 0) {
-    fprintf(stderr, "Error in initialize_chemistry_data.\n");
-    return 0;
-  }
+   .. code-tab:: c++ Primary Functions
+
+         // Finally, initialize the chemistry object.
+         if (initialize_chemistry_data(&my_units) == 0) {
+           fprintf(stderr, "Error in initialize_chemistry_data.\n");
+           return 0;
+         }
+
+   .. code-tab:: c++ Local Functions
+
+         // Allocate the chemistry_data_storage type
+         chemistry_data_storage *my_grackle_rates = new chemistry_data_storage;
+
+         // Finally, initialize the chemistry object.
+         if (local_initialize_chemistry_data(my_chemistry_data, my_grackle_rates,
+                                             &my_units) == 0) {
+           fprintf(stderr, "Error in local_initialize_chemistry_data.\n");
+           return 0;
+         }
 
 The Grackle is now ready to be used.
 

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -836,11 +836,14 @@ Calculating the Dust Temperature Field
 Clearing the memory
 -------------------
 
+
+When using the Grackle's :ref:`primary_functions`, global structures are used and therefore the global structure ``grackle_rates`` needs to be released with
+
 .. code-block:: c++
 
   free_chemistry_data();
 
-Grackle is using global structures and therefore the global structure ``grackle_rates`` needs also to be released.
+When using the :ref:`local_functions`, you should call the counter-part function, :c:func:`local_free_chemistry_data`, to free memory used for storing chemistry and cooling rates.
 
 .. _query-version:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ from query_version import query_version
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx_tabs.tabs']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-tabs


### PR DESCRIPTION
I put this together mostly as an experiment with the `"sphinx_tabs"` (an extension I became aware of if because I wanted to know how the the documentation for readthedocs includes tabbed content -- they use the extension).

Essentially, I modified the `Chemistry Data` section of the docs to include code snippets for the Local Functions in addition to the Primary Functions. (I basically rewrote the section so that the narrative is more consistent with both sets of snippets)

I think this is a nifty extension that makes it easy to describe multiple ways of doing something without requiring us to add a bunch of extra sections to describe those alternative approaches. (plus we don't have to worry about back-referencing or forward referencing between such sessions). I think that there are a few other places we could use this feature.[^1]

Let me know how you feel about this. I suppose there are a few potential cons:
- I don't know how we feel about using an extension... (I am somewhat encouraged that readthedocs's documentation uses it)
- I don't know if it is compatible with building PDF docs (I assume it's not compatible at all). Is this important to us?
- We will have more things to maintain... Honestly, I'm not that worried. Plus, there are steps that we could (maybe should) take to reduce the burden[^2]

Let me know what you think.

[^1]: In particular, there are a few other spots where we could describe the Local-Functions. We could also potentially describe how to use the dynamic-api for initializing chemistry_data (but that might be a little disruptive to the narrative). Perhaps more interestingly, we could illustrate the equivalent `pygrackle` commands. I think we would only need to slightly reframe the narrative to do that (but, it might be easier to do if PR #195 goes through)

[^2]: we could use sphinx's [literalinclude](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude) directive to explicitly extract (at least some of) the code snippets from the example files. We might need to slightly restructure some of the examples, so that the structure is a little more consistent, and we would probably want to add comment-tags to be used with the directive's `:start-after:` and `:end-before:`. But, I actually think this would make the example-files even more useful.