### PR TITLE
Introduce a warning discouraging people from using ``pygrackle.utilities.data_path.grackle_data_dir`` in external code

### DIFF
--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -191,6 +191,11 @@ Editable Install Requirement
 All of the example scripts discussed below use the following line to
 make a guess at where the Grackle input files are located.
 
+.. caution::
+
+   This snippet is **NOT** part of the public API.
+   It is a short-term solution that is being used until functionality proposed by `GitHub PR #237 <https://github.com/grackle-project/grackle/pull/237>`__ can be reviewed.
+
 .. code-block:: python
 
    from pygrackle.utilities.data_path import grackle_data_dir


### PR DESCRIPTION
FYI: I don't care strongly about this PR. I proposed it because I think it's generally a "good idea." If you feel strongly one way or the other, I would be fine with simply closing this PR (but we need to decide one way or the other before 3.4). 

-----

PR #237 proposes an alternative (more robust approach) for managing data file locations (I can go into more detail).  Importantly it provides a standard way to specify a datafile's location across C, C++, Fortran, and Python.

While it is possible to continue supporting `pygrackle.utilities.data_path.grackle_data_dir` (indeed, this is what #237 currently does), we may not want to do that. As a general rule, I think it would be better if we encouraged people to use a single approach across all languages[^1] rather than telling them they can use `pygrackle.utilities.data_path.grackle_data_dir` in python and doing something else in the other languages.

By adding the warning now, we give ourselves the option to change our minds later. (This is more important since `pygrackle.utilities.data_path.grackle_data_dir` is a variable, which is much harder to gracefully deprecate later)

[^1]: There are large exceptions to this policy. If we can provide a significantly more "ergonomic" way to do something in python that reduces the chance for error, then I think it's totally fine to support that in python. But, I don't really think that ``pygrackle.utilities.data_path.grackle_data_dir`` falls in this category