### PR TITLE
2 minor (but important) googletest-related CMake tweaks

### DIFF
--- a/cmake/setup_GTest.cmake
+++ b/cmake/setup_GTest.cmake
@@ -3,9 +3,7 @@ find_package(GTest)
 
 if (NOT GTest_FOUND)
     message(STATUS
-    "Preparing to download GTest from GitHub & configure its build. Don't "
-    "worry about any mentions of Python in the following text -- that is "
-    "only used internally by the Google test build"
+      "GTest not found. Fetching via FetchContent and configuring its build"
     )
 
     # NOTE: it is idiomatic to use FetchContent with a git hash rather than the
@@ -15,10 +13,13 @@ if (NOT GTest_FOUND)
 
     include(FetchContent)
     FetchContent_Declare(
-      googletest # the url contains the hash for v1.13.0
-      URL https://github.com/google/googletest/archive/b796f7d44681514f58a683a3a71ff17c94edb0c1.zip
+      googletest # the url contains the hash for v1.15.2
+      URL https://github.com/google/googletest/archive/b514bdc898e2951020cbdca1304b75f5950d1f59.zip
     )
 
+    # Tell GoogleTest's build-system not to define installation rules (since we
+    # only use it to run tests from the build-directory)
+    set(INSTALL_GTEST OFF)
     # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
This makes 2 very minor (but important changes):

1. Most importantly, it tells the googletest build-system not to define "installation rules". Prior to this change, building Grackle with the unit tests would make `cmake --install` install Googletest headers/libraries alongside Grackle headers/libraries (this is unnecessary for using googletest and undesirable).
2. It bumps the default version of googletest that we use from 1.13 to 1.15.2. The build-system included in the newer version has slightly saner defaults. Importantly, Grackle's CMake build-system will no longer print (potentially confusing/concerning) messages about searching for Python.[^1]

I really want to get this merged in before we bump the gold-standard. There is a special streamlined workflow for more easily running all tests (I'm working on documenting it). But I don't want to document it unless the gold-standard has the first fix described here.

[^1]: In slightly more detail, the googletest framework uses Python to run some of the tests of the framework itself. Earlier versions of googletest's CMake build-system would look for all testing dependencies even if the build wasn't configured to run the tests of the framework, itself. This is now fixed in the newer version.