### PR TITLE
add a list of software that uses Grackle to the `README.md` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ pressure, and ratio of specific heats (gamma).
 For more information on features, installation, and integration with simulation
 codes and models, see our [online documentation](https://grackle.readthedocs.io/).
 
+## Software that uses Grackle
+
+A (non-exhaustive) list of software that provides out-of-the-box support for using Grackle includes:
+
+- [ChaNGa](https://github.com/N-BodyShop/changa)
+
+- [Cholla](https://github.com/cholla-hydro/cholla)
+
+- [Enzo](https://enzo-project.org/)
+
+- [Enzo-E](https://enzo-e.readthedocs.io/en/latest/)
+
+- [Gamer](https://github.com/gamer-project/gamer)
+
+- [Gasoline](https://github.com/N-BodyShop/gasoline)
+
+- [GIZMO](http://www.tapir.caltech.edu/~phopkins/Site/GIZMO.html)
+
+- [Swift](https://github.com/SWIFTSIM/SWIFT)
+
+We welcome PRs to add your simulation code to this list. We also welcome the inclusion of python modules that depend on Pygrackle.
+
 ## Resources
 
 - documentation: https://grackle.readthedocs.io/


### PR DESCRIPTION
I think this list is a nice way to illustrate how commonly used Grackle is. It could be nice to add this information to the documentation. If we did that, it might be optimal to convert the README from markdown to restructured text to avoid duplicating the list in multiple locations. 

I'm probably missing some cases, but all codes in this initial list provide out-of-the-box support for at least some version of Grackle (and I think they all mention this in their documentation).

One thing to think about is: what is the criterion for inclusion in this list?
- In an ideal world, it would be preferable to exclusively list software that provides out-of-the-box support for Grackle.
- With that said, I don't want to be too exclusive... But the following cases are worth considering:
   1. What do we do about codes that only use a vendored copy of Grackle (that may or may not have internal customizations)?
   2. What about codes that only support a particular Grackle-fork?
   3. What do we do about cases where there is no public-release of a code with Grackle support? (For example, I think I heard that some people have private Arepo forks with Grackle support. I suspect that similar forks of Athena++ probably also exist).
- In general, I'm personally pretty open to supporting cases 1 and 2 (especially if there are active plans to support the primary Grackle repository).
- I'm not sure we need to adopt a policy now. But, it's definitely worth considering.

In fact, it may be beneficial not to explicitly adopt a firm policy and handle this on a case-by-case basis. If someone wants to add their code, we probably just address this on a case-by-case basis