### PR TITLE
Code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+# this is based on Google style, with a few tweaks based on LLVM style 
+# -> the 2 styles are extremely similar
+# -> The Google style tries to put a function's return-type on the same line
+#    as the function's name (which a lot of people prefer). It also makes a
+#    few minor stylistic choices that generally produces slightly terser code 
+# -> LLVM style is a little more permissive about certain things
+
+# we inherit all defaults from Google style
+BasedOnStyle: Google
+
+# this is redundant, but this is specified to ensure that we remove all tabs
+UseTab: Never
+
+# overrides based on LLVM
+# -----------------------
+# tweaks indents/outdent of private, public, protected in C++ classes/structs
+AccessModifierOffset: -2
+# controls alignment of backslashes that escape newlines (most common in macros
+# that extend over 3 or more lines)
+AlignEscapedNewlines: Right
+# be more definitive about the preferred pointer alignment
+DerivePointerAlignment: false
+# don't reorder include-statements (with that said, reordering shouldn't 
+# actually cause any problems for Grackle)
+IncludeBlocks: Preserve

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# test run of clang format on src/clib/utils.[ch]
+cba8b7cb98b55e1732aa62443f1d1868a9fb9dee

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,37 @@ config/configure_file.py\
 |src/python/tests/test_volumetric_heating_rate.py\
 |src/python/pygrackle/grackle_defs.pxd\
 |src/python/pygrackle/grackle_wrapper.pyx\
+|src/clib/calculate_cooling_time.c\
+|src/clib/calculate_dust_temperature.c\
+|src/clib/calculate_gamma.c\
+|src/clib/calculate_pressure.c\
+|src/clib/calculate_temperature.c\
+|src/clib/cie_thin_cooling_rate_tables.h\
+|src/clib/dynamic_api.c\
+|src/clib/grackle_macros.h\
+|src/clib/grackle_units.c\
+|src/clib/index_helper.c\
+|src/clib/index_helper.h\
+|src/clib/initialize_UVbackground_data.c\
+|src/clib/initialize_chemistry_data.c\
+|src/clib/initialize_cloudy_data.c\
+|src/clib/initialize_rates.c\
+|src/clib/phys_constants.h\
+|src/clib/rate_functions.c\
+|src/clib/set_default_chemistry_parameters.c\
+|src/clib/solve_chemistry.c\
+|src/clib/update_UVbackground_rates.c\
+|src/clib/utils.c\
+|src/clib/utils.h\
+|src/example/c_example.c\
+|src/example/c_local_example.c\
+|src/example/cxx_example.C\
+|src/example/cxx_grid_example.C\
+|src/example/cxx_omp_example.C\
+|src/include/grackle.h\
+|src/include/grackle_chemistry_data.h\
+|src/include/grackle_rate_functions.h\
+|src/include/grackle_types.h\
 )"
 
 
@@ -49,6 +80,17 @@ repos:
     rev: v4.6.0
     hooks:
     - id: check-executables-have-shebangs
+
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    # unlike most pre-commit tools, the version of this repository exactly
+    # matches the version of clang-format
+    rev: v17.0.1
+    hooks:
+    -   id: clang-format
+        verbose: true
+        types_or: [c++, c]
+        args: ["-style=file", "--verbose"]
 
 # settings adopted from yt
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+
+# per discussion in GH-#218, we aren't applying formatters to old code yet (to avoid merge
+# conflicts) - maybe we start applying them after version
+exclude: "^(\
+config/configure_file.py\
+|config/query_version.py\
+|doc/source/conf.py\
+|src/python/examples/cooling_cell.py\
+|src/python/examples/cooling_rate.py\
+|src/python/examples/freefall.py\
+|src/python/examples/yt_grackle.py\
+|src/python/pygrackle/__init__.py\
+|src/python/pygrackle/api.py\
+|src/python/pygrackle/fluid_container.py\
+|src/python/pygrackle/utilities/__init__.py\
+|src/python/pygrackle/utilities/api.py\
+|src/python/pygrackle/utilities/convenience.py\
+|src/python/pygrackle/utilities/evolve.py\
+|src/python/pygrackle/utilities/misc.py\
+|src/python/pygrackle/utilities/physical_constants.py\
+|src/python/pygrackle/utilities/primordial_equilibrium.py\
+|src/python/pygrackle/utilities/testing.py\
+|src/python/pygrackle/utilities/units.py\
+|src/python/pygrackle/yt_fields.py\
+|src/python/setup.py\
+|src/python/tests/test_chemistry.py\
+|src/python/tests/test_chemistry_struct_synched.py\
+|src/python/tests/test_code_examples.py\
+|src/python/tests/test_dynamic_api.py\
+|src/python/tests/test_examples.py\
+|src/python/tests/test_get_grackle_version.py\
+|src/python/tests/test_initialisation.py\
+|src/python/tests/test_primordial.py\
+|src/python/tests/test_specific_heating_rate.py\
+|src/python/tests/test_volumetric_heating_rate.py\
+|src/python/pygrackle/grackle_defs.pxd\
+|src/python/pygrackle/grackle_wrapper.pyx\
+)"
+
+
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+
+# there are some other useful hooks we could enable from here in the future
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    - id: check-executables-have-shebangs
+
+# settings adopted from yt
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.0
+  hooks:
+  - id: ruff-format
+    types_or: [ python, pyi, jupyter ]
+  - id: ruff
+    types_or: [ python, pyi, jupyter ]
+    args: [--fix, "--show-fixes"]
+
+# uncomment the following, when we stop excluding cython files
+# (settings adopted from yt)
+#- repo: https://github.com/MarcoGorelli/cython-lint
+#  rev: v0.16.2
+#  hooks:
+#  - id: cython-lint
+#    args: [--no-pycodestyle]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,6 @@ config/configure_file.py\
 |src/clib/set_default_chemistry_parameters.c\
 |src/clib/solve_chemistry.c\
 |src/clib/update_UVbackground_rates.c\
-|src/clib/utils.c\
-|src/clib/utils.h\
 |src/example/c_example.c\
 |src/example/c_local_example.c\
 |src/example/cxx_example.C\

--- a/doc/source/Contributing.rst
+++ b/doc/source/Contributing.rst
@@ -1,5 +1,33 @@
 .. include:: ../../CONTRIBUTING.rst
 
+Style Formatting
+----------------
+All C/C++/python code contributed in new files will be formatted by automated tools (for the time being, code in older files will not be formatted to avoid merge-conflicts).
+
+The formatters are run by the `pre-commit.ci <https://pre-commit.ci/>`__ continuous integration tool.
+This form of continuous integration is built on top of the `pre-commit <https://pre-commit.com/>`__ framework, which is responsible for calling individual linting tools.
+
+In more detail:
+
+* python code is formatted by `https://github.com/astral-sh/ruff`__
+
+* C/C++ code is formatted by `clang-format <https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormat.html>`__.
+  Note: clang-format version is tied to the LLVM version number and different major versions are not necessarily compatible. 
+  If you want to manually invoke clang-format locally, you need to make sure you have **exactly** version 17.0.1 installed.
+  The easier way to invoke it directly is to rely upon the pre-commit software.
+
+At this time, we highly discourage manually invoking these linters (currently they aren't aware of which files to skip -- that information is only known to pre-commit).
+If you want to invoke these linters locally you should install the `pre-commit <https://pre-commit.com/>`__ python package and then invoke the following from the root of the Grackle directory
+
+.. code-block:: shell-session
+
+   ~/grackle $ pre-commit run --all-files
+
+The above command will install local copies of the required linting tools (and will manage local copies of them) and will then modify the files in your repository.
+
+Alternatively you can leave a comment on a PR that says ``pre-commit.ci autofix`` and pre-commit.ci will add a commit to your branch to fix formatting errors.
+
+
 .. _adding-new-params:
 
 Adding a New Parameter

--- a/src/clib/utils.c
+++ b/src/clib/utils.c
@@ -7,31 +7,33 @@
 /
 / Distributed under the terms of the Enzo Public Licence.
 /
-/ The full license is in the file LICENSE, distributed with this 
+/ The full license is in the file LICENSE, distributed with this
 / software.
 ************************************************************************/
 
 #include "utils.h"
-#include <stdio.h> // fprintf, stderr
+#include <stdio.h>  // fprintf, stderr
 #include "grackle_macros.h"
 
-int self_shielding_err_check(const chemistry_data *my_chemistry,
-                             const grackle_field_data *fields,
+int self_shielding_err_check(const chemistry_data* my_chemistry,
+                             const grackle_field_data* fields,
                              const char* func_name) {
   if (my_chemistry->H2_self_shielding == 1) {
     if (fields->grid_rank != 3) {
-      fprintf(stderr, "Error in %s: H2 self-shielding option 1 "
-                      "will only work for 3D Cartesian grids. Use option 2 "
-                      "to provide an array of shielding lengths with "
-                      "H2_self_shielding_length or option 3 to use the "
-                      "local Jeans length.",
+      fprintf(stderr,
+              "Error in %s: H2 self-shielding option 1 "
+              "will only work for 3D Cartesian grids. Use option 2 "
+              "to provide an array of shielding lengths with "
+              "H2_self_shielding_length or option 3 to use the "
+              "local Jeans length.",
               func_name);
       return FAIL;
     } else if (my_chemistry->primordial_chemistry >= 2 &&
                fields->grid_dx <= 0) {
-      fprintf(stderr, "Error in %s: H2 self-shielding option 1 and primordial "
-                      "chemistry options of 2 or more require that grid_dx "
-                      "has a positive value.",
+      fprintf(stderr,
+              "Error in %s: H2 self-shielding option 1 and primordial "
+              "chemistry options of 2 or more require that grid_dx "
+              "has a positive value.",
               func_name);
       return FAIL;
     }

--- a/src/clib/utils.h
+++ b/src/clib/utils.h
@@ -7,7 +7,7 @@
 /
 / Distributed under the terms of the Enzo Public Licence.
 /
-/ The full license is in the file LICENSE, distributed with this 
+/ The full license is in the file LICENSE, distributed with this
 / software.
 ************************************************************************/
 
@@ -20,6 +20,6 @@
 /// @param my_chemistry Holds configuration of chemistry solver
 /// @param fields Specify the field names
 /// @param func_name Name of the function that is calling the error check
-int self_shielding_err_check(const chemistry_data *my_chemistry,
-                             const grackle_field_data *fields,
+int self_shielding_err_check(const chemistry_data* my_chemistry,
+                             const grackle_field_data* fields,
                              const char* func_name);


### PR DESCRIPTION
## Overview

As a followup to #218, This introduced a basic configuration file for the [pre-commit](https://pre-commit.com/) software that calls clang-format and ruff run code-formatting on all new c/c++/python files added to grackle. All existing files will not be touched. (with that said, I tested out the new c/c++ linting on ``src/clib/utils.c`` and ``src/clib/utils.h`` since they are unlikely to have merge conflicts).

I also added documentation explaining how to locally run this machinery.

We are interested in using [pre-commit.ci](https://pre-commit.ci/), which is a continuous integration system designed around pre-commit. 
- After we set up pre-commit.ci, a check will appear at the bottom of every PR that specifies whether the configured lints (namely ruff and clang-format) passed or failed. 
- pre-commit.ci is free for all open-source software. It also has the nifty feature, where adding a comment that says "pre-commit.ci autofix" to a PR (where the pre-commit.ci check has failed), will trigger pre-commit.ci to add a commit to that PR that fixes the formatting.

``yt`` actually makes use of pre-commit.ci

## What we need to do after merging

We will need to go to the [pre-commit.ci](https://pre-commit.ci/) and enable it for the grackle repository. (I'm happy to try to do that, but I may not have appropriate permissions -- so Britton may ultimately need to do that)


