### PR TITLE
Remove the lone `cimport numpy` line

### DIFF
--- a/src/python/pygrackle/grackle_wrapper.pyx
+++ b/src/python/pygrackle/grackle_wrapper.pyx
@@ -19,7 +19,6 @@ from pygrackle.utilities.physical_constants import \
 from libc.limits cimport INT_MAX
 from .grackle_defs cimport *
 import numpy as np
-cimport numpy as np
 
 cdef class chemistry_data:
     cdef _wrapped_c_chemistry_data data
@@ -654,12 +653,26 @@ cdef class chemistry_data:
         def __get__(self):
             return self.density_units * self.energy_units
 
-cdef gr_float* get_field(fc, name):
-    cdef np.ndarray rv = fc.get(name, None)
-    if rv is None:
+
+
+cdef gr_float* get_field(object fc, object name) except? NULL:
+    """
+    Helper function to retrieve a field's pointer from a ``FluidContainer``
+
+    Note
+    ----
+    This function signature informs cython that it needs to inject code every
+    time this function is called to check whether a Python Exception was raised
+    when function-call returns a ``NULL`` pointer. Exceptions can arise if a
+    user accidently typed ``fc[k] = vals`` instead of ``fc[k][:] = vals``.
+    """
+    cdef object arr = fc.get(name, None)
+    if arr is None:
         return NULL
-    else:
-        return <gr_float *> rv.data
+
+    assert arr.size == fc.n_vals # sanity check
+    cdef gr_float[::1] view = arr
+    return <gr_float *> &view[0]
 
 cdef c_field_data setup_field_data(object fc, int[::1] buf,
                                    bint include_velocity) except *:


### PR DESCRIPTION
This should let us drop numpy as a build-time requirement. This involved a minor edit to the ``get_field`` c-function written in `grackle_wrapper.pyx` (we now use Cython's built-in typed memory-view functionality instead. While I was there, I made a minor tweak to the function so that it will perform proper error-checking for a plausible failure-mode.

I have not actually modified `setup.py` to remove `numpy` from the list of build-requirements. I quickly tried to do that, but got an opaque setuptools-related error. I decided not to deal with this since we are transitioning to scikit-build-core.