### PR TITLE
Convert reaction rate test to gold standard model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
       - install-grackle:
           omp: 'false'
           classic_build: 'false'
-          tag: gold-standard-v1
+          tag: gold-standard-v2
 
       - run-tests:
           omp: 'false'

--- a/src/python/tests/test_initialisation.py
+++ b/src/python/tests/test_initialisation.py
@@ -14,7 +14,15 @@ import os
 from pygrackle import chemistry_data
 #Necessary constants from grackle
 from pygrackle.utilities.physical_constants import mass_hydrogen_cgs
-from pygrackle.utilities.testing import assert_allclose
+from pygrackle.utilities.testing import \
+    assert_allclose, \
+    ensure_dir
+
+from testing_common import \
+    generate_test_results, \
+    test_answers_dir
+
+ensure_dir(test_answers_dir)
 
 #* Function which returns chemistry_data instance with default initialisation settings.
 def get_defChem():
@@ -101,7 +109,7 @@ def set_parameters(parSet, my_chemistry):
 
 #* Function which tests that the rates have been initialised correctly for each parameter set.
 def test_rate_initialisation(printParameters=False, printOOMdiscrepanices=False, testCustomFile=False, parSets=[1,2,3,4,5,6,7],
-                                fileName="rate_coefficients.h5", noAssert=False):
+                                fileName="rate_coefficients.h5"):
     """
     Test that the rate tables are initialized correctly.
 
@@ -126,6 +134,8 @@ def test_rate_initialisation(printParameters=False, printOOMdiscrepanices=False,
 
     #* Calculate rates for each parameter set and write to hdf5 file
     #Create and open file. If the file already exists this will overwrite it.
+    if generate_test_results:
+        fileName = os.path.join(test_answers_dir, fileName)
     f = h5py.File(fileName, "w")
 
     #Iterate over parameter sets.
@@ -152,13 +162,14 @@ def test_rate_initialisation(printParameters=False, printOOMdiscrepanices=False,
     #Close the file.
     f.close()
 
-    #* Compare rates with the expected (correct) ones which are stored and check they are in agreement
-    expectedRates = h5py.File("test_data/rate_coefficients.h5", "r")
-    initialisedRates = h5py.File("rate_coefficients.h5", "r")
-
-    #Used to skip assert, testing only.
-    if noAssert:
+    # Just generate results and leave.
+    if generate_test_results:
         return
+
+    #* Compare rates with the expected (correct) ones which are stored and check they are in agreement
+    expectedRates = h5py.File(os.path.join(test_answers_dir, fileName), "r")
+    initialisedRates = h5py.File(fileName, "r")
+
 
     #*Check all rates for each parameter set.
     #All rates except dust parameters


### PR DESCRIPTION
This minimally converts test_initialization to using the gold standard model. This will facilitate tracking of changes to reaction rates coming in PR #177.