### PR TITLE
Fix ReadTheDocs doc CI build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,3 +8,7 @@ build:
 python:
    install:
    - requirements: doc/source/requirements.txt
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: doc/source/conf.py


### PR DESCRIPTION
ReadTheDocs has broken CI builds builds unless you explicitly specify that we are building sphinx docs