### PR TITLE
[newchem-cpp] Move itmask reset inside if statement.

### DIFF
--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -1344,12 +1344,12 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &                itmask_metal, itr, imp_eng
      &              )
 
-            endif ! if (ispecies .gt. 0) then
-
 !           return itmask
             do i = is+1, ie+1
                itmask(i) = itmask_tmp(i)
             enddo
+
+            endif ! if (ispecies .gt. 0) then
 
 !           Add the timestep to the elapsed time for each cell and find
 !            minimum elapsed time step in this row


### PR DESCRIPTION
This puts the following lines *inside* of the `if (ispecies .gt. 0) then` block:

```
!           return itmask
            do i = is+1, ie+1
               itmask(i) = itmask_tmp(i)
            enddo
```
With `primordial_chemistry=0` these lines were running and setting the itmask to False after the first iteration.

Note: with this fix, newchem-cpp now gives identical results to main for `primordial_chemistry=0`.

@mabruzzo, I'm issuing this as a PR so you can see it as I'm not sure it will affect your transcription. Feel free to merge whenever.