### PR TITLE
Fixup query_version.py

### DIFF
--- a/config/query_version.py
+++ b/config/query_version.py
@@ -1,17 +1,25 @@
 #!/usr/bin/env python3
-import argparse, os, subprocess
+import argparse
+import os
+import subprocess
+
 
 def get_last_line(path):
     last_line = None
-    with open(path, 'r') as f:
-        for line in filter(lambda l: len(l) > 0 and not l.isspace(), f):
-            last_line = line
+    with open(path, "r") as f:
+        for line in f:
+            if len(line) > 0 and not line.isspace():
+                last_line = line
     if last_line is None:
         raise ValueError("the {} file is empty".format(path))
     return last_line.rstrip()
 
+
 def query_version():
-    return get_last_line(os.path.join(os.path.dirname(__file__), '../VERSION'))
+    return get_last_line(
+        os.path.join(os.path.dirname(__file__), "..", "VERSION")
+    )
+
 
 def _call(command, fallback_result=None, **kwargs):
     try:
@@ -20,6 +28,7 @@ def _call(command, fallback_result=None, **kwargs):
         return fallback_result
     return rslt.decode().rstrip()  # return as str & remove any trailing '\n'
 
+
 def query_git(command):
     # historically, we queried whether git exists before executing a command.
     # However, on certain systems this doesn't seem to be adequate. Instead, we
@@ -27,15 +36,20 @@ def query_git(command):
     return _call(command, fallback_result="N/A")
 
 
-choices = {"show-version" : query_version,
-           "git-branch" : lambda: query_git("git rev-parse --abbrev-ref HEAD"),
-           "git-revision" : lambda: query_git("git rev-parse HEAD")}
+choices = {
+    "show-version": query_version,
+    "git-branch": lambda: query_git("git rev-parse --abbrev-ref HEAD"),
+    "git-revision": lambda: query_git("git rev-parse HEAD"),
+}
 
 parser = argparse.ArgumentParser("query version information")
-parser.add_argument('directive', choices = list(choices),
-                    help = "specifies the information to check")
+parser.add_argument(
+    "directive",
+    choices=list(choices),
+    help="specifies the information to check",
+)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()
     result = choices[args.directive]()
     print(result)


### PR DESCRIPTION
This consists of 2 commits:
1. The first tries to modify the logic for querying git information. This is mostly an attempt to try to address an issue @ChristopherBignamini was encountering.
2. The second commit reformats a bunch of code in order to try to satisfy `flake8` (I also applied `ruff format`)