### PR TITLE
CI: shift core-library tests to a separate "job"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ commands:
             fi
 
   install-cmake-dependencies:
-    description: "Install just the dependencies needed for a CMake build"
+    description: "Install minimal dependencies needed for a CMake build"
     steps:
       - run:
-          name: "Install only the basic dependencies for a CMake build"
+          name: "Install minimal dependencies needed for a CMake build"
           command: |
             git submodule update --init --remote
             sudo apt update
@@ -398,7 +398,7 @@ jobs:
                   -GNinja -Bbuild
             cmake --build build
       - run:
-          name: "description: Run the suite of tests that operate directly on the core-library."
+          name: "Run the suite of tests that operate directly on the core-library."
           command: |
             cd build
             ctest --output-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,33 +304,17 @@ jobs:
       - lint
       - download-test-data
 
-      - install-grackle:
-          omp: 'false'
-          classic_build: 'true'
-          tag: $CIRCLE_BRANCH
-
-      - run-pygrackle-tests:
-          omp: 'false'
-          build_kind: 'classic'
-          generate: 'true'
-
-      - install-grackle:
-          omp: 'true'
-          classic_build: 'true'
-          tag: $CIRCLE_BRANCH
-
-      - run-classic-omp-test
-
+      # record results of answer-tests using the gold-standard
       - install-grackle:
           omp: 'false'
           classic_build: 'false'
           tag: gold-standard-v2
-
       - run-pygrackle-tests:
           omp: 'false'
           build_kind: 'cmake'
           generate: 'true'
 
+      # run full pygrackle test-suite on latest commit (CMake-build)
       - install-grackle:
           omp: 'false'
           classic_build: 'false'
@@ -340,6 +324,25 @@ jobs:
           omp: 'false'
           build_kind: 'cmake'
           generate: 'false'
+
+      # run full pygrackle test-suite on latest commit (classic-build)
+      - install-grackle:
+          omp: 'false'
+          classic_build: 'true'
+          tag: $CIRCLE_BRANCH
+
+      - run-pygrackle-tests:
+          omp: 'false'
+          build_kind: 'classic'
+          generate: 'false'
+
+      # setup and run classic-omp-test on latest commit
+      - install-grackle:
+          omp: 'true'
+          classic_build: 'true'
+          tag: $CIRCLE_BRANCH
+
+      - run-classic-omp-test
 
 # TODO: once we merge in GH-#208, we need to issue a new gold standard, and then we should
 #       issue a followup PR where we uncomment the remainder of this test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,27 @@ commands:
               git fetch --tags https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME
             fi
 
+  install-cmake-dependencies:
+    description: "Install just the dependencies needed for a CMake build"
+    steps:
+      - run:
+          name: "Install only the basic dependencies for a CMake build"
+          command: |
+            git submodule update --init --remote
+            sudo apt update
+            sudo apt install -y libhdf5-serial-dev gfortran ninja-build cmake
+
   install-dependencies:
     description: "Install dependencies."
     steps:
+      - install-cmake-dependencies
       - run:
-          name: "Install dependencies."
+          name: "Install all other dependencies."
           command: |
-            git submodule update --init --remote
             source $BASH_ENV
-            sudo apt update
-            sudo apt install -y libhdf5-serial-dev gfortran libtool-bin castxml
+            # libtool-bin is a requirement of the classic build-system
+            # castxml is a requirement of the pygrackle test-suite
+            sudo apt install -y libtool-bin castxml
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
@@ -241,45 +252,19 @@ commands:
               fi
             fi
 
-  run-core-tests:
-    description: "Run the suite of tests that operate directly on the core-library."
-    parameters:
-      omp:
-        type: enum
-        default: 'false'
-        enum: ['true', 'false']
-      build_kind:
-        type: enum
-        default: 'classic'
-        enum: ['classic', 'cmake', 'standalone-pygrackle']
+  run-classic-omp-test:
+    description: "Run the OpenMP test with the classic build-system"
     steps:
       - run:
-          name: "Run core-library tests (build_kind: << parameters.build_kind >>, omp: << parameters.omp >>)."
+          name: "Run the OpenMP test with the classic build system"
           command: |
             source $BASH_ENV
             cd src
-
-            # actually execute the tests
-            if [[ << parameters.build_kind >> == 'classic' &&
-                  << parameters.omp >> == 'true' ]]; then
-              export OMP_NUM_THREADS=4
-              cd example
-              make cxx_omp_example
-              ./cxx_omp_example
-              make clean
-            elif [ << parameters.build_kind >> == 'cmake' >> ]; then
-              # compile the tests (it would probably would be better to do this
-              # when compiling the rest of Grackle)
-              cmake -DGRACKLE_BUILD_TESTS=ON -Bbuild
-              cmake --build build
-              # execute the tests
-              # -> if the cmake build-system was configured with OpenMP, the
-              #    test-suite automatically knows to run the OpenMP example
-              cd build
-              ctest --output-on-failure
-            else
-              echo "the core-library tests can't be run in this configuration"
-            fi
+            export OMP_NUM_THREADS=4
+            cd example
+            make cxx_omp_example
+            ./cxx_omp_example
+            make clean
 
   build-docs:
     description: "Test the docs build."
@@ -334,9 +319,7 @@ jobs:
           classic_build: 'true'
           tag: $CIRCLE_BRANCH
 
-      - run-core-tests:
-          omp: 'true'
-          build_kind: 'classic'
+      - run-classic-omp-test
 
       - install-grackle:
           omp: 'false'
@@ -357,10 +340,6 @@ jobs:
           omp: 'false'
           build_kind: 'cmake'
           generate: 'false'
-
-      - run-core-tests:
-          omp: 'false'
-          build_kind: 'cmake'
 
 # TODO: once we merge in GH-#208, we need to issue a new gold standard, and then we should
 #       issue a followup PR where we uncomment the remainder of this test
@@ -393,6 +372,34 @@ jobs:
       #    build_kind: 'standalone-pygrackle'
       #    generate: 'false'
 
+  corelib-tests:
+    # we're only using a python docker-image out of convenience (We only care
+    # that a version of python exists with a version of 3.7 or newer to run
+    # our scripts).
+    executor:
+      name: python
+      tag: 3.8.14
+
+    working_directory: ~/grackle
+
+    steps:
+      - checkout
+      - install-cmake-dependencies
+      - run:
+          name: "Build libgrackle and all of the core library's tests"
+          command: |
+            cmake -DGRACKLE_USE_DOUBLE=ON                   \
+                  -DGRACKLE_USE_OPENMP=OFF                  \
+                  -DGRACKLE_BUILD_TESTS=ON                  \
+                  -DCMAKE_BUILD_TYPE=Release                \
+                  -GNinja -Bbuild
+            cmake --build build
+      - run:
+          name: "description: Run the suite of tests that operate directly on the core-library."
+          command: |
+            cd build
+            ctest --output-on-failure
+
   docs-build:
     parameters:
       tag:
@@ -415,12 +422,15 @@ workflows:
    tests:
      jobs:
        - test-suite:
-           name: "Full test suite - Python 3.8"
+           name: "Pygrackle test suite - Python 3.8"
            tag: "3.8.14"
 
        - test-standalone-pygrackle:
-           name: "Standalone Python 3.8 tests"
+           name: "Standalone Pygrackle tests - Python 3.8"
            tag: "3.8.14"
+
+       - corelib-tests:
+           name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"
@@ -436,12 +446,15 @@ workflows:
                 - main
      jobs:
        - test-suite:
-           name: "Full test suite - Python 3.8"
+           name: "Pygrackle test suite - Python 3.8"
            tag: "3.8.14"
 
        - test-standalone-pygrackle:
-           name: "Standalone Python 3.8 tests"
+           name: "Standalone Pygrackle tests - Python 3.8"
            tag: "3.8.14"
+
+       - corelib-tests:
+           name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,12 +215,12 @@ commands:
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate
-            set -x
 
             # actually execute the tests
             if [[ '<< parameters.build_kind >>' == 'classic' &&
                   '<< parameters.omp >>' == 'true' ]]; then
-              echo "the pygrackle tests can't be run in this configuration"
+              echo "ERROR: pygrackle tests can't be run in this configuration"
+              exit 1
 
             elif [ ! -f ./src/python/tests/conftest.py ]; then
               # NOTE: these tests should run if using OpenMP without the
@@ -230,7 +230,7 @@ commands:
               # defining environment variables)
               # - We can stop supporting this case once the most recent gold
               #   standard tags a repository version containing conftest.py
-              if [ << parameters.generate >> == 'true' ]; then
+              if [ '<< parameters.generate >>' == 'true' ]; then
                 export GENERATE_PYGRACKLE_TEST_RESULTS=1
               else
                 export GENERATE_PYGRACKLE_TEST_RESULTS=0
@@ -245,7 +245,7 @@ commands:
               # ANSWER_DIR was picked to ensure that it matches up with the old
               # hardcoded location (we can change it once the most recent gold
               # standard tags a repository version containing conftest.py)
-              ANSWER_DIR=./python/tests/test_answers
+              ANSWER_DIR=./src/python/tests/test_answers
               if [ '<< parameters.generate >>' == 'true' ]; then
                 py.test --answer-dir=${ANSWER_DIR} --answer-store
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,13 +98,13 @@ commands:
 
 
             # Next, we actually perform the installation
-            if [ << parameters.classic_build >> == 'true' ]; then
+            if [ '<< parameters.classic_build >>' == 'true' ]; then
               mkdir -p $HOME/local # installation location
               ./configure
               cd src/clib
               make clean
               make machine-linux-gnu
-              if [ << parameters.omp >> == 'true' ]; then
+              if [ '<< parameters.omp >>' == 'true' ]; then
                 make omp-on
               fi
               make
@@ -217,11 +217,11 @@ commands:
             source $HOME/venv/bin/activate
 
             # actually execute the tests
-            if [[ << parameters.build_kind >> == 'classic' &&
-                  << parameters.omp >> == 'true' ]]; then
+            if [[ '<< parameters.build_kind >>' == 'classic' &&
+                  '<< parameters.omp >>' == 'true' ]]; then
               echo "the pygrackle tests can't be run in this configuration"
 
-            elif [ ! -f ./python/tests/conftest.py ]; then
+            elif [ ! -f ./src/python/tests/conftest.py ]; then
               # NOTE: these tests should run if using OpenMP without the
               #       classic build-system
 
@@ -245,7 +245,7 @@ commands:
               # hardcoded location (we can change it once the most recent gold
               # standard tags a repository version containing conftest.py)
               ANSWER_DIR=./python/tests/test_answers
-              if [ << parameters.generate >> == 'true' ]; then
+              if [ '<< parameters.generate >>' == 'true' ]; then
                 py.test --answer-dir=${ANSWER_DIR} --answer-store
               else
                 py.test --answer-dir=${ANSWER_DIR}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,7 @@ commands:
           command: |
             source $BASH_ENV
             source $HOME/venv/bin/activate
+            set -x
 
             # actually execute the tests
             if [[ '<< parameters.build_kind >>' == 'classic' &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ add_test(
   COMMAND ${checker_script} cmp
     --target $<TARGET_FILE:c_example>
     --ref ${CMAKE_CURRENT_LIST_DIR}/scripts/c_example_ref.json
-    --rtol 1e-15
+    --rtol 3e-14
     --exec-timeout 10
     --exec-dir ${example_exec_dir}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ add_test(
   COMMAND ${checker_script} cmp
     --target $<TARGET_FILE:c_example>
     --ref ${CMAKE_CURRENT_LIST_DIR}/scripts/c_example_ref.json
-    --rtol 3e-14
+    --rtol 6e-14
     --exec-timeout 10
     --exec-dir ${example_exec_dir}
 )

--- a/tests/scripts/code_example_checker.py
+++ b/tests/scripts/code_example_checker.py
@@ -25,6 +25,7 @@ import re
 import stat
 import subprocess
 import sys
+import textwrap
 
 # Common machinery used for multiple subcommands
 # ----------------------------------------------
@@ -264,39 +265,131 @@ def main_cmp(args):
     atol, rtol = args.atol, args.rtol
     print(f"Comparing Results: atol = {atol}, rtol = {rtol}")
 
-    mismatch_fields = []
-    for field_name, ref_val_pair in ref_rslt.items():
-        actual_val_pair = target_rslt[field_name]
-        if args.verbose:
-            print(field_name, actual_val_pair, ref_val_pair)
-        if (ref_val_pair is None) or (actual_val_pair is None):
-            is_equal = (ref_val == actual_val)
-        else:
-            ref_val, ref_units = ref_val_pair
-            actual_val, actual_units = actual_val_pair
-            
-            absdiff = abs(ref_val - actual_val)
-            is_equal = (
-                (actual_units == ref_units) and
-                (absdiff <= (atol + rtol * abs(ref_val)))
-            )
-        if not is_equal:
-            mismatch_fields.append(field_name)
-
-    if len(mismatch_fields) == 0:
+    successful_check = isclose_resultpacks(
+        actual=target_rslt,
+        reference=ref_rslt,
+        atol=args.atol,
+        rtol=args.rtol,
+        verbose=args.verbose
+    )
+    if successful_check:
         print("SUCCESS")
         return 0
-
-    # report the error
-    print("FAIL")
-    for field_name in mismatch_fields:
-        ref_val = ref_rslt[field_name]
-        actual_val = target_rslt[field_name]
-        print(
-            f"  {field_name!r} has a mismatch -"
-            f"ref: {ref_val}, target: {actual_val}"
-        )
     return 1
+
+class CmpErrorRecorder:
+    # as we perform a comparison, instances of this class record errors
+    def __init__(self): self.log = []
+    def record_err(self, s): self.log.append(s)
+    def any_err(self): return len(self.log) > 0
+    def __iter__(self): return iter(self.log)
+
+def _consistent_keys(actual, reference, err_recorder):
+    # returns iterable for the keys shared by actual and reference
+    refkeys = reference.keys()
+    refkey_set = set(refkeys)
+    mismatch_keys = refkey_set.symmetric_difference(actual.keys())
+    if len(mismatch_keys) == 0:
+        return actual.keys()
+    else:
+        shared_keys = list(refkey_set.intersection(actual.keys()))
+        extra_ref, extra_actual = [], []
+        for k in mismatch_keys:
+            if k in refkeys:
+                extra_ref.append(k)
+            else:
+                extra_actual.append(k)
+        err_recorder.record_err(textwrap.dedent(f"""\
+            Key Mismatch Error: the following are extra (unmatched) keys
+              actual:    {extra_actual!r}
+              reference: {extra_ref!r}"""
+        ))
+        return shared_keys
+
+
+def isclose_resultpacks(actual, reference, rtol, atol, verbose=False):
+    """
+    Returns True if entries of the result packs are equal within a tolerance.
+
+    Parameters
+    ----------
+    actual, reference : mapping
+        A mapping holding results obtained in calculations. The keys are the
+        names of quantities. Each value is a tuple where the first element is
+        a number and the second value is a string (corresponding to a uniy)
+    rtol : float
+        The relative tolerance parameter
+    atol : float
+        The absolute tolerance parameter
+    verbose : bool
+        Print information
+    announce_mismatch : bool
+        Print detailed error-reports on failure
+    """
+
+    if verbose:
+        print(f"Comparing Results with atol = {atol}, rtol = {rtol}")
+
+    match_count = 0
+    checked_cases = 0
+    err_recorder = CmpErrorRecorder()
+    keys = _consistent_keys(actual, reference, err_recorder)
+    for key in keys:
+        checked_cases += 1
+        actual_pair, ref_pair = actual[key], reference[key]
+
+        if verbose:
+            print(f"  comparing {key}: actual={actual!r}, ref={ref!r}")
+
+        if (ref_pair is None) or (actual_pair is None):
+            if actual_pair != ref_pair:
+                err_recorder.record_err(textwrap.dedent(f"""\
+                    {key!r}: one of the values is None
+                      actual: {actual_pair!r}
+                      ref: {ref_pair!r}"""
+                ))
+            else:
+                match_count += 1
+            continue
+
+        # we use numpy's convention of asymmetric relative differences
+        ref_val, ref_units = ref_pair
+        actual_val, actual_units = actual_pair
+        diff = actual_val - ref_val
+
+        if ref_units != actual_units:
+            err_recorder.record_err(textwrap.dedent(f"""\
+                {key!r}: Unit mismatch!
+                  units: actual = {actual_units!r}, ref = {ref_units!r}
+                  values: actual = {actual_val!r}, ref = {ref_val!r}"""
+            ))
+        elif (abs(diff) > (atol + rtol * abs(ref_val))):
+            rdiff_str = f'{diff/ref_val:g}' if (ref_val != 0) else 'undefined'
+            err_recorder.record_err(textwrap.dedent(f"""\
+                {key!r}: not equal to specified tolerance
+                  relative Difference: {rdiff_str}
+                  absolute Difference: {abs(diff):g}
+                  values: actual = {actual_val!r}, ref = {ref_val!r}
+                  units: {ref_units!r}"""
+            ))
+        else:
+            match_count+=1
+
+    if not err_recorder.any_err():
+        return True
+
+    msg = textwrap.dedent(f"""
+        FAIL: Result-packs not equal to tolerance rtol={rtol}, atol={atol}
+          Context:
+            compared results for the following keys:
+              {repr(list(keys))[1:-1]}
+            {match_count} of these {checked_cases} results matched"""
+    )
+    print(
+        msg, *(textwrap.indent(e,prefix='  ') for e in err_recorder), sep='\n'
+    )
+    return False
+
 
 # datacheck subcommand
 # --------------------

--- a/tests/scripts/code_example_checker.py
+++ b/tests/scripts/code_example_checker.py
@@ -263,7 +263,6 @@ def main_cmp(args):
 
     ref_rslt, target_rslt = result_l
     atol, rtol = args.atol, args.rtol
-    print(f"Comparing Results: atol = {atol}, rtol = {rtol}")
 
     successful_check = isclose_resultpacks(
         actual=target_rslt,


### PR DESCRIPTION
This PR shifts the core-library tests to a separate "job."

It has come to my attention in recent PRs (e.g. #273, #279), that our current choice to run the core-library test-suite after the Pygrackle test-suite is somewhat undesirable. Specifically, the core-library test-suite is more likely to include unit-tests (while there may not be many unit-tests yet, many forthcoming PRs have proposed adding them).

This is important for 2 reasons:
1. Unit-tests are inherently faster than answer-tests. We should run these as soon as possible so we can fail quickly.
2. Unit-tests are also more specialized than answer-tests. If a unit-test fails, it is likely that an answer-test will also fail. The way things have been configured (before this PR) will cause the answer-test to fail and CI to abort before the unit-tests can be reun.

As I write this up, I realize that I probably just could have re-ordered the tests. I'm totally willing to do that. But, I think in some ways this may be better (if we aren't too worried about using up resources)