### PR TITLE
Warn about usage of deprecated headers

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(Grackle_Grackle
   # C/C++ public headers
   ../include/grackle.h
   ../include/grackle_chemistry_data.h
+  ../include/grackle_misc.h
   ../include/grackle_rate_functions.h
   ../include/grackle_types.h
 

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -256,3 +256,8 @@ target_compile_options(Grackle_Grackle PRIVATE
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "^(Linux)|(Darwin)$")
   target_compile_definitions(Grackle_Grackle PRIVATE "LINUX")
 endif()
+
+# define macro to suppress warnings about C files using our deprecated public
+# headers (the files should include grackle.h instead). We're currently holding
+# off on this to minimize conflicts with the newchem-cpp branch
+target_compile_definitions(Grackle_Grackle PRIVATE GRIMPL_PUBLIC_INCLUDE=1)

--- a/src/clib/Make.config.assemble
+++ b/src/clib/Make.config.assemble
@@ -192,8 +192,13 @@
                $(ASSEMBLE_LDFLAGS)
     LDOUTPUT_FLAGS = $(ASSEMBLE_LDOUTPUT_FLAGS)
 
+    # the use of -DGRIMPL_PUBLIC_INCLUDE=1 is a temporary measure until we
+    # modify all C/C++ source files to stop referencing the deprecated public
+    # headers (and include grackle.h instead). We're currently holding off on
+    # this to minimize conflicts with the newchem-cpp branch
     DEFINES = $(MACH_DEFINES) \
-              $(ASSEMBLE_IO_DEFINES)
+              $(ASSEMBLE_IO_DEFINES) \
+              -DGRIMPL_PUBLIC_INCLUDE=1
 
     PUBLIC_HEADER_SRCDIR = $(GRACKLE_DIR)/../include
     AUTOGEN_DIR = $(GRACKLE_DIR)/autogen

--- a/src/include/grackle.h
+++ b/src/include/grackle.h
@@ -14,6 +14,18 @@
 #ifndef __GRACKLE_H__
 #define __GRACKLE_H__
 
+// this logic must occur before including Grackle's headers
+#ifndef GRIMPL_PUBLIC_INCLUDE
+  #define GRIMPL_PUBLIC_INCLUDE 0
+#elif GRIMPL_PUBLIC_INCLUDE == 1
+  // we temporarily allow this case for internal use within the Grackle lib to
+  // avoid merge conflicts (external Grackle users shouldn't depend on this!)
+#else
+  #error "it is an error for GRIMPL_PUBLIC_INCLUDE to be defined"
+#endif /* GRIMPL_PUBLIC_INCLUDE */
+
+
+// include the private headers
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
 
@@ -135,5 +147,11 @@ int gr_initialize_field_data(grackle_field_data *my_fields);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* __cplusplus */
+
+
+// this is important for letting us diagnose improper use of private headrs
+#if GRIMPL_PUBLIC_INCLUDE == 0
+  #undef GRIMPL_PUBLIC_INCLUDE
+#endif
 
 #endif /* __GRACKLE_H__ */

--- a/src/include/grackle_chemistry_data.h
+++ b/src/include/grackle_chemistry_data.h
@@ -11,6 +11,17 @@
 / software.
 ************************************************************************/
 
+// this should go before the header-guard
+#ifndef GRIMPL_PUBLIC_INCLUDE
+  #include "grackle_misc.h"
+  GRIMPL_COMPTIME_WARNING(
+    "You are using a deprecated header file; include the public \"grackle.h\" "
+    "header file instead! In a future Grackle version, "
+    "\"grackle_chemistry_data.h\" may cease to exist (or contents may change "
+    "in an incompatible manner)."
+  );
+#endif
+
 #ifndef __CHEMISTRY_DATA_H__
 #define __CHEMISTRY_DATA_H__
 

--- a/src/include/grackle_float.h.in
+++ b/src/include/grackle_float.h.in
@@ -1,3 +1,24 @@
+#if defined(__STDC__) || defined(__cplusplus)
+  // this block is hidden from all Fortran compilers
+  // -> the block will also be hidden from K&R C compilers (i.e. pre C89).
+  //    This is ok since this block just implements a warning. Frankly, I
+  //    suspect K&R C may be incompatible with Grackle.
+  // -> the alternative to hiding this block from K&R C is defining a special
+  //    macro (maybe GRIMPL_FORTRAN_LANG) before this file is included in each
+  //    relevant `.def` file.
+
+  // this logic should occur before the header guards
+  #ifndef GRIMPL_PUBLIC_INCLUDE
+    #include "grackle_misc.h"
+    GRIMPL_COMPTIME_WARNING(
+      "You are using a deprecated header file; include the public "
+      "\"grackle.h\" header file instead! In a future Grackle version, "
+      "\"grackle_float.h\" may cease to exist (or contents may change in an "
+      "incompatible manner)."
+    );
+  #endif
+#endif
+
 #ifndef __GRACKLE_FLOAT_H__
 #define __GRACKLE_FLOAT_H__
 #define @GRACKLE_FLOAT_MACRO@

--- a/src/include/grackle_misc.h
+++ b/src/include/grackle_misc.h
@@ -1,0 +1,34 @@
+// This existence of this header file is considered an implementation detail
+// - it's an error for external project to directly include this file. Any
+//   external project directly include this file can/will start encountering
+//   problems @ an arbitrary point in the future
+// - the only reason we don't currently abort with an error is so we can
+//   gracefully warn about deprecated headers without introducing lots of
+//   complex preprocessor logic
+
+
+#ifndef GRACKLE_MISC_H
+#define GRACKLE_MISC_H
+
+/// @def GRIMPL_COMPTIME_WARNING(MSG)
+/// @brief Internal macro used to produces a compile-time warning with the
+///     specified message (it should be a string literal). This exists because
+///     `#warning` is a non-standard extension (before C23 and C++23). On less
+///     popular compilers, this is a no-op
+///
+/// @note
+/// The use of GRIMPL_DO_PRAGMA is based on gcc documentation
+/// https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html
+
+#define GRIMPL_DO_PRAGMA(x) _Pragma(#x)
+#ifdef __GNUC__
+  // Modern versions of mainstream compilers that masquerade as gcc (like
+  // clang or intel), understand the pragma used to implement this macro.
+  // - Any compiler that don't understand it will treat it as a no-op (as
+  //   mandated by the C and C++ standards).
+  #define GRIMPL_COMPTIME_WARNING(MSG) GRIMPL_DO_PRAGMA(GCC warning MSG)
+#else
+  #define GRIMPL_COMPTIME_WARNING(MSG) /* no-op */
+#endif
+
+#endif /* GRACKLE_MISC_H */

--- a/src/include/grackle_rate_functions.h
+++ b/src/include/grackle_rate_functions.h
@@ -1,8 +1,8 @@
 // Header file containing all rate function declarations.
-#include "grackle_chemistry_data.h"
+#include "grackle.h"
 
-#ifndef RATE_FUNCTIONS_H
-#define RATE_FUNCTIONS_H
+#ifndef GRACKLE_RATE_FUNCTIONS_H
+#define GRACKLE_RATE_FUNCTIONS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,4 +97,4 @@ double gamma_isrf_rate(double units, chemistry_data *my_chemistry);
 } /* extern "C" */
 #endif /* __cplusplus */
 
-#endif /* RATE_FUNCTIONS_H */
+#endif /* GRACKLE_RATE_FUNCTIONS_H */

--- a/src/include/grackle_types.h
+++ b/src/include/grackle_types.h
@@ -11,6 +11,17 @@
 / software.
 ************************************************************************/
 
+// this should go before the header-guard
+#ifndef GRIMPL_PUBLIC_INCLUDE
+  #include "grackle_misc.h"
+  GRIMPL_COMPTIME_WARNING(
+    "You are using a deprecated header file; include the public \"grackle.h\" "
+    "header file instead! In a future Grackle version, \"grackle_types.h\" "
+    "may cease to exist (or contents may change in an incompatible manner)."
+  );
+#endif
+
+
 #ifndef __GRACKLE_TYPES_H__
 #define __GRACKLE_TYPES_H__
 /***********************************************************************

--- a/src/python/pygrackle/grackle_defs.pxd
+++ b/src/python/pygrackle/grackle_defs.pxd
@@ -1,8 +1,10 @@
-cdef extern from "grackle_types.h":
+cdef extern from "grackle.h":
+
     # This does not need to be exactly correct, only of the right basic type
     ctypedef float gr_float
 
-cdef extern from "grackle_chemistry_data.h":
+    # currently defined within "grackle_chemistry_data.h"
+    # ---------------------------------------------------
     ctypedef struct c_chemistry_data "chemistry_data":
         # no need to declare the members since there is no cython code that
         # directly accesses the struct members (dynamic api is used instead)
@@ -119,7 +121,8 @@ cdef extern from "grackle_chemistry_data.h":
         double hei_avg_crs
         double heii_avg_crs
 
-cdef extern from "grackle_types.h":
+    # currently defined within "grackle_types.h"
+    # ------------------------------------------
     ctypedef struct c_code_units "code_units":
       int comoving_coordinates
       double density_units
@@ -171,7 +174,9 @@ cdef extern from "grackle_types.h":
       const char* branch;
       const char* revision;
 
-cdef extern from "grackle.h":
+
+    # defined in "grackle.h"
+    # ----------------------
     cdef int GRACKLE_FAIL_VALUE "GR_FAIL"
     cdef int GR_SPECIFY_INITIAL_A_VALUE
 


### PR DESCRIPTION
In a prior PR, we deprecated some of the public headers. This PR adds some processor logic to detect when external code includes one of the deprecated headers and warns the person compiling the code (at compile time) that they should just `#include "grackle.h"` instead.

I added some logic to suppress this warning when compiling the core grackle library (I want to fix this, but it will create some merge conflicts with the newchem-cpp branch if we aren't careful). I also tweaked the pygrackle logic so that it only touches `grackle.h`.

I sorta just maintained the status quo with `grackle_rate_functions.h`. It could probably use some attention, but I'm not totally sure what the best way to handle it is...