### PR TITLE
Revert changes in make_consistent_g

### DIFF
--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -582,42 +582,6 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
 
       dlogtem = (log(temend) - log(temstart))/real(nratec-1, DKIND)
 
-!     We better make consistent at first GC202002
-
-      if (ispecies .gt. 0) then
-
-#define ABUNDANCE_CORRECTION
-#ifdef ABUNDANCE_CORRECTION
-      call make_consistent_g(de, HI, HII, HeI, HeII, HeIII,
-     &                     HM, H2I, H2II, DI, DII, HDI, metal, dust,
-     &                     d, is, ie, js, je, ks, ke,
-     &                     in, jn, kn, ispecies, imetal, fh, dtoh
-     &                   , idustfield, imchem, igrgr, dom
-     &                   , DM, HDII, HeHII
-     &                   , CI, CII, CO, CO2
-     &                   , OI, OH, H2O, O2
-     &                   , SiI, SiOI, SiO2I
-     &                   , CH, CH2, COII, OII
-     &                   , OHII, H2OII, H3OII, O2II
-     &                   , Mg, Al, S, Fe
-     &                   , SiM, FeM, Mg2SiO4, MgSiO3, Fe3O4
-     &                   , AC, SiO2D, MgO, FeS, Al2O3
-     &                   , reforg, volorg, H2Oice
-     &                   , immulti, imabund, idspecies, itdmulti, idsub
-     &                   , metal_loc
-     &                   , metal_C13, metal_C20, metal_C25, metal_C30
-     &                   , metal_F13, metal_F15, metal_F50, metal_F80
-     &                   , metal_P170, metal_P200, metal_Y19
-     &                   , SN0_N
-     &                   , SN0_XC, SN0_XO, SN0_XMg, SN0_XAl, SN0_XSi
-     &                   , SN0_XS, SN0_XFe
-     &                   , SN0_fC, SN0_fO, SN0_fMg, SN0_fAl, SN0_fSi
-     &                   , SN0_fS, SN0_fFe
-     &                      )
-#endif
-
-      endif
-
 !  Convert densities from comoving to proper
 
       if (iexpand .eq. 1) then
@@ -5329,9 +5293,7 @@ C           enddo
 !     Correct densities by keeping fractions the same
 
       do i = is+1, ie+1
-!        Only include D/H ratio if using D species
-         correctH = real(fh*(1._DKIND - my_dtoh)*metalfree(i)/totalH(i),
-     &        RKIND)
+         correctH = real(fh*metalfree(i)/totalH(i), RKIND)
          HI(i,j,k)  = HI(i,j,k)*correctH
          HII(i,j,k) = HII(i,j,k)*correctH
 


### PR DESCRIPTION
This reverts two changes in newchem-cpp that, after discussion, we decided were not critical. These changes are:

1. removal of a call to make_consistent_g that was added to the top of solve_rate_cool_g. Eventually, we will change the behavior of the conservation step to preserving the total species densities present before the solve rather than trying to adhere to cosmic constants like the H mass fraction and D/H ratio.
2. removal of a small correction to the H conservation to account for deuterium. This is a very small correction that will similarly be redone when the above changes occur.

The main benefits of reverting both these changes is that we get a little bit closer to getting the tests to pass with the original answers. @mabruzzo, I misspoke the other day when I stated that reverting these alone will cause the tests to pass. This is only strictly true when setting `UVBackground=0`. There is currently one more behavior change involving the UV background that I need to work out. *Then*, the tests should pass.