### PR TITLE
Introducing a Bidirectional Map Internal Datatype

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(Grackle_Grackle
   calculate_pressure.c
   calculate_temperature.c
   dynamic_api.c
+  FrozenKeyIdxBiMap.c FrozenKeyIdxBiMap.h FrozenKeyIdxBiMap_details.h
   grackle_units.c
   index_helper.c
   initialize_chemistry_data.c

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(Grackle_Grackle
   rate_functions.c
   set_default_chemistry_parameters.c
   solve_chemistry.c
+  status_reporting.c status_reporting.h
   update_UVbackground_rates.c
   utils.c
 

--- a/src/clib/FrozenKeyIdxBiMap.c
+++ b/src/clib/FrozenKeyIdxBiMap.c
@@ -1,0 +1,217 @@
+// See LICENSE file for license and copyright information
+
+/// @file FrozenKeyIdxBiMap.c
+/// @brief Implements parts of FrozenKeyIdxBiMap type
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "FrozenKeyIdxBiMap.h"
+#include "status_reporting.h"
+#include "grackle.h" // GR_SUCCESS
+
+/// @def    INVERSE_LOAD_FACTOR
+/// @brief  the load factor specifies the fraction of the capcity of the Hash
+///         table that is filled. This should be an integer.
+///
+/// This should not be 1. Generally, the larger this is, the fewer collisions
+/// there are, but the more memory is required. If this is too large, it may
+/// actually slow down lookups. 
+#define INVERSE_LOAD_FACTOR 2
+
+// this is the list of allowed capacities. These are all prime numbers that
+// have nearly constant linear spacing (it may make more sense to have
+// logarithmic spacing)
+static const uint32_t allowed_capacities_l_[] = {
+  7,  19,  31,  41, 53, 61,  71,  83, 89, 101, 113, 127, 139, 149, 163, 173,
+  181, 191, 199, 211, 223, 233, 241, 251
+};
+
+static const int allowed_capacities_len_ = (
+  sizeof(allowed_capacities_l_) / sizeof(uint32_t)
+);
+
+/// compute the maximum number of keys
+static inline BiMap_rowidx_type get_max_key_count_(void) {
+  uint16_t max_from_allowed_capacity = (
+    allowed_capacities_l_[allowed_capacities_len_ - 1] / INVERSE_LOAD_FACTOR
+  );
+
+  // while the following may seem silly, it is important to keep it here
+  if (BIMAP_ROWIDX_TYPE_MAX < max_from_allowed_capacity) {
+    return BIMAP_ROWIDX_TYPE_MAX;
+  } else {
+    return max_from_allowed_capacity;
+  }
+}
+
+/// compute the capacity of the map
+///
+/// @param num_keys the desired number of keys (should be positive)
+///
+/// @returns the capacity. A value of 0 means that there is not enough space
+static inline uint16_t calc_map_capacity_(int key_count) {
+  uint64_t target_capacity = INVERSE_LOAD_FACTOR * (uint64_t)key_count;
+  // binary search may be faster
+  for (int i = 0; i < allowed_capacities_len_; i++) {
+    if (target_capacity < allowed_capacities_l_[i]) {
+      return (uint16_t)allowed_capacities_l_[i];
+    }
+  }
+  return (uint16_t)0;
+}
+
+static int allocate_FrozenKeyIdxBiMap_(FrozenKeyIdxBiMap** out,
+                                       uint16_t length,
+                                       uint16_t capacity) {
+  // when we shift to C++, it would be nice to perform one call to malloc (so
+  // that the memory is all contiguous) and then use placement new
+  *out = (FrozenKeyIdxBiMap*)malloc(sizeof(FrozenKeyIdxBiMap));
+  (*out)->length = length;
+  (*out)->capacity = capacity;
+  // we use calloc so keylen is always 0
+  (*out)->table_rows = (struct StrU16Row_*)calloc(
+    capacity, sizeof(struct StrU16Row_)
+  );
+  (*out)->ordered_row_indices = (uint16_t*)malloc(sizeof(uint16_t) * length);
+  // most platforms don't let us gracefully handle failure when it comes to
+  // allocations, so we don't bother...
+  return GR_SUCCESS;
+}
+
+static void StrU16Row_overwrite_(
+  struct StrU16Row_* row, const char* key, size_t keylen, uint16_t value,
+  enum BiMapMode mode
+) {
+  GR_INTERNAL_REQUIRE(row->keylen == 0, "Sanity check failed!");
+  row->value = value;
+  row->keylen = keylen;
+  if (mode == BIMAP_COPIES_KEYDATA) {
+    size_t total_len = keylen + 1; // <- add 1 to account for null-terminator
+    char* ptr = (char*)malloc(sizeof(char) * total_len);
+    memcpy(ptr, key, total_len);
+    row->key = ptr;
+  } else {
+    row->key = key;
+  }
+}
+
+// do some checks on keys and get keylen
+int check_key_get_len_(const char* keys[], int i, size_t* keylen) {
+  GR_INTERNAL_REQUIRE(keys[i] != NULL, "Can't specify a nullptr key");
+  *keylen = strlen(keys[i]); // <- excludes the null terminator from len
+  if ((*keylen == 0) || (*keylen > STRU16MAP_KEYLEN_MAX)) {
+    return GrPrintAndReturnErr(
+      "calling strlen on \"%s\", the key @ index %d, yields 0 or a length "
+      "exceeding %d",
+      keys[i], i, STRU16MAP_KEYLEN_MAX
+    );
+  }
+  return GR_SUCCESS;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int new_FrozenKeyIdxBiMap(
+  FrozenKeyIdxBiMap** out, const char* keys[], int key_count,
+  enum BiMapMode mode
+) {
+  if ((mode != BIMAP_REFS_KEYDATA) && (mode != BIMAP_COPIES_KEYDATA)) {
+    return GrPrintAndReturnErr(
+      "mode must be BIMAP_REFS_KEYDATA or BIMAP_COPIES_KEYDATA"
+    );
+  } else if ( (key_count < 1) || (key_count > get_max_key_count_()) ) {
+    return GrPrintAndReturnErr(
+      "key_count must be positive and cannot exceed %lld",
+      (long long)get_max_key_count_()
+    );
+  }
+
+  uint16_t capacity = calc_map_capacity_(key_count);
+  // the following shouldn't be possible based on the prior check
+  GR_INTERNAL_REQUIRE(capacity > 0, "something went wrong");
+
+  int ec = allocate_FrozenKeyIdxBiMap_(out, key_count, capacity);
+  if ((*out) == NULL) { return GrPrintAndReturnErr("something went wrong"); }
+
+  (*out)->mode = mode;
+  
+  int max_probe_count = 1;
+
+  for (int i = 0; i < key_count; i++) {
+    size_t keylen;
+    int tmp = check_key_get_len_(keys, i, &keylen);
+    if (tmp != GR_SUCCESS) {
+      drop_FrozenKeyIdxBiMap(*out);
+      *out = NULL;
+      return tmp;
+    }
+
+    // insert the row
+    struct StrU16Search_ search_rslt = StrU16Map_find_match_or_empty_(
+      (*out)->table_rows, keys[i], capacity, capacity
+    );
+    StrU16Row_overwrite_((*out)->table_rows + search_rslt.rowidx, keys[i],
+                         keylen, i, mode);
+    (*out)->ordered_row_indices[i] = search_rslt.rowidx;
+
+    if (max_probe_count < search_rslt.probe_count) {
+      max_probe_count = search_rslt.probe_count;
+    }
+  }
+  (*out)->max_probe = max_probe_count;
+
+  return GR_SUCCESS;
+}
+
+int FrozenKeyIdxBiMap_clone(FrozenKeyIdxBiMap** out,
+                            const FrozenKeyIdxBiMap* ptr) {
+  int ec = allocate_FrozenKeyIdxBiMap_(out, ptr->length, ptr->capacity);
+  if (ec != GR_SUCCESS) { return ec; }
+
+  (*out)->length = ptr->length; // (technically this is also redundant)
+  (*out)->capacity = ptr->capacity; // (technically this is also redundant)
+  (*out)->max_probe = ptr->max_probe;
+  (*out)->mode = ptr->mode;
+  
+  if (!ptr->mode) {
+    memcpy((*out)->table_rows, ptr->table_rows,
+           sizeof(struct StrU16Row_)*ptr->capacity);
+  } else {
+    const int capacity = ptr->capacity; // this may help compiler
+    for (int i = 0; i < capacity; i++) {
+      struct StrU16Row_ ref_row = ptr->table_rows[i];
+      if (ref_row.keylen > 0) {
+        StrU16Row_overwrite_((*out)->table_rows + i, ref_row.key,
+                             ref_row.keylen, ref_row.value, 1);
+      } else {
+        (*out)->table_rows[i] = ref_row; // technically unnecessary
+      }
+    }
+  }
+
+  memcpy((*out)->ordered_row_indices, ptr->ordered_row_indices,
+         sizeof(BiMap_rowidx_type) * ptr->capacity);
+  return GR_SUCCESS;
+}
+
+void drop_FrozenKeyIdxBiMap(FrozenKeyIdxBiMap* ptr) {
+  if (ptr->mode) {
+    BiMap_rowidx_type capacity = ptr->capacity;
+    for (BiMap_rowidx_type i = 0; i < capacity; i++) {
+      struct StrU16Row_* row = ptr->table_rows+i;
+      // casting from (const char*) to (char*) should be legal (as long as
+      // there were no bugs modifying the value of ptr->mode)
+      if (row->keylen > 0) { free((char*)row->key); }
+    }
+  }
+  free(ptr->table_rows);
+  free(ptr->ordered_row_indices);
+  free(ptr);
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/src/clib/FrozenKeyIdxBiMap.h
+++ b/src/clib/FrozenKeyIdxBiMap.h
@@ -1,0 +1,212 @@
+// See LICENSE file for license and copyright information
+
+/// @file FrozenKeyIdxBiMap.h
+/// @brief Declares the internal FrozenKeyIdxBiMap type
+///
+///
+/// All insertions occur during initialization. This simplifies a lot of
+/// bookkeeping.
+///
+/// If necessary, a number of optimizations could be made to the implementation
+/// that might make key lookups faster. These optimizations could take
+/// advantage of the following factors:
+///    - Assumptions about the max key size and the max capacity of the map.
+///      For example, if the max key size never exceeds ~22 characters and
+///      there are never more than ~128 entries, it would probably be optimal
+///      to store the strings in-place (improving cache locallity).
+///    - Alternatively, making assumptions 
+
+#ifndef FROZEN_KEY_IDX_BIMAP_HPP
+#define FROZEN_KEY_IDX_BIMAP_HPP
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "FrozenKeyIdxBiMap_details.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// the type used for indexing the rows of the BiMap's internal hash table
+///
+/// @note
+/// This does not necessarily need to be a uint16_t (even if the internal
+/// values of the hash table are uint16_t).
+typedef uint16_t BiMap_rowidx_type;
+
+/// @def BIMAP_ROWIDX_TYPE_MAX
+/// @brief the maximum value representable by BiMap_rowidx_type
+#define BIMAP_ROWIDX_TYPE_MAX UINT16_MAX
+
+
+enum BiMapMode {
+  BIMAP_REFS_KEYDATA = 0,
+  BIMAP_COPIES_KEYDATA = 1
+};
+
+/// @brief This is a bidirectional map (bimap). It is specialized to map `n`
+///     unique string keys to unique indexes with values of `0` thru `n-1` and 
+///     vice-versa. The ordering of keys is set at initialization and frozen.
+///
+/// This is primarily intended to be used in the implementation of Maps of 
+/// arrays (where the values could be part of a single contiguous array or are
+/// individual arrays), but this but may be broadly useful for other
+/// applications.
+///
+/// This operates in 2 modes:
+/// 1. BIMAP_REFS_KEYDATA: This is the default, where we operate under the
+///    assumption that the allocations holding the string characters outlive
+///    the bimap. In this mode the bimap  is intended to hold string-literals
+///    (which are live for the entirety of a program). This minimizes memory
+///    usage.
+/// 2. BIMAP_COPIES_KEYDATA: Under this mode, the bimap copies the data of all
+///    of the keys. This is useful for testing purposes. In the long-term, if
+///    we allow dynamic extension of chemistry networks, it will also be
+///    useful. If we are implement the optimizations described down below
+///    (where we directly embed the string in the hash-table-rows), this will
+///    probably be a quite a bit faster
+///
+/// This is based on the logic I wrote for Enzo-E.
+///   https://github.com/enzo-project/enzo-e/blob/main/src/Cello/view_StringIndRdOnlyMap.hpp
+/// (More details are provided below under C++ considerations)
+///
+/// Why Frozen?
+/// ===========
+/// The contents are "frozen" for a 3 primary reasons:
+/// - It drastically simplifies the implementation (we don't have to worry
+///   about deletion -- which can be quite messy)
+/// - Linear-probing generally provides better data locallity than other hash
+///   collision resolution techniques, but generally has other drawbacks.
+///   Freezing the contents let's us mitigate many drawbacks (mostly related to
+///   the deletion operation)
+/// - It could let us make copy operations cheaper. If we know the map won't
+///   change, we could just use reference counting.
+///
+/// Improvements: Reference Counting
+/// ================================
+/// The original C++ leverages std::shared_ptr to achieve reference counting
+/// (and reduce the cost of copying). Theoretically, I would like to see us use
+/// some kind of reference-counting too. But this is tricky in library code,
+/// given the diversity of threading libraries that are not formally
+/// interoperable. I think the only way to properly do this would be to come up
+/// with a system for allowing registration of locks/atomics with Grackle as a
+/// whole.
+/// 
+/// C++ Considerations
+/// ==================
+/// As we starting using a C++ compiler, I would like us to eventually embrace
+/// the class structure present in the original Enzo-E version (it would
+/// greatly reduce the chance of memory leaks). But, for reasons expressed
+/// above, I am concerned about using std::shared_ptr for reference counting.
+///
+/// I would be stunned if std::map<std::string, uint16_t> or
+/// std::map<const char*, uint16_t> is faster than the internal hash table
+/// since std::map is usually implemented as a tree.
+///
+/// Potential Improvements
+/// ======================
+/// There is definitely room for optimizing this implementation:
+/// - We could be smarter about the order that we insert keys into the table
+///   (in the constructor) to minimize the search time.
+/// - We might be able to come up with a better hash function
+/// - We can achieve even better locality, in BIMAP_COPIES_KEYDATA mode, thanks
+///   to our use of STRU16MAP_KEYLEN_MAX (which is currently 29). Once we
+///   shift everything to C++17 (it is possible now, but requires care), we
+///   could define:
+///   ```{.cpp}
+///   struct alignas(32) packedrow_ { char data[32]; };
+///   bool is_empty(packed_row_ r) { return data[0] == '\0' }
+///   const char* get_key(packed_row_ r) { return r.data; }
+///   uint16_t get_val(packed_row_ r)
+///   { uint16_t o; memcpy(&o, r.data+30, 2); return o; }
+///   ```
+///   This is useful since it improves locality of the string. `alignas(32)` is
+///   present to help ensure better cacheline alignment and with a little extra
+///   care, it lets us use SIMD operations for faster probing
+///
+/// > [!note]
+/// > The contents of this struct should be considered an implementation
+/// > detail! Always prefer the associated functions (they are defined in such
+/// > a way that they should be inlined
+struct FrozenKeyIdxBiMap{
+  // don't forget to update FrozenKeyIdxBiMap_clone when changing members
+
+  /// the number of contained strings
+  BiMap_rowidx_type length;
+  /// the number of elements in table_rows
+  BiMap_rowidx_type capacity;
+  /// max number of rows that must be probed to determine if a key is contained
+  BiMap_rowidx_type max_probe;
+  /// indicates whether the map "owns" the memory holding the characters in
+  /// each key or just references it
+  enum BiMapMode mode;
+
+  /// actual hash table data
+  struct StrU16Row_* table_rows;
+  /// tracks the row indices to make iteration faster
+  BiMap_rowidx_type* ordered_row_indices;
+};
+
+typedef struct FrozenKeyIdxBiMap FrozenKeyIdxBiMap;
+
+/// Constructs a new FrozenKeyIdxBiMap
+///
+/// @param[out] out Pointer where the allocated type is stored
+/// @param[in]  keys Sequence of 1 or more unique strings. Each string must
+///     include at least 1 non-null character and be null-terminated
+/// @param[in]  key_count The length of keys
+/// @param[in]  mode specifies handling of keys. This will be passed on to any
+///     clones that are made.
+int new_FrozenKeyIdxBiMap(
+  FrozenKeyIdxBiMap** out, const char* keys[], int key_count,
+  enum BiMapMode mode
+);
+
+/// Destroys the specified FrozenKeyIdxBiMap
+void drop_FrozenKeyIdxBiMap(FrozenKeyIdxBiMap*);
+
+/// Makes a clone of the specified FrozenKeyIdxBiMap (the clone inherites the
+/// original BiMapMode).
+int FrozenKeyIdxBiMap_clone(FrozenKeyIdxBiMap** out,
+                            const FrozenKeyIdxBiMap* ptr);
+
+/// returns the value associated with the key (or STRU16MAP_INVALID_VAL)
+///
+/// @note
+/// denoting this as static is the only effective way to define inline in C
+static inline uint16_t FrozenKeyIdxBiMap_idx_from_key(
+  const FrozenKeyIdxBiMap* map, const char* key
+)
+{
+  return StrU16Map_find_match_or_empty_(
+    map->table_rows, key, map->capacity, map->max_probe
+  ).val;
+}
+
+/// checks if the map contains a key
+static inline int FrozenKeyIdxBiMap_contains(const FrozenKeyIdxBiMap* map,
+                                             const char* key) {
+  return FrozenKeyIdxBiMap_idx_from_key(map, key) != STRU16MAP_INVALID_VAL;
+}
+
+static inline int FrozenKeyIdxBiMap_size(const FrozenKeyIdxBiMap* map)
+{ return map->length; }
+
+/// Return the ith key (this is effectively a reverse lookup)
+static inline const char* FrozenKeyIdxBiMap_key_from_idx(
+  const FrozenKeyIdxBiMap* map, uint16_t i
+) {
+  if (i >= map->length) { return NULL; }
+  const char* out = map->table_rows[map->ordered_row_indices[i]].key;
+  GR_INTERNAL_REQUIRE(out != NULL, "The string can't be NULL - logical error");
+  return out;
+}
+
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* FROZEN_KEY_IDX_BIMAP_HPP */

--- a/src/clib/FrozenKeyIdxBiMap_details.h
+++ b/src/clib/FrozenKeyIdxBiMap_details.h
@@ -1,0 +1,150 @@
+// See LICENSE file for license and copyright information
+
+/// @file FrozenKeyIdxBiMap_details.h
+/// @brief Defines the hashtable machinery used to help implement the internals
+///        of the FrozenKeyIdxBiMap type
+///
+/// In more detail, the type internally uses a hash table to associate strings
+/// with a u16 (a 16-bit unsigned integer or uint16_t).
+
+#ifndef FROZEN_KEY_IDX_BIMAP_DETAILS_H
+#define FROZEN_KEY_IDX_BIMAP_DETAILS_H
+
+#include <stdint.h> // uint16_t, UINT16_MAX
+#include <string.h> // memcmp
+#include "status_reporting.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// this lists an invalid value of the map (we state that you can't store the
+// max u16 value)
+#define STRU16MAP_INVALID_VAL UINT16_MAX
+
+// this is the max number of characters allowed in a key (excluding the null
+// character). While this may seem a little low, it will enable some really
+// cool optimizations
+#define STRU16MAP_KEYLEN_MAX 29
+
+
+// keylen is the length of key (excluding the null character)
+struct hash_rslt_pair_{ uint16_t keylen; uint32_t hash; };
+
+/// calculate hash of key (and measure the length of the key). A key length of
+/// 0 indicates an error
+///
+/// @param key a null-terminated string
+///
+/// We use 32bit FNV-1 hash (this should be checked!). We may want to consider
+/// a faster hash (maybe fxhash) or check hash functions against the known keys
+static inline struct hash_rslt_pair_ hash_from_str_(const char* key) {
+
+  const uint32_t prime = 16777619;
+  const uint32_t offset = 2166136261;
+
+  // initialize to a value denoting an error
+  struct hash_rslt_pair_ out = { 0, 0 };
+
+  // here we need to short-circuit
+  if (key[0] == '\0') { return out; }
+
+  uint32_t hash = offset;
+  for (int i = 0; i <= STRU16MAP_KEYLEN_MAX; i++) { // the `<=` is intentional
+    char cur = key[i];
+    if (cur == '\0') {
+      out.keylen = i; // since i is 0-indexed, we don't subtract by one
+      out.hash = hash;
+      return out;
+    }
+
+    // update hash
+    hash = hash * prime;
+    hash = hash ^ cur;
+  }
+
+  return out; // remember, this was initialized to denote a problem
+}
+
+/// represents the result of an internal searching for a key
+///
+/// @note
+/// As a rule of thumb, it's generally better (for compiler optimization) to
+/// return a struct of integers than rely modifying pointer arguments 
+struct StrU16Search_{
+  /// specifies the value found by the search (or STRU16MAP_INVALID_VAL)
+  uint16_t val;
+  /// specified the number of probes before returning
+  int probe_count;
+  /// specify the index of the "row" corresponding to the search result
+  int rowidx;
+};
+
+/// entry in the hash table.
+///
+/// the members are ordered to minimize the struct size (i.e. smallest members
+/// are listed first) try to pack as many entries into a cacheline as possible
+struct StrU16Row_{
+
+  /// specifies the value associated with the current key 
+  uint16_t value;
+
+  /// specifies the length of the key (not including a null character)
+  ///
+  /// Included to short-circuit comparisons (to try to speed up probing when
+  /// collisions occur)
+  uint16_t keylen;
+
+  /// identifies the address of this entry's key
+  const char* key;  
+};
+
+/// Search for the row matching key. The search ends when a match is found, the
+/// an empty row is found, or the function has probed `max_probe` entries
+///
+/// @param rows an array of rows to search to be compared
+/// @param key the key to be compared
+/// @param capacity the length of the rows array
+/// @param max_probe the maximum number of rows to check before giving up
+///
+/// @important
+/// The behavior is undefined if key is NULL, keylen is 0, keylen exceeds
+/// STRU16MAP_KEYLEN_MAX or strlen(key) != keylen
+///
+/// @note
+/// This is declared as `static inline` to facillitate inlining within
+/// FrozenKeyIdxBiMap's interface API.
+static inline struct StrU16Search_ StrU16Map_find_match_or_empty_(
+  const struct StrU16Row_* rows, const char* key, int capacity, int max_probe
+) {
+  if ((max_probe < 0) || (max_probe > capacity)) { max_probe = capacity; }
+
+  GR_INTERNAL_REQUIRE(key != NULL, "A nullptr key is forbidden");
+  struct hash_rslt_pair_ hash_rslt = hash_from_str_(key);
+  const uint16_t keylen = hash_rslt.keylen;
+  int i = (int)(hash_rslt.hash % capacity); // <- 1st index to check
+
+  for (int probe_count = 1; probe_count <= max_probe; probe_count++) {
+    const struct StrU16Row_ row = rows[i];
+
+    if (rows[i].keylen == 0) { // order matters (to handle hash_rslt.keylen==0)
+      struct StrU16Search_ out = {STRU16MAP_INVALID_VAL, probe_count, i};
+      return out;
+    } else if ((row.keylen == keylen) && (memcmp(row.key, key, keylen) == 0)) {
+      struct StrU16Search_ out = {rows[i].value, probe_count, i};
+      return out;
+    }
+
+    i = (i != 0) ? i - 1 : capacity - 1; // prep for next pass thru loop
+  }
+
+  struct StrU16Search_ out = {STRU16MAP_INVALID_VAL, max_probe, i};
+  return out;
+}
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* FROZEN_KEY_IDX_BIMAP_DETAILS_H */

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -36,6 +36,7 @@ OBJS_CONFIG_LIB = \
         set_default_chemistry_parameters.lo \
         solve_chemistry.lo \
         solve_rate_cool_g.lo \
+        status_reporting.lo \
         update_UVbackground_rates.lo \
         rate_functions.lo \
         initialize_rates.lo \

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -27,6 +27,7 @@ OBJS_CONFIG_LIB = \
         cool1d_multi_g.lo \
         cool_multi_time_g.lo \
         dynamic_api.lo \
+        FrozenKeyIdxBiMap.lo \
         grackle_units.lo \
 	index_helper.lo \
         initialize_chemistry_data.lo \

--- a/src/clib/status_reporting.c
+++ b/src/clib/status_reporting.c
@@ -1,0 +1,79 @@
+/// @file status_reporting.c
+/// @brief Implements status reporting functionality
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "status_reporting.h"
+#include "grackle.h" // GR_FAIL
+
+// this is the internal routine that everything else dispatches to
+static void vprint_err_(
+  int internal_error, const struct grimpl_source_location_ locinfo,
+  const char* msg, va_list vlist
+) {
+  const char* santized_func_name = (locinfo.fn_name == NULL)
+    ? "{unspecified}" : locinfo.fn_name;
+
+  const char* fallback_msg_ = "{NULL encountered instead of error message}";
+  char* dynamic_msg_buf = NULL;
+  const char* msg_buf;
+  if (msg == NULL) {
+    msg_buf = fallback_msg_;
+  } else {
+    // make a copy of the variadic function arguments
+    va_list vlist_copy;
+    va_copy(vlist_copy, vlist);
+
+    // get the total size of the formatted message
+    size_t msg_len = vsnprintf(NULL, 0, msg, vlist_copy) + 1;
+    va_end(vlist_copy);
+
+    // allocate the buffer to hold the message
+    dynamic_msg_buf = malloc(sizeof(char) * msg_len);
+
+    // actually format the message
+    vsnprintf(dynamic_msg_buf, msg_len, msg, vlist);
+    va_end(vlist);
+
+    msg_buf = dynamic_msg_buf;
+  }
+
+  const char* descr = (internal_error == 1) ? "FATAL" : "ERROR";
+
+  fprintf(
+    stderr, "Grackle-%s %s:%d in %s] %s\n", descr, locinfo.file,
+    locinfo.lineno, santized_func_name, msg_buf
+  );
+  fflush(stderr);  // probably unnecessary for stderr
+
+  if (dynamic_msg_buf != NULL) { free(dynamic_msg_buf); }
+}
+
+void grimpl_abort_with_internal_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(1, locinfo, msg, args);
+  abort();
+}
+
+int grimpl_print_and_return_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(0, locinfo, msg, args);
+  return GR_FAIL;
+}
+
+void grimpl_print_err_msg_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+) {
+  va_list args;
+  va_start(args, msg);
+  vprint_err_(0, locinfo, msg, args);
+}
+

--- a/src/clib/status_reporting.h
+++ b/src/clib/status_reporting.h
@@ -1,0 +1,324 @@
+// See LICENSE file for license and copyright information
+
+/// @file status_reporting.h
+/// @brief Declares the tools used for result-reporting
+///
+/// Purpose
+/// =======
+/// Define machinery to let us standardize our internal logic for
+/// status-reporting. This will:
+/// - reduce boilerplate code
+/// - allow us to provide more context (e.g. filename/lineno/function name)
+/// - allow us to more easily change how we communicate this information with
+///   the downstream application in the future (if we decide that is something
+///   we ultimately want to do -- we motivate this in the next section)
+///
+/// Current Status
+/// ==============
+/// In general, status-reporting is an area where Grackle could really improve.
+/// At the time of writing, our error/status reporting leaves a lot to be
+/// desired. Essentially, it consists of:
+/// - returning a binary code GR_SUCCESS or GR_FAIL
+/// - printing some extra output information:
+///   - we use fprintf(stderr, ...) in the C routines when errors arise
+///   - we print some context information in the Fortran
+///
+/// Ideally, we would adopt a solution that provides the downstream application
+/// (i.e. the simulation-code or PyGrackle) control over whether/how this info
+/// is consumed/recorded.
+///
+/// Motivating Perspective
+/// ======================
+/// Must of us are developers of simulation-codes, but status reporting in the
+/// context of a library is different. In particular, considerations for a
+/// numerical library are very different from other libraries.
+///
+/// For this discussion, we ignore warnings.
+///
+/// The statuses that we communicate primarily fall under 2: (i) unrecoverable
+/// internal errors and (ii) function results.
+///
+/// It is also important to realize that there are certain errors we just can't
+/// check without crippling Grackle's performance. Documentation needs to be
+/// exceptionally clear in these cases.
+///
+/// I. Unrecoverable Internal Errors
+/// --------------------------------
+/// The idea is that if Grackle detects that it is a state where it seems like
+/// it may produce bad/unreliable results/behavior, we print an error message
+/// and immediately abort the program.
+///
+/// Generally, this is the result of a sanity check or a broken invariant.
+///
+/// As a rule of thumb:
+/// - if the sanity check is a direct result of the application's action, we
+///   should prefer to gracefully communicate this to the application
+/// - always consider, should this error crash an interactive Jupyter session
+///   using PyGrackle?
+/// - loudly failing is ALWAYS better than silently failing. Since these errors
+///   are quick and easy to add, these can be a quick temporary solution to
+///   address a problematic code path (and an indication that we need to more
+///   gracefully handle the error mode in the future)
+///
+/// Function Results
+/// ----------------
+/// There are generally 4 kinds of results/statuses a grackle-like library
+/// might want to report. 2 are currently relevant. 2 more may become relevant
+/// in the future. These result/statuses may include
+/// - the API function successfully completed an operation
+/// - (may become relevant with GPUs) a function can be configured to be
+///   either synchronous or asynchronous just succesfully launched a GPU
+///   kernel. (honestly, we may choose to simply denote success)
+/// - A(may become relevant with GPUs) a temporary  error
+///   occurred that could be overcome by trying again. For example, a GPU had
+///   too much pending work (honestly, we may want to configure Grackle so it
+///   knows to try again).
+/// - A generic error occurred that requires human-intervention
+///
+/// It is useful to highlight categories of these generic errors (the last of
+/// the above kinds). There is some overlap here. Categories may include:
+/// 1. resource errors like out-of-memory. While we can't really deal with OOM
+///    errors on CPUs (due to "memory overcommitment") it may be worth
+///    supporting on GPUs.
+/// 2. invalid parameter values
+///    - depending on the application and parameter this may result from
+///      end-user or application
+///    - there's a lot of value to providing lots of info about these errors
+///      (to make debugging much more pleasant)
+/// 3. file-system errors when reading the datafile. This could happen if the
+///    specified path isn't valid (e.g. it doesn't point to a valid hdf5 file,
+///    there is a permissions issue, etc.). Or it could happen do to a system
+///    error (a network filesystem is down or too many files are open)
+/// 4. An obviously invalid argument is detected (e.g. passing a nullptr). This
+///    is clearly an application error.
+/// 5. A broken precondition indicating that the application has made an error
+///    using the API
+/// 6. Generic calculation error (e.g. exceeding the iteration limit or
+///    detecting a NaN). This could arise because the application provided
+///    nonsensical field values. It could also arise simply because the current
+///    logic doesn't handle a particular case very well. An application might
+///    want to know about this class of errors so that it could log extra
+///    information (e.g. the current simulation cycle and location) so that the
+///    error can be reproduced later.
+///
+/// Hypothetically, it could also be cool to allow more recoverable
+/// error-handling when a calculation error only affects a small subset of
+/// field values (e.g. the code might overwrite those zones with values from
+/// neighboring cells). From a practical perspective, this may not be a good
+/// use of time.
+///
+/// How this can be improved
+/// ========================
+/// An issue will be created that describes various strategies for improved
+/// reporting. A common strategy for dealing with simple errors involves exit
+/// codes...
+
+#ifndef STATUS_REPORTING_H
+#define STATUS_REPORTING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// define attributes to annotate functionsA:
+// 1. ERRFMT_ATTR_(fmt_pos) tells the compiler argument number `fmt_pos`
+//    expects a printf-style format-string. Compilers supporting this will
+//    know to check consistency between arg-types and the string @ compile-time
+// 2. suppress warnings that may arise about not returning in control-flows
+//    where an internal error aborts the program with NORETURN_ATTR_
+// 3. compiler raises warnings when the value returned by a function annotated
+//    with NODISCARD_ATTR_ isn't used. We use this for a function where this is
+//    almost certainly indicative of programming error
+
+#if 0
+  // this branch will be used once we transition to compiling all non-fortran
+  // files with C++17. (We use the official syntax for specifying attributes)
+  // - starting in C++17, implementations know to ignore attributes that they
+  //   don't recognize
+  #define ERRFMT_ATTR_(fmt_pos) [[gnu::format(__printf__, fmt_pos, fmt_pos+1)]]
+  #define NORETURN_ATTR_ [[noreturn]]
+  #define NODISCARD_ATTR_ [[nodiscard]]
+
+#elif defined(__GNUG__)
+  #define ERRFMT_ATTR_(fmt_pos)                                               \
+    __attribute__((format(__printf__, fmt_pos, fmt_pos+1)))
+  #define NORETURN_ATTR_ __attribute__((noreturn))
+  // unlike [[nodiscard]], warnings associated with the following might not be
+  // suppressed by casting the result to (void). (this is ok for this file)
+  #define NODISCARD_ATTR_ __attribute__((warn_unused_result))
+
+#else
+  #define NORETURN_ATTR_ /* ... */
+  #define ERRFMT_ATTR_(fmt_pos) /* ... */
+  #define NODISCARD_ATTR_ /* ... */
+
+#endif
+
+// ---------------------------------------
+
+/// @def      __GRIMPL_PRETTY_FUNC__
+/// @brief    a magic contant like __LINE__ or __FILE__ used to specify the
+///           name of the current function
+///
+/// In more detail:
+/// - The C99 and C++11 standards ensures __func__ is provided on all
+///   platforms, but it only provides limited information (just the name of the
+///   function).
+/// - note that __func__ is technically not a macro. It's a static constant
+///   string implicitly defined by the compiler within each function definition
+/// - Where available, we prefer to use compiler-specific features that provide
+///   more information about the function (like the scope of the function, the
+///   the function signature, any template specialization, etc.).
+#ifdef __GNUG__
+  #define __GRIMPL_PRETTY_FUNC__ __PRETTY_FUNCTION__
+#else
+  #define __GRIMPL_PRETTY_FUNC__ __func__
+#endif
+
+struct grimpl_source_location_{
+  const char* file;
+  int lineno;
+  const char* fn_name;
+};
+
+/// This is a helper function used to help implement __GRIMPL_SRCLOC__
+///
+/// @note
+/// static is required to use inline with C
+static inline struct grimpl_source_location_ get_src_location_(
+  const char* file, int lineno, const char* fn_name
+) {
+  struct grimpl_source_location_ out;
+  out.file = file;
+  out.lineno = lineno;
+  out.fn_name = fn_name;
+  return out;
+}
+
+/// @def __GRIMPL_SRCLOC__
+/// @brief Roughly equivalent to __FILE__, __LINE__, etc. But, it gathers the
+///        info for us in a very concise manner
+#define __GRIMPL_SRCLOC__                                                   \
+  get_src_location_(__FILE__, __LINE__, __GRIMPL_PRETTY_FUNC__)
+
+/// helper function that helps implement GR_INTERNAL_ERROR and
+ERRFMT_ATTR_(2) NORETURN_ATTR_ void grimpl_abort_with_internal_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GR_INTERNAL_ERROR
+/// @brief function-like macro that handles a (lethal) error message
+///
+/// This macro should be treated as a function with the signature:
+///
+///   [[noreturn]] void GR_INTERNAL_ERROR(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+///
+/// @note
+/// the ``fmt`` string is part of the variadic args so that there is always
+/// at least 1 variadic argument (even in cases when ``msg`` doesn't format
+/// any arguments). There is no portable way around this until C++ 20.
+#define GR_INTERNAL_ERROR(...)                                            \
+  { grimpl_abort_with_internal_err_(__GRIMPL_SRCLOC__, __VA_ARGS__); }
+
+/// @def GR_INTERNAL_REQUIRE
+/// @brief implements functionality analogous to the assert() macro
+///
+/// if the condition is false, print an error-message (with printf
+/// formatting) & abort the program.
+///
+/// This macro should be treated as a function with the signature:
+///
+///   void GR_INTERNAL_REQUIRE(bool cond, const char* fmt, ...);
+///
+/// - The 1st arg is a boolean condition. When true, this does nothing
+/// - The 2nd arg is printf-style format argument specifying the error message
+/// - The remaining args arguments are used to format error message
+///
+/// @note
+/// The behavior is independent of the ``NDEBUG`` macro
+#define GR_INTERNAL_REQUIRE(cond, ...)                                     \
+  {  if (!(cond))                                                              \
+      { grimpl_abort_with_internal_err_(__GRIMPL_SRCLOC__, __VA_ARGS__); } }
+
+// helper function
+ERRFMT_ATTR_(2) NODISCARD_ATTR_ int grimpl_print_and_return_err_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GrPrintAndReturnErr
+/// @brief prints the error message & returns the appropriate status-value
+///
+/// This macro should be treated as a function with the signature:
+///
+///   [[nodiscard]] int GrPrintAndReturnErr(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+///
+/// This is intended to be used in scenarios like
+/// ```{.cpp}
+///   return GrPrintAndReturnErr("My err. %g is a bad val", val);
+/// ```
+/// or
+/// ```{.cpp}
+///   int ec = GrPrintAndReturnErr("My err. %g is a bad val", val);
+///   // do some cleanup...
+///   return ec;
+/// ```
+///
+/// The compiler will issue a warning if you don't do anything with the exit
+/// code. If you don't care about the exit-code, you should use the
+/// `GrPrintErrMsg` function-like macro instead
+///
+/// @note
+/// the ``fmt`` string is part of the variadic args so that there is always
+/// at least 1 variadic argument (even in cases when ``fmt`` doesn't format
+/// any arguments). There is no portable way around this until C++20.
+///
+/// @note
+/// This macro has been designed so that we have a uniform/easily grep-able
+/// interface that we can easily replace in the future if/when we improve error
+/// reporting
+#define GrPrintAndReturnErr(...)                                             \
+  grimpl_print_and_return_err_(__GRIMPL_SRCLOC__, __VA_ARGS__);
+
+
+// helper function
+ERRFMT_ATTR_(2) void grimpl_print_err_msg_(
+  const struct grimpl_source_location_ locinfo, const char* msg, ...
+);
+
+/// @def GrPrintErrMsg
+/// @brief prints the appropriate error message.
+///
+/// > [!important]
+/// > In any situation where you ultimately return an error code, you should
+/// > prefer to use GrPrintAndReturnErr. This macro is for the subset of cases
+/// > where you need to do something different.
+///
+/// This macro should be treated as a function with the signature:
+///
+///   void GrPrintErrMsg(const char* fmt, ...);
+///
+/// The ``fmt`` arg is a printf-style format argument specifying the error
+/// message. The remaining args arguments are used to format error message
+#define GrPrintErrMsg(...)                              \
+  grimpl_print_err_msg_(__GRIMPL_SRCLOC__, __VA_ARGS__);
+
+
+// undefine the attributes so we avoid leaking them
+// ------------------------------------------------
+#undef ERRFMT_ATTR_
+#undef NORETURN_ATTR_
+#undef NODISCARD_ATTR_
+
+// I don't think we can undef __GRIMPL_PRETTY_FUNC__ without causing issues
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* STATUS_REPORTING */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,6 +10,12 @@ target_compile_features(testdeps INTERFACE cxx_std_17)
 
 # start declaring targets for tests
 # ---------------------------------
+add_executable(runFrozenKeyIdxBiMapTests test_unit_FrozenKeyIdxBiMap.cpp)
+target_link_libraries(runFrozenKeyIdxBiMapTests testdeps)
+
+gtest_discover_tests(runFrozenKeyIdxBiMapTests)
+
+
 add_executable(runInterpolationTests test_unit_interpolators_g.cpp)
 target_link_libraries(runInterpolationTests testdeps)
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(testdeps INTERFACE Grackle::Grackle GTest::gtest_main)
 # short-term hack to let tests invoke Fortran functions from C
 target_compile_definitions(testdeps INTERFACE "$<$<PLATFORM_ID:Linux,Darwin>:LINUX>")
 target_include_directories(testdeps INTERFACE ${PROJECT_SOURCE_DIR}/src/clib)
+target_compile_features(testdeps INTERFACE cxx_std_17)
 
 # start declaring targets for tests
 # ---------------------------------
@@ -13,3 +14,14 @@ add_executable(runInterpolationTests test_unit_interpolators_g.cpp)
 target_link_libraries(runInterpolationTests testdeps)
 
 gtest_discover_tests(runInterpolationTests)
+
+
+add_executable(runStatusReporting test_status_reporting.cpp)
+target_link_libraries(runStatusReporting testdeps)
+# short-term hack. We should use the machinery introduced in PR #237 related to
+# Operating-system specific functionality when that PR is merged
+target_compile_definitions(runStatusReporting PRIVATE
+  "$<$<PLATFORM_ID:Linux,Darwin>:PLATFORM_GENERIC_UNIX>"
+)
+
+gtest_discover_tests(runStatusReporting)

--- a/tests/unit/test_status_reporting.cpp
+++ b/tests/unit/test_status_reporting.cpp
@@ -1,0 +1,251 @@
+#include <gtest/gtest.h>
+
+// the following 2 headers are the c versions of the headers (rather than the
+// C++ versions) since it seems more likely that posix-specific functions are
+// provided in this version
+#include <stdio.h> // fflush, tmpfile, fread, fileno
+#include <stdlib.h> // mkstemp, getenv
+
+#include <memory>
+#include <string>
+
+#include "grackle.h" // GR_FAIL
+#include "status_reporting.h"
+
+/// Machinery to capture a stream (namely stderr)
+///
+/// This is similar in concept to pytest's capfd entity (I haven't looked under
+/// the hood of that type, but I imagine they work in a similar manner)
+class CaptureSink {
+  FILE* redirected_stream_ = nullptr;
+  int redirected_fd_ = -1;
+  int backup_fd_ = -1;
+
+  CaptureSink() = default;
+  CaptureSink(const CaptureSink&) = delete;
+  CaptureSink& operator=(const CaptureSink&) = delete;
+  CaptureSink(CaptureSink&&) = delete;
+  CaptureSink& operator=(CaptureSink&&) = delete;
+
+public:
+
+  ~CaptureSink() { end_capture(false); }
+  /// create an instance that wraps stream
+  static std::unique_ptr<CaptureSink> create(FILE* stream);
+  /// end the capture and return the object
+  std::string end_capture(bool ret_captured = true);
+};
+
+#ifndef PLATFORM_GENERIC_UNIX
+
+// provide dummy implementations that will never work
+std::unique_ptr<CaptureSink> CaptureSink::create(FILE*) { return nullptr; }
+std::string CaptureSink::end_capture(bool) { return {}; }
+
+#else
+#include <unistd.h> // dup, dup2, lseek, SEEK_SET, SEEK_CUR, close
+
+// the logic we are invoking here is VERY standard. Lots and lots of examples
+// of it exist online
+
+/// closes the current file descriptor associated with fd and then opens a new
+/// file descriptor (reusing the same integer) that points to a temporary file.
+/// The temporary file will be deleted once all file descriptors to it are
+/// closed.
+///
+/// @returns
+/// true and false indicates success and failure
+static bool redirect_fd_to_tempfile_(int fd) {
+  // create a temporary file and get a descriptor to it
+  char* prefix = getenv("TMPDIR");
+  std::string path = (prefix != nullptr) ? prefix : "/tmp";
+  path += "/grackle-test-XXXXXX";
+  int temporary_fd = mkstemp(path.data());
+  if (temporary_fd == -1) { return false; }
+
+  // remove the temporary file's name from the filesystem (so it is deleted
+  // once there are no more file descriptors refer to it)
+  unlink(path.data()); // <-- nothing we can reasonably do if this fails
+
+  // in a single atomic transaction, the next line:
+  // 1. closes the file descriptor tracked by fd (i.e. the integer value will
+  //    no longer is associated with any file and can be used to create a new
+  //    file descriptor)
+  // 2. allocates a brand new file descriptor, which both reuses the file
+  //    descriptor number from fd AND refers to the file currently
+  //    referenced by temporary_fd
+  if (dup2(temporary_fd, fd) == -1) {
+    close(temporary_fd);
+    return false;
+  }
+
+  // finally, close the temporary_fd
+  close(temporary_fd); // <-- nothing we can reasonably do if this fails
+
+  return true;
+}
+
+// if we want to avoid heap-allocations, we could use std::optional
+std::unique_ptr<CaptureSink> CaptureSink::create(FILE* stream) {
+  if (stream == nullptr) { return nullptr; }
+
+  // 1. flush the stream (this is critical for the general case)!
+  if ( fflush(stream) != 0 ) { return nullptr; }
+
+  // 2. get the file descriptor that we want to redirect
+  int underlying_fd = fileno(stream);
+  if (underlying_fd == -1) { return nullptr; }
+
+  // 3. create a new file descriptor that references the same file as
+  //    `underlying_fd` (a "backup" we use later for restoring properties)
+  int backup_fd = dup(underlying_fd);
+  if (backup_fd == -1) { return nullptr; }
+
+  // 4. closes the current file descriptor associated with underlying_fd and
+  //    then opens a new file descriptor (reusing the same integer) that points
+  //    to a temporary file. Upon success, any writes to stream will write to
+  //    the temporary file -- rather than the original destination
+  if (!redirect_fd_to_tempfile_(underlying_fd)) {
+    close(backup_fd);
+    return nullptr;
+  }
+
+  // 5. prepare the container
+  std::unique_ptr<CaptureSink> out{new CaptureSink};
+  out->redirected_stream_ = stream;
+  out->redirected_fd_ = underlying_fd;
+  out->backup_fd_ = backup_fd;
+  return out;
+}
+
+// since the class is primary intended to capture stderr, we eagerly abort if
+// things go wrong (why even go on if testing is crippled?)
+std::string CaptureSink::end_capture(bool ret_captured) {
+  std::string out;
+  if (this->redirected_fd_ < 0) { return out; }
+
+  // flushing is critical for the general case!
+  if (fflush(this->redirected_stream_) != 0) { abort(); };
+
+  // determine the number of captured bytes we wish to read
+  off_t nbytes = 0;
+  if (ret_captured) {
+    nbytes = lseek(this->redirected_fd_, 0, SEEK_END);
+    if (nbytes == -1) { abort(); }
+    // restore position in file to the very start
+    if (lseek(this->redirected_fd_, 0, SEEK_SET) == -1) { abort(); } 
+  }
+
+  // actually read in bytes
+  if (nbytes > 0) {
+    out = std::string(nbytes, ' '); // <- allocate the necessary space
+    char* buf = out.data();
+    if (read(this->redirected_fd_, buf, nbytes) != nbytes) { abort(); }
+  }
+
+  // in a single atomic transaction, the next line:
+  // 1. closes the file descriptor tracked by redirected_fd_ (i.e. the integer
+  //    value no longer is associated with any file and can be when creating
+  //    a new file descriptor)
+  // 2. allocates a brand new file descriptor, which both reuses the file
+  //    descriptor number from redirected_fd_ AND refers to the file currently
+  //    referenced by backup_fd_
+  // At the time of writing, redirected_fd_ was the last descriptor refering to
+  // a temporary file, whose name was already deleted from the file system.
+  // Thus, the temporary file no longer exists after this operation.
+  if (dup2(this->backup_fd_, this->redirected_fd_) == -1) { abort(); }
+
+  // we no longer need to keep backup_fd_
+  close(this->backup_fd_);
+
+  // overwrite variables so we know not to execute this logic again
+  redirected_stream_ = NULL;
+  this->redirected_fd_ = -1;
+  this->backup_fd_ = -1;
+
+  return out;
+}
+
+/// capturer
+#endif
+
+
+testing::AssertionResult ContainsFormattedMessage_(int n) {
+  if ((n % 2) == 0)
+    return testing::AssertionSuccess();
+  else
+    return testing::AssertionFailure() << n << " is odd";
+}
+
+
+TEST(StatusReportingTest, PrintErrMsg) {
+
+  // setup capture of stderr
+  std::unique_ptr<CaptureSink> capstderr = CaptureSink::create(stderr);
+  if (capstderr.get() == nullptr) {
+    GTEST_SKIP() << "Stream redirection doesn't seem to be working. It may "
+                 << "not be implemented for the current platform";
+  }
+
+  GrPrintErrMsg("message with string: `%s` & int: %d", "str", 4);
+  const char* expected_msg = "message with string: `str` & int: 4";
+
+  // end the capture
+  std::string msg = capstderr->end_capture();
+
+  // now do some checking (it would be cleaner to use gmock's matchers)
+  ASSERT_GT(msg.size(), 0) << "nothing seems to have printed";
+  EXPECT_EQ(msg[msg.size()-1], '\n') << "we expect a trailing newline";
+  ASSERT_NE(msg.find(expected_msg), std::string::npos)
+    << "The error message doesn't contain the substring \"" << expected_msg
+    << "\". The contents of the message is: \"" << msg << '"';
+}
+
+
+TEST(StatusReportingTest, PrintAndReturnErr) {
+
+  // setup capture of stderr
+  std::unique_ptr<CaptureSink> capstderr = CaptureSink::create(stderr);
+  if (capstderr.get() == nullptr) {
+    GTEST_SKIP() << "Stream redirection doesn't seem to be working. It may "
+                 << "not be implemented for the current platform";
+  }
+
+  int ec = GrPrintAndReturnErr("message with string: `%s` & int: %d", "str", 4);
+  const char* expected_msg = "message with string: `str` & int: 4";
+
+  // end the capture
+  std::string msg = capstderr->end_capture();
+
+  EXPECT_EQ(ec, GR_FAIL) << "GrPrintAndReturnErr's exit code, " << ec
+                         << ", doesn't match GR_FAIL (" << GR_FAIL << ')';
+
+  // now do some checking (it would be cleaner to use gmock's matchers)
+  ASSERT_GT(msg.size(), 0) << "nothing seems to have printed";
+  EXPECT_EQ(msg[msg.size()-1], '\n') << "we expect a trailing newline";
+  ASSERT_NE(msg.find(expected_msg), std::string::npos)
+    << "The error message doesn't contain the substring \"" << expected_msg
+    << "\". The contents of the message is: \"" << msg << '"';
+}
+
+TEST(StatusReportingDeathTest, InternalError) {
+  // right now, we are mostly just confirm that the program aborts
+  // -> we are checking that the specified error is included
+  // -> in the future, we have the option to test the formatting of the message
+  EXPECT_DEATH({
+    GR_INTERNAL_ERROR("This is a dummy error message %s", "dummy-str");
+  }, ".*This is a dummy error message dummy-str.*");
+}
+
+TEST(StatusReportingDeathTest, InternalRequireFalse) {
+  // right now, we are mostly just confirm that the program aborts
+  // -> we are checking that the specified error is included
+  // -> in the future, we have the option to test the formatting of the message
+  EXPECT_DEATH({
+    GR_INTERNAL_REQUIRE(1 == 0, "This is a dummy error message %d", 10);
+  }, ".*This is a dummy error message 10.*");
+}
+
+TEST(StatusReportingDeathTest, InternalRequireTrue) {
+  GR_INTERNAL_REQUIRE(1 == 1, "This program shouldn't abort");
+}

--- a/tests/unit/test_unit_FrozenKeyIdxBiMap.cpp
+++ b/tests/unit/test_unit_FrozenKeyIdxBiMap.cpp
@@ -1,0 +1,228 @@
+// to be clear, this file is not directly testing a part of the public API
+// -> instead it is testing a well-defined internal building-block
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "FrozenKeyIdxBiMap.h"
+#include "grackle.h"
+
+class FrozenKeyIdxBiMapConstructorSuite : 
+  public testing::TestWithParam<enum BiMapMode> {
+  // You can implement all the usual fixture class members here.
+  // To access the test parameter, call GetParam() from class
+  // TestWithParam<T>.
+
+};
+
+TEST_P(FrozenKeyIdxBiMapConstructorSuite, Simple) {
+  FrozenKeyIdxBiMap* tmp = nullptr;
+  const char* keys[] = {"denisty", "internal_energy"};
+
+  EXPECT_EQ(new_FrozenKeyIdxBiMap(&tmp, keys, 2, GetParam()), GR_SUCCESS);
+  ASSERT_NE(tmp, nullptr);
+  drop_FrozenKeyIdxBiMap(tmp);
+}
+
+TEST_P(FrozenKeyIdxBiMapConstructorSuite, LongKey) {
+  FrozenKeyIdxBiMap* tmp = nullptr;
+
+  const char* first_key = "density";
+  std::string long_key(STRU16MAP_KEYLEN_MAX, 'A');
+  const char* keys[2] = {first_key, long_key.data()};
+  EXPECT_EQ(new_FrozenKeyIdxBiMap(&tmp, keys, 2, GetParam()), GR_SUCCESS);
+  ASSERT_NE(tmp, nullptr);
+  drop_FrozenKeyIdxBiMap(tmp);
+}
+
+TEST_P(FrozenKeyIdxBiMapConstructorSuite, TooLongKey) {
+  FrozenKeyIdxBiMap* tmp = nullptr;
+
+  const char* first_key = "density";
+  std::string long_key(STRU16MAP_KEYLEN_MAX+1, 'A');
+  const char* keys[2] = {first_key, long_key.data()};
+  EXPECT_NE(new_FrozenKeyIdxBiMap(&tmp, keys, 2, GetParam()), GR_SUCCESS);
+  ASSERT_EQ(tmp, nullptr);
+}
+
+TEST_P(FrozenKeyIdxBiMapConstructorSuite, 0LenKey) {
+  FrozenKeyIdxBiMap* tmp = nullptr;
+
+  const char* keys[2] = {"density",""};
+  EXPECT_NE(new_FrozenKeyIdxBiMap(&tmp, keys, 2, GetParam()), GR_SUCCESS);
+  ASSERT_EQ(tmp, nullptr);
+}
+
+TEST_P(FrozenKeyIdxBiMapConstructorSuite, NoKeys) {
+  FrozenKeyIdxBiMap* tmp = nullptr;
+
+  EXPECT_NE(new_FrozenKeyIdxBiMap(&tmp, nullptr, 0, GetParam()), GR_SUCCESS);
+  ASSERT_EQ(tmp, nullptr); // if this fails, we'll leak memory (but not much
+                           // can be done)
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  , /* <- leaving Instantiation name empty */
+  FrozenKeyIdxBiMapConstructorSuite,
+  testing::Values(BIMAP_REFS_KEYDATA, BIMAP_COPIES_KEYDATA),
+  [](const testing::TestParamInfo<FrozenKeyIdxBiMapConstructorSuite::ParamType>& info){
+    if (info.param == BIMAP_REFS_KEYDATA) {
+      return std::string("BIMAP_REFS_KEYDATA");
+    } else {
+      return std::string("BIMAP_COPIES_KEYDATA");
+    }
+  }
+);
+
+
+/// helper function to initialize a map from a vector
+int new_FrozenKeyIdxBiMap(FrozenKeyIdxBiMap** out,
+                          const std::vector<std::string>& vec_,
+                          enum BiMapMode mode)
+{
+  std::size_t key_count = vec_.size();
+
+  // create a vector of pointers
+  std::vector<const char*> key_ptr_l(key_count, nullptr);
+  for (std::size_t i = 0; i < key_count; i++) {
+    key_ptr_l[i] = vec_[i].c_str();
+  }
+
+  return new_FrozenKeyIdxBiMap(out, key_ptr_l.data(), key_count, mode);
+}
+
+class FrozenKeyIdxBiMapGeneralSuite :
+  public testing::TestWithParam<enum BiMapMode>
+{
+protected:
+  std::vector<std::string> ordered_keys;
+  FrozenKeyIdxBiMap* bimap_p = nullptr;
+
+  // I don't think we can use this->GetParam from a constructor... So we use 
+  // SetUp/Teardown instead of constructor and destructor instead
+  void SetUp() override {
+    ordered_keys = std::vector<std::string>{
+      "internal_energy", "density", "metal_density"
+    };
+
+    enum BiMapMode mode = this->GetParam();
+
+    // since we are in SetUp, (rather than a constructor) we can perform some sanity checks with ASSERTIONs
+    ASSERT_EQ(
+        new_FrozenKeyIdxBiMap(&this->bimap_p, ordered_keys, mode),
+        GR_SUCCESS
+    );
+
+  }
+
+  void TearDown() override {
+    if (bimap_p != nullptr) { drop_FrozenKeyIdxBiMap(bimap_p); }
+  }
+
+  bool ReusesOriginalKeyPtrs(const FrozenKeyIdxBiMap* p) const {
+    for (int i = 0; i < 3; i++) {
+      const char* orig_key_ptr = ordered_keys[i].c_str();
+      if (FrozenKeyIdxBiMap_key_from_idx(p, i) != orig_key_ptr) {return false;}
+    }
+    return true;
+  }
+
+};
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, IdxFromKey_ContainedKey) {
+  EXPECT_EQ(FrozenKeyIdxBiMap_idx_from_key(bimap_p, "density"), 1);
+  EXPECT_EQ(FrozenKeyIdxBiMap_idx_from_key(bimap_p, "internal_energy"), 0);
+  EXPECT_EQ(FrozenKeyIdxBiMap_idx_from_key(bimap_p, "metal_density"), 2);
+}
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, IdxFromKey_AbsentKey) {
+  EXPECT_EQ(
+    FrozenKeyIdxBiMap_idx_from_key(bimap_p, "notAKey"), STRU16MAP_INVALID_VAL
+  );
+}
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, IdxFromKey_AbsentIrregularKeys) {
+  EXPECT_EQ(
+    FrozenKeyIdxBiMap_idx_from_key(bimap_p, ""), STRU16MAP_INVALID_VAL
+  );
+
+  std::string key(STRU16MAP_KEYLEN_MAX+1, 'A');
+  EXPECT_EQ(
+    FrozenKeyIdxBiMap_idx_from_key(bimap_p, key.data()), STRU16MAP_INVALID_VAL
+  );
+}
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, KeyFromIdx_InvalidIdx) {
+  EXPECT_EQ(FrozenKeyIdxBiMap_key_from_idx(bimap_p, 3), nullptr);
+  EXPECT_EQ(
+    FrozenKeyIdxBiMap_key_from_idx(bimap_p, STRU16MAP_INVALID_VAL), nullptr
+  );
+}
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, KeyFromIdx_ValidIdx) {
+  EXPECT_EQ(
+    std::string(FrozenKeyIdxBiMap_key_from_idx(bimap_p, 2)),
+    std::string("metal_density")
+  );
+  EXPECT_EQ(
+    std::string(FrozenKeyIdxBiMap_key_from_idx(bimap_p, 1)),
+    std::string("density")
+  );
+  EXPECT_EQ(
+    std::string(FrozenKeyIdxBiMap_key_from_idx(bimap_p, 0)),
+    std::string("internal_energy")
+  );
+
+  // check whether the bimap is using pointers to the keys used during init
+  if (GetParam() == BIMAP_REFS_KEYDATA) {
+    EXPECT_TRUE(ReusesOriginalKeyPtrs(bimap_p));
+  } else {
+    EXPECT_FALSE(ReusesOriginalKeyPtrs(bimap_p));
+  }
+}
+
+TEST_P(FrozenKeyIdxBiMapGeneralSuite, Clone) {
+  FrozenKeyIdxBiMap* clone_p = nullptr;
+  EXPECT_EQ(FrozenKeyIdxBiMap_clone(&clone_p, bimap_p), GR_SUCCESS);
+  ASSERT_NE(clone_p, nullptr);
+
+  // for the sake of robustly checking everything, we delete bimap_p
+  drop_FrozenKeyIdxBiMap(bimap_p);
+  bimap_p = nullptr;
+
+  EXPECT_EQ(FrozenKeyIdxBiMap_idx_from_key(clone_p, "internal_energy"), 0);
+  EXPECT_EQ(
+    FrozenKeyIdxBiMap_idx_from_key(clone_p, "notAKey"), STRU16MAP_INVALID_VAL
+  );
+
+  EXPECT_EQ(FrozenKeyIdxBiMap_key_from_idx(clone_p, 3), nullptr);
+  EXPECT_EQ(
+    std::string(FrozenKeyIdxBiMap_key_from_idx(clone_p, 1)),
+    std::string("density")
+  );
+
+  // check whether the clone is using pointers to the keys used during init
+  if (GetParam() == 0) {
+    EXPECT_TRUE(ReusesOriginalKeyPtrs(clone_p));
+  } else {
+    EXPECT_FALSE(ReusesOriginalKeyPtrs(clone_p));
+  }
+
+  // finally, cleanup the clone
+  drop_FrozenKeyIdxBiMap(clone_p);
+}
+
+
+INSTANTIATE_TEST_SUITE_P(
+  , /* <- leaving Instantiation name empty */
+  FrozenKeyIdxBiMapGeneralSuite,
+  testing::Values(BIMAP_REFS_KEYDATA, BIMAP_COPIES_KEYDATA),
+  [](const testing::TestParamInfo<FrozenKeyIdxBiMapGeneralSuite::ParamType>& info){
+    if (info.param == BIMAP_REFS_KEYDATA) {
+      return std::string("BIMAP_REFS_KEYDATA");
+    } else {
+      return std::string("BIMAP_COPIES_KEYDATA");
+    }
+  }
+);


### PR DESCRIPTION
This builds directly on PR #269 (that PR must be merged first)

------------------

This introduces a data structure called `FrozenStringIdxBiMap`. This is a bidirectional map (aka a bidirectional dictionary), that can be used to map between a unique set of `n` strings (keys) and a unique set of indexes (with values of `0` through `n-1`) and vice-versa. 

I intend to use this as a building block to implement other types (namely types with a map-like interface). There are some obvious applications related to the dynamic API. The primary impetus was to implement a reimagined version of `grackle_field_data`.

The underlying implementation is based on a hash table. To implement this, I ported a class (from C++ to C) that I previously implemented in Enzo-E to perform the same function (called [StringIndRdOnlyMap](https://github.com/enzo-project/enzo-e/blob/main/src/Cello/view_StringIndRdOnlyMap.hpp)). In addition to porting the logic from C++ to C[^1], I also added logic to handle a few edge cases. For context, I originally wrote the Enzo-E class so that to make use of more specialized logic, which should make this faster that a solution that makes use of more generic types like `std::map` from the C++ standard library.

[^1]: With the benefit of hindsight, the effort to convert from C++ to C took way more time than I expected and it probably wasn’t worth it.