### PR TITLE
Standard Status Reporting Machinery

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(Grackle_Grackle
   rate_functions.c
   set_default_chemistry_parameters.c
   solve_chemistry.c
+  status_reporting.c status_reporting.h
   update_UVbackground_rates.c
   utils.c
 

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -36,6 +36,7 @@ OBJS_CONFIG_LIB = \
         set_default_chemistry_parameters.lo \
         solve_chemistry.lo \
         solve_rate_cool_g.lo \
+        status_reporting.lo \
         update_UVbackground_rates.lo \
         rate_functions.lo \
         initialize_rates.lo \

--- a/src/clib/status_reporting.c
+++ b/src/clib/status_reporting.c
@@ -1,0 +1,79 @@
+/// @file status_reporting.c
+/// @brief Implements status reporting functionality
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "status_reporting.h"
+#include "grackle.h" // GR_FAIL
+
+// this is the internal routine that everything else dispatches to
+static void vprint_err_(
+  int internal_error, const struct grimpl_source_location_ locinfo,
+  const char* msg, va_list vlist
+) {
+  const char* santized_func_name = (locinfo.fn_name == NULL)
+    ? "{unspecified}" : locinfo.fn_name;
+
+  const char* fallback_msg_ = "{NULL encountered instead of error message}";
+  char* dynamic_msg_buf = NULL;
+  const char* msg_buf;
+  if (msg == NULL) {
+    msg_buf = fallback_msg_;
+  } else {
+    // make a copy of the variadic function arguments
+    va_list vlist_copy;
+    va_copy(vlist_copy, vlist);
+
+    // get the total size of the formatted message
+    size_t msg_len = vsnprintf(NULL, 0, msg, vlist_copy) + 1;
+    va_end(vlist_copy);
+
+    // allocate the buffer to hold the message
+    dynamic_msg_buf = malloc(sizeof(char) * msg_len);
+
+    // actually format the message
+    vsnprintf(dynamic_msg_buf, msg_len, msg, vlist);
+    va_end(vlist);
+
+    msg_buf = dynamic_msg_buf;
+  }
+
+  const char* descr = (internal_error == 1) ? "FATAL" : "ERROR";
+
+  fprintf(
+    stderr, "Grackle-%s %s:%d in %s] %s\n", descr, locinfo.file,
+    locinfo.lineno, santized_func_name, msg_buf
+  );
+  fflush(stderr);  // probably unnecessary for stderr
+
+  if (dynamic_msg_buf != NULL) { free(dynamic_msg_buf); }
+}
+
+void grimpl_abort_with_internal_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(1, locinfo, msg, args);
+  abort();
+}
+
+int grimpl_print_and_return_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(0, locinfo, msg, args);
+  return GR_FAIL;
+}
+
+void grimpl_print_err_msg_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(0, locinfo, msg, args);
+}
+

--- a/src/clib/status_reporting.h
+++ b/src/clib/status_reporting.h
@@ -1,0 +1,324 @@
+// See LICENSE file for license and copyright information
+
+/// @file status_reporting.h
+/// @brief Declares the tools used for result-reporting
+///
+/// Purpose
+/// =======
+/// Define machinery to let us standardize our internal logic for
+/// status-reporting. This will:
+/// - reduce boilerplate code
+/// - allow us to provide more context (e.g. filename/lineno/function name)
+/// - allow us to more easily change how we communicate this information with
+///   the downstream application in the future (if we decide that is something
+///   we ultimately want to do -- we motivate this in the next section)
+///
+/// Current Status
+/// ==============
+/// In general, status-reporting is an area where Grackle could really improve.
+/// At the time of writing, our error/status reporting leaves a lot to be
+/// desired. Essentially, it consists of:
+/// - returning a binary code GR_SUCCESS or GR_FAIL
+/// - printing some extra output information:
+///   - we use fprintf(stderr, ...) in the C routines when errors arise
+///   - we print some context information in the Fortran
+///
+/// Ideally, we would adopt a solution that provides the downstream application
+/// (i.e. the simulation-code or PyGrackle) control over whether/how this info
+/// is consumed/recorded.
+///
+/// Motivating Perspective
+/// ======================
+/// Must of us are developers of simulation-codes, but status reporting in the
+/// context of a library is different. In particular, considerations for a
+/// numerical library are very different from other libraries.
+///
+/// For this discussion, we ignore warnings.
+///
+/// The statuses that we communicate primarily fall under 2: (i) unrecoverable
+/// internal errors and (ii) function results.
+///
+/// It is also important to realize that there are certain errors we just can't
+/// check without crippling Grackle's performance. Documentation needs to be
+/// exceptionally clear in these cases.
+///
+/// I. Unrecoverable Internal Errors
+/// --------------------------------
+/// The idea is that if Grackle detects that it is a state where it seems like
+/// it may produce bad/unreliable results/behavior, we print an error message
+/// and immediately abort the program.
+///
+/// Generally, this is the result of a sanity check or a broken invariant.
+///
+/// As a rule of thumb:
+/// - if the sanity check is a direct result of the application's action, we
+///   should prefer to gracefully communicate this to the application
+/// - always consider, should this error crash an interactive Jupyter session
+///   using PyGrackle?
+/// - loudly failing is ALWAYS better than silently failing. Since these errors
+///   are quick and easy to add, these can be a quick temporary solution to
+///   address a problematic code path (and an indication that we need to more
+///   gracefully handle the error mode in the future)
+///
+/// Function Results
+/// ----------------
+/// There are generally 4 kinds of results/statuses a grackle-like library
+/// might want to report. 2 are currently relevant. 2 more may become relevant
+/// in the future. These result/statuses may include
+/// - the API function successfully completed an operation
+/// - (may become relevant with GPUs) a function can be configured to be
+///   either synchronous or asynchronous just succesfully launched a GPU
+///   kernel. (honestly, we may choose to simply denote success)
+/// - A(may become relevant with GPUs) a temporary  error
+///   occurred that could be overcome by trying again. For example, a GPU had
+///   too much pending work (honestly, we may want to configure Grackle so it
+///   knows to try again).
+/// - A generic error occurred that requires human-intervention
+///
+/// It is useful to highlight categories of these generic errors (the last of
+/// the above kinds). There is some overlap here. Categories may include:
+/// 1. resource errors like out-of-memory. While we can't really deal with OOM
+///    errors on CPUs (due to "memory overcommitment") it may be worth
+///    supporting on GPUs.
+/// 2. invalid parameter values
+///    - depending on the application and parameter this may result from
+///      end-user or application
+///    - there's a lot of value to providing lots of info about these errors
+///      (to make debugging much more pleasant)
+/// 3. file-system errors when reading the datafile. This could happen if the
+///    specified path isn't valid (e.g. it doesn't point to a valid hdf5 file,
+///    there is a permissions issue, etc.). Or it could happen do to a system
+///    error (a network filesystem is down or too many files are open)
+/// 4. An obviously invalid argument is detected (e.g. passing a nullptr). This
+///    is clearly an application error.
+/// 5. A broken precondition indicating that the application has made an error
+///    using the API
+/// 6. Generic calculation error (e.g. exceeding the iteration limit or
+///    detecting a NaN). This could arise because the application provided
+///    nonsensical field values. It could also arise simply because the current
+///    logic doesn't handle a particular case very well. An application might
+///    want to know about this class of errors so that it could log extra
+///    information (e.g. the current simulation cycle and location) so that the
+///    error can be reproduced later.
+///
+/// Hypothetically, it could also be cool to allow more recoverable
+/// error-handling when a calculation error only affects a small subset of
+/// field values (e.g. the code might overwrite those zones with values from
+/// neighboring cells). From a practical perspective, this may not be a good
+/// use of time.
+///
+/// How this can be improved
+/// ========================
+/// An issue will be created that describes various strategies for improved
+/// reporting. A common strategy for dealing with simple errors involves exit
+/// codes...
+
+#ifndef STATUS_REPORTING_H
+#define STATUS_REPORTING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// define attributes to annotate functionsA:
+// 1. ERRFMT_ATTR_(fmt_pos) tells the compiler argument number `fmt_pos`
+//    expects a printf-style format-string. Compilers supporting this will
+//    know to check consistency between arg-types and the string @ compile-time
+// 2. suppress warnings that may arise about not returning in control-flows
+//    where an internal error aborts the program with NORETURN_ATTR_
+// 3. compiler raises warnings when the value returned by a function annotated
+//    with NODISCARD_ATTR_ isn't used. We use this for a function where this is
+//    almost certainly indicative of programming error
+
+#if 0
+  // this branch will be used once we transition to compiling all non-fortran
+  // files with C++17. (We use the official syntax for specifying attributes)
+  // - starting in C++17, implementations know to ignore attributes that they
+  //   don't recognize
+  #define ERRFMT_ATTR_(fmt_pos) [[gnu::format(__printf__, fmt_pos, fmt_pos+1)]]
+  #define NORETURN_ATTR_ [[noreturn]]
+  #define NODISCARD_ATTR_ [[nodiscard]]
+
+#elif defined(__GNUG__)
+  #define ERRFMT_ATTR_(fmt_pos)                                               \
+    __attribute__((format(__printf__, fmt_pos, fmt_pos+1)))
+  #define NORETURN_ATTR_ __attribute__((noreturn))
+  // unlike [[nodiscard]], warnings associated with the following might not be
+  // suppressed by casting the result to (void). (this is ok for this file)
+  #define NODISCARD_ATTR_ __attribute__((warn_unused_result))
+
+#else
+  #define NORETURN_ATTR_ /* ... */
+  #define ERRFMT_ATTR_(fmt_pos) /* ... */
+  #define NODISCARD_ATTR_ /* ... */
+
+#endif
+
+// ---------------------------------------
+
+/// @def      __GRIMPL_PRETTY_FUNC__
+/// @brief    a magic contant like __LINE__ or __FILE__ used to specify the
+///           name of the current function
+///
+/// In more detail:
+/// - The C99 and C++11 standards ensures __func__ is provided on all
+///   platforms, but it only provides limited information (just the name of the
+///   function).
+/// - note that __func__ is technically not a macro. It's a static constant
+///   string implicitly defined by the compiler within each function definition
+/// - Where available, we prefer to use compiler-specific features that provide
+///   more information about the function (like the scope of the function, the
+///   the function signature, any template specialization, etc.).
+#ifdef __GNUG__
+  #define __GRIMPL_PRETTY_FUNC__ __PRETTY_FUNCTION__
+#else
+  #define __GRIMPL_PRETTY_FUNC__ __func__
+#endif
+
+struct grimpl_source_location_{
+  const char* file;
+  int lineno;
+  const char* fn_name;
+};
+
+/// This is a helper function used to help implement __GRIMPL_SRCLOC__
+///
+/// @note
+/// static is required to use inline with C
+static inline struct grimpl_source_location_ get_src_location_(
+  const char* file, int lineno, const char* fn_name
+) {
+  struct grimpl_source_location_ out;
+  out.file = file;
+  out.lineno = lineno;
+  out.fn_name = fn_name;
+  return out;
+}
+
+/// @def __GRIMPL_SRCLOC__
+/// @brief Roughly equivalent to __FILE__, __LINE__, etc. But, it gathers the
+///        info for us in a very concise manner
+#define __GRIMPL_SRCLOC__                                                   \
+  get_src_location_(__FILE__, __LINE__, __GRIMPL_PRETTY_FUNC__)
+
+/// helper function that helps implement GR_INTERNAL_ERROR and
+ERRFMT_ATTR_(2) NORETURN_ATTR_ void grimpl_abort_with_internal_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GR_INTERNAL_ERROR
+/// @brief function-like macro that handles a (lethal) error message
+///
+/// This macro should be treated as a function with the signature:
+///
+///   [[noreturn]] void GR_INTERNAL_ERROR(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+///
+/// @note
+/// the ``fmt`` string is part of the variadic args so that there is always
+/// at least 1 variadic argument (even in cases when ``msg`` doesn't format
+/// any arguments). There is no portable way around this until C++ 20.
+#define GR_INTERNAL_ERROR(...)                                            \
+  { grimpl_abort_with_internal_err_(__GRIMPL_SRCLOC__, __VA_ARGS__); }
+
+/// @def GR_INTERNAL_REQUIRE
+/// @brief implements functionality analogous to the assert() macro
+///
+/// if the condition is false, print an error-message (with printf
+/// formatting) & abort the program.
+///
+/// This macro should be treated as a function with the signature:
+///
+///   void GR_INTERNAL_REQUIRE(bool cond, const char* fmt, ...);
+///
+/// - The 1st arg is a boolean condition. When true, this does nothing
+/// - The 2nd arg is printf-style format argument specifying the error message
+/// - The remaining args arguments are used to format error message
+///
+/// @note
+/// The behavior is independent of the ``NDEBUG`` macro
+#define GR_INTERNAL_REQUIRE(cond, ...)                                     \
+  {  if (!(cond))                                                              \
+      { grimpl_abort_with_internal_err_(__GRIMPL_SRCLOC__, __VA_ARGS__); } }
+
+// helper function
+ERRFMT_ATTR_(2) NODISCARD_ATTR_ int grimpl_print_and_return_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GrPrintAndReturnErr
+/// @brief prints the error message & returns the appropriate status-value
+///
+/// This macro should be treated as a function with the signature:
+///
+///   [[nodiscard]] int GrPrintAndReturnErr(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+///
+/// This is intended to be used in scenarios like
+/// ```{.cpp}
+///   return GrPrintAndReturnErr("My err. %g is a bad val", val);
+/// ```
+/// or
+/// ```{.cpp}
+///   int ec = GrPrintAndReturnErr("My err. %g is a bad val", val);
+///   // do some cleanup...
+///   return ec;
+/// ```
+///
+/// The compiler will issue a warning if you don't do anything with the exit
+/// code. If you don't care about the exit-code, you should use the
+/// `GrPrintErrMsg` function-like macro instead
+///
+/// @note
+/// the ``fmt`` string is part of the variadic args so that there is always
+/// at least 1 variadic argument (even in cases when ``fmt`` doesn't format
+/// any arguments). There is no portable way around this until C++20.
+///
+/// @note
+/// This macro has been designed so that we have a uniform/easily grep-able
+/// interface that we can easily replace in the future if/when we improve error
+/// reporting
+#define GrPrintAndReturnErr(...)                                             \
+  grimpl_print_and_return_err_(__GRIMPL_SRCLOC__, __VA_ARGS__);
+
+
+// helper function
+ERRFMT_ATTR_(2) void grimpl_print_err_msg_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GrPrintErrMsg
+/// @brief prints the appropriate error message.
+///
+/// > [!important]
+/// > In any situation where you ultimately return an error code, you should
+/// > prefer to use GrPrintAndReturnErr. This macro is for the subset of cases
+/// > where you need to do something different.
+///
+/// This macro should be treated as a function with the signature:
+///
+///   void GrPrintErrMsg(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+#define GrPrintErrMsg(...)                              \
+  grimpl_print_err_msg_(__GRIMPL_SRCLOC__, __VA_ARGS__);
+
+
+// undefine the attributes so we avoid leaking them
+// ------------------------------------------------
+#undef ERRFMT_ATTR_
+#undef NORETURN_ATTR_
+#undef NODISCARD_ATTR_
+
+// I don't think we can undef __GRIMPL_PRETTY_FUNC__ without causing issues
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* STATUS_REPORTING */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(testdeps INTERFACE Grackle::Grackle GTest::gtest_main)
 # short-term hack to let tests invoke Fortran functions from C
 target_compile_definitions(testdeps INTERFACE "$<$<PLATFORM_ID:Linux,Darwin>:LINUX>")
 target_include_directories(testdeps INTERFACE ${PROJECT_SOURCE_DIR}/src/clib)
+target_compile_features(testdeps INTERFACE cxx_std_17)
 
 # start declaring targets for tests
 # ---------------------------------
@@ -13,3 +14,14 @@ add_executable(runInterpolationTests test_unit_interpolators_g.cpp)
 target_link_libraries(runInterpolationTests testdeps)
 
 gtest_discover_tests(runInterpolationTests)
+
+
+add_executable(runStatusReporting test_status_reporting.cpp)
+target_link_libraries(runStatusReporting testdeps)
+# short-term hack. We should use the machinery introduced in PR #237 related to
+# Operating-system specific functionality when that PR is merged
+target_compile_definitions(runStatusReporting PRIVATE
+  "$<$<PLATFORM_ID:Linux,Darwin>:PLATFORM_GENERIC_UNIX>"
+)
+
+gtest_discover_tests(runStatusReporting)

--- a/tests/unit/test_status_reporting.cpp
+++ b/tests/unit/test_status_reporting.cpp
@@ -1,0 +1,251 @@
+#include <gtest/gtest.h>
+
+// the following 2 headers are the c versions of the headers (rather than the
+// C++ versions) since it seems more likely that posix-specific functions are
+// provided in this version
+#include <stdio.h> // fflush, tmpfile, fread, fileno
+#include <stdlib.h> // mkstemp, getenv
+
+#include <memory>
+#include <string>
+
+#include "grackle.h" // GR_FAIL
+#include "status_reporting.h"
+
+/// Machinery to capture a stream (namely stderr)
+///
+/// This is similar in concept to pytest's capfd entity (I haven't looked under
+/// the hood of that type, but I imagine they work in a similar manner)
+class CaptureSink {
+  FILE* redirected_stream_ = nullptr;
+  int redirected_fd_ = -1;
+  int backup_fd_ = -1;
+
+  CaptureSink() = default;
+  CaptureSink(const CaptureSink&) = delete;
+  CaptureSink& operator=(const CaptureSink&) = delete;
+  CaptureSink(CaptureSink&&) = delete;
+  CaptureSink& operator=(CaptureSink&&) = delete;
+
+public:
+
+  ~CaptureSink() { end_capture(false); }
+  /// create an instance that wraps stream
+  static std::unique_ptr<CaptureSink> create(FILE* stream);
+  /// end the capture and return the object
+  std::string end_capture(bool ret_captured = true);
+};
+
+#ifndef PLATFORM_GENERIC_UNIX
+
+// provide dummy implementations that will never work
+std::unique_ptr<CaptureSink> CaptureSink::create(FILE*) { return nullptr; }
+std::string CaptureSink::end_capture(bool) { return {}; }
+
+#else
+#include <unistd.h> // dup, dup2, lseek, SEEK_SET, SEEK_CUR, close
+
+// the logic we are invoking here is VERY standard. Lots and lots of examples
+// of it exist online
+
+/// closes the current file descriptor associated with fd and then opens a new
+/// file descriptor (reusing the same integer) that points to a temporary file.
+/// The temporary file will be deleted once all file descriptors to it are
+/// closed.
+///
+/// @returns
+/// true and false indicates success and failure
+static bool redirect_fd_to_tempfile_(int fd) {
+  // create a temporary file and get a descriptor to it
+  char* prefix = getenv("TMPDIR");
+  std::string path = (prefix != nullptr) ? prefix : "/tmp";
+  path += "/grackle-test-XXXXXX";
+  int temporary_fd = mkstemp(path.data());
+  if (temporary_fd == -1) { return false; }
+
+  // remove the temporary file's name from the filesystem (so it is deleted
+  // once there are no more file descriptors refer to it)
+  unlink(path.data()); // <-- nothing we can reasonably do if this fails
+
+  // in a single atomic transaction, the next line:
+  // 1. closes the file descriptor tracked by fd (i.e. the integer value will
+  //    no longer is associated with any file and can be used to create a new
+  //    file descriptor)
+  // 2. allocates a brand new file descriptor, which both reuses the file
+  //    descriptor number from fd AND refers to the file currently
+  //    referenced by temporary_fd
+  if (dup2(temporary_fd, fd) == -1) {
+    close(temporary_fd);
+    return false;
+  }
+
+  // finally, close the temporary_fd
+  close(temporary_fd); // <-- nothing we can reasonably do if this fails
+
+  return true;
+}
+
+// if we want to avoid heap-allocations, we could use std::optional
+std::unique_ptr<CaptureSink> CaptureSink::create(FILE* stream) {
+  if (stream == nullptr) { return nullptr; }
+
+  // 1. flush the stream (this is critical for the general case)!
+  if ( fflush(stream) != 0 ) { return nullptr; }
+
+  // 2. get the file descriptor that we want to redirect
+  int underlying_fd = fileno(stream);
+  if (underlying_fd == -1) { return nullptr; }
+
+  // 3. create a new file descriptor that references the same file as
+  //    `underlying_fd` (a "backup" we use later for restoring properties)
+  int backup_fd = dup(underlying_fd);
+  if (backup_fd == -1) { return nullptr; }
+
+  // 4. closes the current file descriptor associated with underlying_fd and
+  //    then opens a new file descriptor (reusing the same integer) that points
+  //    to a temporary file. Upon success, any writes to stream will write to
+  //    the temporary file -- rather than the original destination
+  if (!redirect_fd_to_tempfile_(underlying_fd)) {
+    close(backup_fd);
+    return nullptr;
+  }
+
+  // 5. prepare the container
+  std::unique_ptr<CaptureSink> out{new CaptureSink};
+  out->redirected_stream_ = stream;
+  out->redirected_fd_ = underlying_fd;
+  out->backup_fd_ = backup_fd;
+  return out;
+}
+
+// since the class is primary intended to capture stderr, we eagerly abort if
+// things go wrong (why even go on if testing is crippled?)
+std::string CaptureSink::end_capture(bool ret_captured) {
+  std::string out;
+  if (this->redirected_fd_ < 0) { return out; }
+
+  // flushing is critical for the general case!
+  if (fflush(this->redirected_stream_) != 0) { abort(); };
+
+  // determine the number of captured bytes we wish to read
+  off_t nbytes = 0;
+  if (ret_captured) {
+    nbytes = lseek(this->redirected_fd_, 0, SEEK_END);
+    if (nbytes == -1) { abort(); }
+    // restore position in file to the very start
+    if (lseek(this->redirected_fd_, 0, SEEK_SET) == -1) { abort(); } 
+  }
+
+  // actually read in bytes
+  if (nbytes > 0) {
+    out = std::string(nbytes, ' '); // <- allocate the necessary space
+    char* buf = out.data();
+    if (read(this->redirected_fd_, buf, nbytes) != nbytes) { abort(); }
+  }
+
+  // in a single atomic transaction, the next line:
+  // 1. closes the file descriptor tracked by redirected_fd_ (i.e. the integer
+  //    value no longer is associated with any file and can be when creating
+  //    a new file descriptor)
+  // 2. allocates a brand new file descriptor, which both reuses the file
+  //    descriptor number from redirected_fd_ AND refers to the file currently
+  //    referenced by backup_fd_
+  // At the time of writing, redirected_fd_ was the last descriptor refering to
+  // a temporary file, whose name was already deleted from the file system.
+  // Thus, the temporary file no longer exists after this operation.
+  if (dup2(this->backup_fd_, this->redirected_fd_) == -1) { abort(); }
+
+  // we no longer need to keep backup_fd_
+  close(this->backup_fd_);
+
+  // overwrite variables so we know not to execute this logic again
+  redirected_stream_ = NULL;
+  this->redirected_fd_ = -1;
+  this->backup_fd_ = -1;
+
+  return out;
+}
+
+/// capturer
+#endif
+
+
+testing::AssertionResult ContainsFormattedMessage_(int n) {
+  if ((n % 2) == 0)
+    return testing::AssertionSuccess();
+  else
+    return testing::AssertionFailure() << n << " is odd";
+}
+
+
+TEST(StatusReportingTest, PrintErrMsg) {
+
+  // setup capture of stderr
+  std::unique_ptr<CaptureSink> capstderr = CaptureSink::create(stderr);
+  if (capstderr.get() == nullptr) {
+    GTEST_SKIP() << "Stream redirection doesn't seem to be working. It may "
+                 << "not be implemented for the current platform";
+  }
+
+  GrPrintErrMsg("message with string: `%s` & int: %d", "str", 4);
+  const char* expected_msg = "message with string: `str` & int: 4";
+
+  // end the capture
+  std::string msg = capstderr->end_capture();
+
+  // now do some checking (it would be cleaner to use gmock's matchers)
+  ASSERT_GT(msg.size(), 0) << "nothing seems to have printed";
+  EXPECT_EQ(msg[msg.size()-1], '\n') << "we expect a trailing newline";
+  ASSERT_NE(msg.find(expected_msg), std::string::npos)
+    << "The error message doesn't contain the substring \"" << expected_msg
+    << "\". The contents of the message is: \"" << msg << '"';
+}
+
+
+TEST(StatusReportingTest, PrintAndReturnErr) {
+
+  // setup capture of stderr
+  std::unique_ptr<CaptureSink> capstderr = CaptureSink::create(stderr);
+  if (capstderr.get() == nullptr) {
+    GTEST_SKIP() << "Stream redirection doesn't seem to be working. It may "
+                 << "not be implemented for the current platform";
+  }
+
+  int ec = GrPrintAndReturnErr("message with string: `%s` & int: %d", "str", 4);
+  const char* expected_msg = "message with string: `str` & int: 4";
+
+  // end the capture
+  std::string msg = capstderr->end_capture();
+
+  EXPECT_EQ(ec, GR_FAIL) << "GrPrintAndReturnErr's exit code, " << ec
+                         << ", doesn't match GR_FAIL (" << GR_FAIL << ')';
+
+  // now do some checking (it would be cleaner to use gmock's matchers)
+  ASSERT_GT(msg.size(), 0) << "nothing seems to have printed";
+  EXPECT_EQ(msg[msg.size()-1], '\n') << "we expect a trailing newline";
+  ASSERT_NE(msg.find(expected_msg), std::string::npos)
+    << "The error message doesn't contain the substring \"" << expected_msg
+    << "\". The contents of the message is: \"" << msg << '"';
+}
+
+TEST(StatusReportingDeathTest, InternalError) {
+  // right now, we are mostly just confirm that the program aborts
+  // -> we are checking that the specified error is included
+  // -> in the future, we have the option to test the formatting of the message
+  EXPECT_DEATH({
+    GR_INTERNAL_ERROR("This is a dummy error message %s", "dummy-str");
+  }, ".*This is a dummy error message dummy-str.*");
+}
+
+TEST(StatusReportingDeathTest, InternalRequireFalse) {
+  // right now, we are mostly just confirm that the program aborts
+  // -> we are checking that the specified error is included
+  // -> in the future, we have the option to test the formatting of the message
+  EXPECT_DEATH({
+    GR_INTERNAL_REQUIRE(1 == 0, "This is a dummy error message %d", 10);
+  }, ".*This is a dummy error message 10.*");
+}
+
+TEST(StatusReportingDeathTest, InternalRequireTrue) {
+  GR_INTERNAL_REQUIRE(1 == 1, "This program shouldn't abort");
+}


### PR DESCRIPTION
This PR introduced some testing machinery to help report errors (and to report errors more consistently). Status reporting is a general topic we need to give more thought to (it has a some implications for GPU porting). I plan to open an Issue that highlights important considerations.

In any case, adopting more standard abstractions for reporting for status reporting should make it easier to make sweeping changes to our error handling strategy.