### PR TITLE
Introduce GR_SUCCESS and GR_FAIL

### DIFF
--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -16,12 +16,17 @@
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
+#include "grackle.h"
 #include "grackle_macros.h"
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
 #include "phys_constants.h"
 #ifdef _OPENMP
 #include <omp.h>
+#endif
+
+#if (GR_SUCCESS != SUCCESS) || (GR_FAIL != FAIL)
+#error "Sanity check failure: GR_SUCCESS must be consistent with SUCCESS and GR_FAIL must be consistent with FAIL"
 #endif
 
 extern int grackle_verbose;
@@ -173,7 +178,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
 
     if (my_chemistry->metal_cooling < 1) {
       fprintf(stderr, "ERROR: dust_chemistry > 0 requires metal_cooling > 0.\n");
-      return FAIL;
+      return GR_FAIL;
     }
 
     if (my_chemistry->photoelectric_heating < 0) {
@@ -211,7 +216,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
     fprintf(stdout,
             "omp_nthreads can't be set when Grackle isn't compiled with "
             "OPENMP\n");
-    return FAIL;
+    return GR_FAIL;
   }
 # else /* _OPENMP */
   if (my_chemistry->omp_nthreads < 1) {
@@ -235,7 +240,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
   if (my_units->comoving_coordinates == FALSE &&
       my_units->a_units != 1.0) {
     fprintf(stderr, "ERROR: a_units must be 1.0 if comoving_coordinates is 0.\n");
-    return FAIL;
+    return GR_FAIL;
   }
 
   // deal with my_chemistry->HydrogenFractionByMass
@@ -255,7 +260,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
 
   if (my_chemistry->HydrogenFractionByMass > 1) {
     fprintf(stderr, "ERROR: HydrogenFractionByMass cannot exceed 1.0\n");
-    return FAIL;
+    return GR_FAIL;
   } else if (my_chemistry->primordial_chemistry == 0) {
     /* In fully tabulated mode, set H mass fraction according to
        the abundances in Cloudy, which assumes n_He / n_H = 0.1.
@@ -284,7 +289,7 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
               "    Grackle would silently overwrite the value of\n"
               "    HydrogenFractionByMass instead of reporting this error\n",
               default_Hfrac);
-      return FAIL;
+      return GR_FAIL;
     }
   } else {
     const double default_Hfrac = 0.76;
@@ -316,25 +321,25 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
   read_data = my_chemistry->primordial_chemistry == 0;
   if (initialize_cloudy_data(my_chemistry, my_rates,
                              &my_rates->cloudy_primordial,
-                             "Primordial", my_units, read_data) == FAIL) {
+                             "Primordial", my_units, read_data) == GR_FAIL) {
     fprintf(stderr, "Error in initialize_cloudy_data.\n");
-    return FAIL;
+    return GR_FAIL;
   }
 
   /* Metal tables. */
   read_data = my_chemistry->metal_cooling == TRUE;
   if (initialize_cloudy_data(my_chemistry, my_rates,
                              &my_rates->cloudy_metal,
-                             "Metals", my_units, read_data) == FAIL) {
+                             "Metals", my_units, read_data) == GR_FAIL) {
     fprintf(stderr, "Error in initialize_cloudy_data.\n");
-    return FAIL;
+    return GR_FAIL;
   }
 
   /* Initialize UV Background data. */
   initialize_empty_UVBtable_struct(&(my_rates->UVbackground_table));
-  if (initialize_UVbackground_data(my_chemistry, my_rates) == FAIL) {
+  if (initialize_UVbackground_data(my_chemistry, my_rates) == GR_FAIL) {
     fprintf(stderr, "Error in initialize_UVbackground_data.\n");
-    return FAIL;
+    return GR_FAIL;
   }
 
   if (grackle_verbose) {
@@ -381,17 +386,17 @@ int local_initialize_chemistry_data(chemistry_data *my_chemistry,
 #   endif
   }
 
-  return SUCCESS;
+  return GR_SUCCESS;
 }
 
 int initialize_chemistry_data(code_units *my_units)
 {
   if (local_initialize_chemistry_data(grackle_data, &grackle_rates,
-                                      my_units) == FAIL) {
+                                      my_units) == GR_FAIL) {
     fprintf(stderr, "Error in local_initialize_chemistry_data.\n");
-    return FAIL;
+    return GR_FAIL;
   }
-  return SUCCESS;
+  return GR_SUCCESS;
 }
 
 // Define helpers for the show_parameters function
@@ -413,11 +418,11 @@ void show_parameters(FILE *fp, chemistry_data *my_chemistry){
 }
 
 int free_chemistry_data(void){
-  if (local_free_chemistry_data(grackle_data, &grackle_rates) == FAIL) {
+  if (local_free_chemistry_data(grackle_data, &grackle_rates) == GR_FAIL) {
     fprintf(stderr, "Error in local_free_chemistry_data.\n");
-    return FAIL;
+    return GR_FAIL;
   }
-  return SUCCESS;
+  return GR_SUCCESS;
 }
 
 int local_free_chemistry_data(chemistry_data *my_chemistry,
@@ -521,5 +526,5 @@ int local_free_chemistry_data(chemistry_data *my_chemistry,
     GRACKLE_FREE(my_rates->UVbackground_table.crsHeI);
   }
 
-  return SUCCESS;
+  return GR_SUCCESS;
 }

--- a/src/include/grackle.h
+++ b/src/include/grackle.h
@@ -21,6 +21,10 @@
 extern "C" {
 #endif /* __cplusplus */
 
+// standard error codes returned by the grackle functions
+#define GR_SUCCESS 1
+#define GR_FAIL 0
+
 extern int grackle_verbose;
 
 extern chemistry_data *grackle_data;

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -1,6 +1,3 @@
-cdef extern from "grackle_macros.h":
-    cdef int GRACKLE_FAIL_VALUE "FAIL"
-
 cdef extern from "grackle_types.h":
     # This does not need to be exactly correct, only of the right basic type
     ctypedef float gr_float
@@ -175,6 +172,8 @@ cdef extern from "grackle_types.h":
       const char* revision;
 
 cdef extern from "grackle.h":
+    cdef int GRACKLE_FAIL_VALUE "GR_FAIL"
+
     int local_initialize_chemistry_parameters(c_chemistry_data *my_chemistry)
 
     void set_velocity_units(c_code_units *my_units)

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -7,7 +7,7 @@ cython_extensions = [
     Extension(
         "pygrackle.grackle_wrapper",
         ["pygrackle/grackle_wrapper.pyx"],
-        include_dirs=["../clib", "../clib/autogen", "../include"],
+        include_dirs=["../clib/autogen", "../include"],
         library_dirs=["../clib/.libs/"],
         libraries=["grackle"],
         define_macros=[


### PR DESCRIPTION
These are macros in the public grackle.h header file. The idea is that external applications will be able to decode the error-codes in a self-consistent manner with the rest of Grackle.

In practice, the main benefit here is that the python bindings no longer need to include a private Grackle header. This will ultimately lead to a minor simplification in GH #208.

Ideally, we would go through and replace all occurences of ``SUCCESS`` with ``GR_SUCCESS`` and ``FAIL`` with ``GR_FAIL`` (so that we can entirely remove ``SUCCESS`` and ``FAIL`` from the codebase), but that would be a fairly invasive change that would touch a lot of code.

- I illustrated what that would look like in ``initialize_chemistry_data.c`` and I also added a compile-time check to ensure consistency of ``GR_SUCCESS`` with ``SUCCESS`` and ``GR_FAIL`` with ``FAIL``.

- I'm happy to propoagate this change, but I want some buy-in before I pursue that. (Maybe it would be better in a separate PR?)