### PR TITLE
Backport some minor bugfixes

### DIFF
--- a/cmake/AddConditionalFortranFlags.cmake
+++ b/cmake/AddConditionalFortranFlags.cmake
@@ -82,9 +82,7 @@ function(add_conditional_fortran_flags target)
     fc_warn_untested() # things compile, but tests haven't been run
     fc_warn_ninja() # issues encountered with ninja with cmake version 3.27.7
 
-    # it's worrisome to pass -qhalt=s (it suppress certain classes of errors),
-    # but it's currently necessary for cool1d_cloudy_old_tables_g.F
-    set(GRACKLE_FC_FLAG "-qfixed=132;-qhalt=s")
+    set(GRACKLE_FC_FLAG "-qfixed=132")
 
   elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     set(GRACKLE_FC_FLAG "-fno-second-underscore;-ffixed-line-length-132")

--- a/src/clib/cool1d_cloudy_old_tables_g.F
+++ b/src/clib/cool1d_cloudy_old_tables_g.F
@@ -71,7 +71,7 @@
 !  Cloudy parameters and data
 
       integer icmbTfloor, iClHeat
-      integer*8 clGridRank, clDataSize, clGridDim(3)
+      integer*8 clGridRank, clDataSize, clGridDim(5)
       real*8 clEleFra
       real*8 clPar1(clGridDim(1)), clPar2(clGridDim(2)),
      &     clPar3(clGridDim(3)), clPar4(clGridDim(4)),

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <math.h>
 #include "hdf5.h"
+#include "grackle.h"
 #include "grackle_macros.h"
 #include "grackle_types.h"
 #include "grackle_chemistry_data.h"
@@ -334,4 +335,5 @@ int _free_cloudy_data(cloudy_data *my_cloudy, chemistry_data *my_chemistry, int 
   if (my_chemistry->primordial_chemistry == 0 && primordial) {
     GRACKLE_FREE(my_cloudy->mmw_data);
   }
+  return GR_SUCCESS;
 }

--- a/src/clib/initialize_rates.c
+++ b/src/clib/initialize_rates.c
@@ -83,10 +83,9 @@
 #include <stdio.h>
 #include <math.h>
 
+#include "grackle.h"
 #include "grackle_macros.h"
-#include "grackle_types.h"
 #include "grackle_rate_functions.h"
-#include "grackle_chemistry_data.h"
 #include "phys_constants.h"
 
 //Define the type of a scalar rate function.
@@ -205,6 +204,7 @@ int add_h2dust_reaction_rate(double **rate_ptr, double units, chemistry_data *my
             (*rate_ptr)[i + my_chemistry->NumberOfTemperatureBins*j] = h2dust_rate(T, T_dust, units, my_chemistry);
         }
     }
+    return GR_SUCCESS;
 }
 
 //Definition of the initialise_rates function.

--- a/src/clib/rate_functions.c
+++ b/src/clib/rate_functions.c
@@ -1274,6 +1274,19 @@ double cie_thin_cooling_rate(double T){
                    / ( t_cie_c[maxInd] - t_cie_c[minInd] );
         }
     }
+
+    // the following logic was added as a quick way to address the compiler
+    // warnings about a control flow that doesn't return get addressed.
+    // - In the future, we may want to consider a way to handle failure more
+    //   gracefully (if failure is even possible)
+    // - for now, loudly exitting with a failure is better than quietly
+    //   continuing with a garbage value
+    fprintf(
+      stderr,
+      "INTERNAL ERROR: something went horribly wrong while computing the "
+      "optically thin cooling rate due to CIE cooling. Aborting\n"
+    );
+    abort();
 }
 
 //Calculation of cieco.

--- a/src/example/c_local_example.c
+++ b/src/example/c_local_example.c
@@ -245,5 +245,7 @@ int main(int argc, char *argv[])
 
   fprintf(stdout, "dust_temperature = %24.16g K\n", dust_temperature[0]);
 
+  local_free_chemistry_data(my_grackle_data, &my_grackle_rates);
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This backports a bunch of minor bugfixes from #273. These are long-standing bugs that result in prominent compiler warnings that are very visible when you use the CMake build-system.[^1] This includes 3 tiny commits:

1. A commit from @ChristopherBignamini that resolved a long-standing bug within `cool1D_cloudy_old_tables_g`
2. A commit removing a relevant flag for the IBM Fortran compiler (from the CMake build system) that existed due to the above bug[^2]
3. A commit that fixes a handful of c functions had a `[-Wreturn-type]` compiler warning where a function was supposed to return a value but had at least 1 control flow branch where we didn't return anything.

While I don't think the bugs actually affected results, I think they should be merged in before the 3.4 release

[^1]: Historically the classic build-system suppressed these warnings unless you explicitly modified the primary Makefile to use ``VERBOSE=1``.
[^2]: I have not tested it (I can't, since I don't have access to the relevant compiler). But that should be absolutely fine since (i) I was the one who added the flag, and (ii), to my knowledge, nobody has ever run the Grackle test-suite using that compiler and the CMake build-system (i.e. we are no worse off than before).