### PR TITLE
Add more detail to pygrackle build documentation

### DIFF
--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -85,7 +85,7 @@ While the above command should "just work," you have a few options for customizi
 
          You can either:
 
-            1. use the :envvar:`!SKBUILD_CMAKE_ARGS` env variable, where each argument is separated by a semicolong (e.g. ``"-DCMAKE_C_COMPILER=gcc-14;-DHDF5_ROOT=/path/to/hdf5"``).
+            1. use the :envvar:`!SKBUILD_CMAKE_ARGS` env variable, where each argument is separated by a semicolon (e.g. ``"-DCMAKE_C_COMPILER=gcc-14;-DHDF5_ROOT=/path/to/hdf5"``).
             2. use the :envvar:`!CMAKE_ARGS` env variable, where each argumenjt is separated by a space (e.g. ``"-DCMAKE_C_COMPILER=gcc-14 -DHDF5_ROOT=/path/to/hdf5"``).
 
 .. tip::
@@ -384,5 +384,5 @@ loaded dataset. Optionally, parameters can be specified manually to override.
 .. rubric:: Footnotes
 
 .. [#f1] When you want to overwrite a flag in a CMake build, we generally encourage use of CMake-specific counterparts to environment variables (e.g. prefer passing ``-DCMAKE_C_COMPILER=<blah>`` on the command-line to exporting ``CC=<blah>``), since the former has precedence and is more case.
-         However, in this case of driving a python build (that internally creates a CMake build, installs the products, and cleans up the build-directory), the use of environment variables is somewhat more common.
+         However, in this case of driving a python build (that internally creates a CMake build, installs the products, and cleans up the build directory), the use of environment variables is somewhat more common.
          Plus, the flags follow fairly standard Unix conventions.

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -61,7 +61,7 @@ If a new enough version of CMake cannot be found, the above command will automat
 
 While the above command should "just work," you have a few options for customizing the build:
 
-1. In most cases, you probably want to use the standard environment variables directly understood by CMake: [#f1]_
+1. In most cases, you probably want to use the standard environment variables directly understood by CMake:\ [#f1]_
 
    - you can specifiy your choice of C and Fortran compilers that are used for this by manipulating the :envvar:`!CC` and :envvar:`!FC` environment variables.
    - if you must pass extra compiler flags to all invocations of the C or Fortran compiler (this *shouldn't* really be necessary), you can use the :envvar:`!CFLAGS` or :envvar:`!FFLAGS` environment variable.


### PR DESCRIPTION
For the embedded pygrackle build:

- I tried to make the existing documentation a little more clear
- I tried to make it more clear how you might resolve issues when the build-system can't locate the HDF5 library (99% of the time, this should not be a problem)
- I also tried to make it clear how you might customize the build of the core grackle library (that occurs as part of the pygrackle build)