### PR TITLE
Updating the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Our [method paper](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S) provides m
 
 ## Projects that provide out-of-the-box support for Grackle
 
+Grackle is a popular tool (the [method paper](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S) has over 275 citations) and has been used in a wide variety of calculations.
+Below, we list open source projects that provide out-of-the-box support for Grackle:
+
 [ChaNGa](https://github.com/N-BodyShop/changa),
 [Cholla](https://github.com/cholla-hydro/cholla),
 [Enzo](https://enzo-project.org/),

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The library offers
 
 - support for user-provided arrays of volumetric and specific heating rates.
 
-Our [method paper](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S) and [capabilities guide](https://grackle.readthedocs.io/en/latest/CapabilityGuide.html#grackle-s-capabilities) provide more information.
+Our [method paper](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S) provides more information.
 
 ## Projects that provide out-of-the-box support for Grackle
 
@@ -87,7 +87,7 @@ To help you start using Grackle, we provide:
 - a [Usage Guide](https://grackle.readthedocs.io/en/latest/Interaction.html)
 - example Grackle programs written in [C, C++, and Fortran](https://github.com/grackle-project/grackle/tree/main/src/example)
 - an [Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) (for linking Grackle)
-- a curated [guide](https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts) for the [Pygrackle examples](https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts)
+- a curated [guide](https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts) for the Pygrackle examples
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,62 +4,97 @@
 [![CircleCI](https://circleci.com/gh/grackle-project/grackle/tree/main.svg?style=svg)](https://circleci.com/gh/grackle-project/grackle/tree/main)
 [![Documentation Status](https://readthedocs.org/projects/grackle/badge/?version=latest)](https://grackle.readthedocs.io/en/latest/?badge=latest)
 
-Grackle is a chemistry and radiative cooling library for astrophysical
-simulations and models.  Grackle has interfaces for C, C++, Fortran, and
-Python codes and provides:
+[Documentation](https://grackle.readthedocs.io/en/latest/) |
+[Installation](https://grackle.readthedocs.io/en/latest/Installation.html) |
+[Pygrackle Installation](https://grackle.readthedocs.io/en/latest/Python.html) |
+[Usage Guide](https://grackle.readthedocs.io/en/latest/Interaction.html) |
+[Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) |
+[Contributing](https://grackle.readthedocs.io/en/latest/Contributing.html) |
+[Getting Help](https://grackle.readthedocs.io/en/latest/Help.html)
 
-- two options for primordial chemistry and cooling:
+Grackle is a chemistry and radiative cooling library for astrophysical simulations and models.
+The core library provides interfaces for C, C++ and Fortran simulation codes.
+The project also offers the Pygrackle package to provide Python bindings.
 
-   1. non-equilibrium primordial chemistry network for atomic H, D, and He
-   as well as H<sub>2</sub> and HD, including H<sub>2</sub> formation on dust grains.
+## Features
 
-   2. tabulated H and He cooling rates calculated with the photo-ionization
-      code, [Cloudy](http://nublado.org).
+Grackle provides functions to update chemistry species; solve radiative
+cooling and update internal energy; and calculate cooling time, temperature,
+pressure, and ratio of specific heats (γ).
+The library offers
+
+- two options for primordial chemistry and cooling. It can (i) evolve a non-equilibrium chemistry network  **OR** (ii) use tabulated cooling rates calculated with the photo-ionization code, [Cloudy](http://nublado.org).
 
 - tabulated metal cooling rates calculated with [Cloudy](http://nublado.org).
 
-- photo-heating and photo-ionization from two UV backgrounds with optional
-  self-shielding corrections:
-
-   1. [Faucher-Giguere et al. (2009)](http://adsabs.harvard.edu/abs/2009ApJ...703.1416F).
-
-   2. [Haardt & Madau (2012)](http://adsabs.harvard.edu/abs/2012ApJ...746..125H).
+- photo-heating and photo-ionization (with optional self-shielding corrections) from either the [Faucher-Giguere et al. (2009)](http://adsabs.harvard.edu/abs/2009ApJ...703.1416F) or [Haardt & Madau (2012)](http://adsabs.harvard.edu/abs/2012ApJ...746..125H) UV backgrounds.
 
 - support for user-provided arrays of volumetric and specific heating rates.
 
-The Grackle provides functions to update chemistry species; solve radiative
-cooling and update internal energy; and calculate cooling time, temperature,
-pressure, and ratio of specific heats (gamma).
+Our [method paper](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S) and [capabilities guide](https://grackle.readthedocs.io/en/latest/CapabilityGuide.html#grackle-s-capabilities) provide more information.
 
-For more information on features, installation, and integration with simulation
-codes and models, see our [online documentation](https://grackle.readthedocs.io/).
+## Projects that provide out-of-the-box support for Grackle
 
-## Software that uses Grackle
+[ChaNGa](https://github.com/N-BodyShop/changa),
+[Cholla](https://github.com/cholla-hydro/cholla),
+[Enzo](https://enzo-project.org/),
+[Enzo-E](https://enzo-e.readthedocs.io/en/latest/),
+[Gamer](https://github.com/gamer-project/gamer),
+[Gasoline](https://github.com/N-BodyShop/gasoline),
+[GIZMO](http://www.tapir.caltech.edu/~phopkins/Site/GIZMO.html),
+[Swift](https://github.com/SWIFTSIM/SWIFT)
 
-A (non-exhaustive) list of software that provides out-of-the-box support for using Grackle includes:
+> We welcome PRs to add your simulation code (or python package) to this list.
 
-- [ChaNGa](https://github.com/N-BodyShop/changa)
+## Getting Grackle
 
-- [Cholla](https://github.com/cholla-hydro/cholla)
+Currently, Grackle must be built from source.
+If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you.
 
-- [Enzo](https://enzo-project.org/)
+If you contribute to a simulation code, our [Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) provides guidance on simplifying the process (for you and your users) of configuring your code to use Grackle.
 
-- [Enzo-E](https://enzo-e.readthedocs.io/en/latest/)
+### Building the Core Grackle Library From Source
 
-- [Gamer](https://github.com/gamer-project/gamer)
+Grackle requires a C99 compiler, a Fortran compiler, and HDF5 (1.6 or newer).
+On most platforms, compilation with the CMake build system (3.16 or newer) is as simple as:
 
-- [Gasoline](https://github.com/N-BodyShop/gasoline)
+```shell
+cmake -B build          # configure the build-directory
+cmake --build ./build   # perform the build
+```
 
-- [GIZMO](http://www.tapir.caltech.edu/~phopkins/Site/GIZMO.html)
+You can run invoke the examples from within the ``build/examples`` directory.[^1]
+To build Grackle as a shared lib, replace the first command with ``cmake -DBUILD_SHARED_LIBS=ON -Bbuild``.
+To install Grackle, invoke ``cmake --install ./build [--prefix <prefix/path>]`` (the optional part lets you specify an install-path).
 
-- [Swift](https://github.com/SWIFTSIM/SWIFT)
+For more details **(especially if you encounter any errors),** see our comprehensive [Installation Guide](https://grackle.readthedocs.io/en/latest/Installation.html).
+It provides more context for inexperienced CMake users, describes additional configuration options (relevant if you encounter issues), and describes Grackle's "classic" build-system.
 
-We welcome PRs to add your simulation code to this list. We also welcome the inclusion of python modules that depend on Pygrackle.
+### Building Pygrackle from Source
 
-## Resources
+Once you have a Fortran compiler and a copy of HDF5 (1.6 or newer), simply invoke the following from the root of the Grackle repository
 
-- documentation: https://grackle.readthedocs.io/
+```shell
+~/grackle $ pip install .
+```
 
-- source code repository: https://github.com/grackle-project/grackle
+For more about installation see our [Pygrackle installation guide](https://grackle.readthedocs.io/en/latest/Python.html).
 
-- method paper: [Smith et al. (2017)](http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S)
+## Getting Started
+
+To help you start using Grackle, we provide:
+
+- a [Usage Guide](https://grackle.readthedocs.io/en/latest/Interaction.html)
+- example Grackle programs written in [C, C++, and Fortran](https://github.com/grackle-project/grackle/tree/main/src/example)
+- an [Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) (for linking Grackle)
+- a curated [guide](https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts) for the [Pygrackle examples](https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts)
+
+## Contributing
+
+Grackle is a community project!
+We welcome patches, features, and bugfixes from any member of the community!
+For more details, please see our [Constribution Guide](https://grackle.readthedocs.io/en/latest/Contributing.html) and our [Code of Conduct](https://grackle.readthedocs.io/en/latest/Conduct.html)
+
+
+[^1]: You currently **NEED** to invoke the examples from the directory where they are located.
+      We have a ["fix" in the pipeline](https://github.com/grackle-project/grackle/pull/246) to make this more flexible.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,36 +6,76 @@
 Welcome to grackle's documentation!
 ===================================
 
-Grackle is a chemistry and radiative cooling library for astrophysical 
-simulations and models.  Grackle has interfaces for C, C++, Fortran, and
-Python codes and provides:
+Grackle is a chemistry and radiative cooling library for astrophysical simulations and models.
+The core library provides interfaces for C, C++ and Fortran simulation codes.
+The project also offers the Pygrackle package to provide Python bindings.
 
-- two options for primordial chemistry and cooling:
+Features
+--------
+Grackle provides functions to update chemistry species; solve radiative
+cooling and update internal energy; and calculate cooling time, temperature,
+pressure, and ratio of specific heats (γ).
+The library offers
 
-   1. non-equilibrium primordial chemistry network for atomic H, D, and He
-      as well as H\ :sub:`2`\  and HD, including H\ :sub:`2`\  formation on
-      dust grains.
-
-   2. tabulated H and He cooling rates calculated with the photo-ionization
-      code, `Cloudy <http://nublado.org>`_.
+- two options for primordial chemistry and cooling. It can (i) evolve a non-equilibrium chemistry network  **OR** (ii) use tabulated cooling rates calculated with the photo-ionization code, `Cloudy <http://nublado.org>`_.
 
 - tabulated metal cooling rates calculated with `Cloudy <http://nublado.org>`_.
 
-- photo-heating and photo-ionization from two UV backgrounds:
-
-   1. `Faucher-Giguere et al. (2009) <http://adsabs.harvard.edu/abs/2009ApJ...703.1416F>`_.
-
-   2. `Haardt & Madau (2012) <http://adsabs.harvard.edu/abs/2012ApJ...746..125H>`_.
+- photo-heating and photo-ionization (with optional self-shielding corrections) from either the `Faucher-Giguere et al. (2009) <http://adsabs.harvard.edu/abs/2009ApJ...703.1416F>`_ or `Haardt & Madau (2012) <http://adsabs.harvard.edu/abs/2012ApJ...746..125H>`_ UV backgrounds.
 
 - support for user-provided arrays of volumetric and specific heating rates.
 
-The Grackle provides functions to update chemistry species; solve radiative 
-cooling and update internal energy; and calculate cooling time, temperature, 
-pressure, and ratio of specific heats (gamma).
+Our `method paper <http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S>`__ provides more information.
 
-Contents:
+Getting Grackle
+---------------
+
+Currently, Grackle must be built from source.
+If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you.
+
+If you contribute to a simulation code, our `Integration Guide <https://grackle.readthedocs.io/en/latest/Integration.html>`__ provides guidance on simplifying the process (for you and your users) of configuring your code to use Grackle.
+
+Building the Core Grackle Library From Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Grackle requires a C99 compiler, a Fortran compiler, and HDF5 (1.6 or newer).
+On most platforms, compilation with the CMake build system (3.16 or newer) is as simple as:
+
+.. code-block:: shell-session
+
+   cmake -B build          # configure the build-directory
+   cmake --build ./build   # perform the build
+
+You can run invoke the examples from within the ``build/examples`` directory.[^1]
+To build Grackle as a shared lib, replace the first command with ``cmake -DBUILD_SHARED_LIBS=ON -Bbuild``.
+To install Grackle, invoke ``cmake --install ./build [--prefix <prefix/path>]`` (the optional part lets you specify an install-path).
+
+For more details **(especially if you encounter any errors),** see our comprehensive `Installation Guide <https://grackle.readthedocs.io/en/latest/Installation.html>`__.
+It provides more context for inexperienced CMake users, describes additional configuration options (relevant if you encounter issues), and describes Grackle's "classic" build-system.
+
+Building Pygrackle from Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you have a Fortran compiler and a copy of HDF5 (1.6 or newer), simply invoke the following from the root of the Grackle repository
+
+.. code-block:: shell-session
+
+   ~/grackle $ pip install .
+
+For more about installation see our `Pygrackle installation guide <https://grackle.readthedocs.io/en/latest/Python.html>`__.
+
+Getting Started
+---------------
+
+To help you start using Grackle, we provide:
+
+- a `Usage Guide <https://grackle.readthedocs.io/en/latest/Interaction.html>`__
+- example Grackle programs written in `C, C++, and Fortran <https://github.com/grackle-project/grackle/tree/main/src/example>`__
+- an `Integration Guide <https://grackle.readthedocs.io/en/latest/Integration.html>`__ (for linking Grackle)
+- a curated `guide <https://grackle.readthedocs.io/en/latest/Python.html#running-the-example-scripts>`__ for the Pygrackle examples
 
 .. toctree::
+   :hidden:
    :maxdepth: 2
 
    Installation.rst


### PR DESCRIPTION
EDIT: This has been modified so that it can be reviewed now.

----------

## Overview

This is a significant update to the README. The primary impetus for doing this is to emphasize just how easy the new build system is to use![^1]

I also modernized some other parts of the "README" (e.g. added quickstart info, added more links, made some sections a little more concise)

## Detailed Changes

- adding links to various resources at the top of the page.
- slightly tweaking the blurb about Grackle at the top of the page
- Separating the discussion of Features into a separate section and slightly shortening it.[^2]
- I reformatted the list of projects that provide out-of-the-box support for Grackle 
- I added a short section on "getting Grackle." The point is to emphasize how quick and easy this is.
- Addition of a "Getting Started" section and a "Contributing" section. These try to point people to the relevant pages of documentation.

I also added a bunch of this information to the documentation's landing page (`index.rst`).

## Thoughts on convert to README.rst?

In the future, it might be nice to convert `README.md` to `README.rst` and using the `.. include` directive within `index.rst` so that we can automatically keep the documentation's landing page synchronized with the README. Do we have any thoughts? (this obviously isn't important for this PR)

[^1]: If you are vaguely familiar with CMake, then building Grackle simply involves 2 or 3 standard commands. This simplicity isn't obvious at quick glance of the Installation Guide (which provides a thorough explanation to make sure that people inexperienced with CMake can still install Grackle).
[^2]: In the future, I would actually like to make this a little shorter, by pointing people to the doc-page proposed in #292 -- you can think of that page as a "capability guide"