### PR TITLE
Allow unsupported simulation types to work with grackle yt fields.

### DIFF
--- a/src/python/pygrackle/yt_fields.py
+++ b/src/python/pygrackle/yt_fields.py
@@ -118,8 +118,9 @@ def prepare_grackle_data(ds, parameters=None):
     sim_type = type(ds)
     par_map = _parameter_map.get(sim_type)
     if par_map is None:
-        raise RuntimeError(
-            "Simulation type not supported: %s." % sim_type)
+        print (f"Warning: cannot get Grackle parameters from {sim_type}.\n"
+               "All parameters need to be supplied through the \"parameters\" keyword.")
+        par_map = {}
 
     all_parameters = \
       dict([(gpar, ds.parameters[dpar])


### PR DESCRIPTION
This is in response to a user request on slack. This minor change will allow non-Enzo simulations to use the [yt fields](https://grackle.readthedocs.io/en/latest/Python.html#using-grackle-with-yt) feature of Pygrackle. Currently, we only have a map between simulation parameter names and grackle parameter names for Enzo, but users can still provide them by hand, or at least they could if we didn't raise an exception if a parameter map is not found. This removes the exception and simply prints a warning, allowing the user to proceed.

All of this is fairly undocumented outside of the example Python scripts provided, but I intend to improve that moving forward, but ideally not a part of this pull request.