### PR TITLE
[newchem-cpp] Fix deuterium correction in make_consistent

### DIFF
--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -5060,7 +5060,7 @@ C***** H2Oice **********
 
       integer i, j, k
       real*8 totalH(in), totalHe(in),
-     &       totalD, metalfree(in)
+     &       totalD, metalfree(in), my_dtoh
       R_PREC correctH, correctHe, correctD
       real*8 totalZ
       real*8 totalC, totalO, totalMg, totalAl
@@ -5085,6 +5085,12 @@ C***** H2Oice **********
      &     , Sig(in), Sg(in), Feg(in)
       real*8 Cd(in), Od(in), Mgd(in), Ald(in)
      &     , Sid(in), Sd(in), Fed(in)
+
+      if (ispecies .gt. 2) then
+         my_dtoh = dtoh
+      else
+         my_dtoh = 0._DKIND
+      endif
 
 !     Loop over all zones
 
@@ -5303,10 +5309,9 @@ C           enddo
 !     Correct densities by keeping fractions the same
 
       do i = is+1, ie+1
-         correctH = real(fh*(1._DKIND - dtoh)*metalfree(i)/totalH(i)
-     &              , RKIND)
-         !! GC202005
-!!       correctH = real(fh*metalfree(i)/totalH(i), RKIND)
+!        Only include D/H ratio if using D species
+         correctH = real(fh*(1._DKIND - my_dtoh)*metalfree(i)/totalH(i),
+     &        RKIND)
          HI(i,j,k)  = HI(i,j,k)*correctH
          HII(i,j,k) = HII(i,j,k)*correctH
 

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -1344,12 +1344,12 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &                itmask_metal, itr, imp_eng
      &              )
 
-            endif ! if (ispecies .gt. 0) then
-
 !           return itmask
             do i = is+1, ie+1
                itmask(i) = itmask_tmp(i)
             enddo
+
+            endif ! if (ispecies .gt. 0) then
 
 !           Add the timestep to the elapsed time for each cell and find
 !            minimum elapsed time step in this row


### PR DESCRIPTION
This is sitting on PR #262. The make_consistent_g function in newchem-cpp was modified to include the D/H ratio when correcting the H densities. However, this should probably not be done if deuterium is not in the network.

With this change, running with `primodial_chemistry=1` produces identical results to main **if the first call to make_consistent_g in solve_rate_cool_g is commented out**. This call was added in this newchem-cpp. Previously make_consistent_g was only called at the end of solve_rate_cool_g. In the future, we will want to change the behavior so that we record initial total species densities at the beginning and then use make_consistent_g to ensure that they are conserved instead of setting them based on constants like the H mass fraction and D/H ratio. The new call to make_consistent_g can at least serve as a placeholder for what comes next.