### PR TITLE
Fix bugs in $H_2$ self-shielding implementations in solve_rate_cool_g.F

### DIFF
--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -1437,7 +1437,7 @@ c -------------------------------------------------------------------
                   endif
                enddo
 !              (rho / divrho) is the Sobolev-like length in cell widths
-               l_H2shield = min(dx_cgs * d(i,j,k) / abs(divrho), xbase1)
+               l_H2shield = min(dx_cgs * d(i,j,k) / (2._DKIND * abs(divrho)), xbase1)
 
 !              User-supplied length-scale field.
                else if (iH2shield == 2) then
@@ -1470,7 +1470,7 @@ c -------------------------------------------------------------------
                x = 2.0E-15_DKIND * N_H2
                b_doppler = 1E-5_DKIND *
      &                 sqrt(2._DKIND * kboltz *
-     &                      tgas1d(i) / mass_h)
+     &                      tgas1d(i) / (2._DKIND * mass_h))
                f_shield = 0.965_DKIND /
      &              (1._DKIND + x/b_doppler)**aWG2019 +
      &              0.035_DKIND * exp(-8.5e-4_DKIND *


### PR DESCRIPTION
---
Fix bugs in $H_2$ self-shielding implementations
---

**Pull request summary**

Fix bugs in the Sobolev-like approximation in the $H_2$ self-shielding implementation.

**Describe your pull request**

There are two bugs in the Sobolev-like approximation formulas of the GRACKLE's $H_2$ self-shielding implementations. The code to implement is _[**solve_rate_cool_g.F**](https://github.com/grackle-project/grackle/blob/main/src/clib/solve_rate_cool_g.F)_. The two bugs are:

1. On Line [1473](https://github.com/grackle-project/grackle/blob/main/src/clib/solve_rate_cool_g.F#L1473), we compute the variable $b_5$ (or $b_{\text{Doppler}}$) to get the self-shielding factor using the fit in Equation 7 of [Wolcott-Green and Haiman 2019](https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2467W/abstract). Since the equation concerns the Doppler line broadening of $H_{2}$'s absorption band, the mass of $H_{2}$ should be used in stead of the mass of atomic hydrogen in this line (i.e., `2.0_DKIND * mass_h` instead of just `mass_h`).

2. On Line [1440](https://github.com/grackle-project/grackle/blob/main/src/clib/solve_rate_cool_g.F#L1440), the Sobolev-like length is calculated as $L_{Sob} = \rho/\nabla\rho$, following Equation 4 of [Gnedin et al 2009](https://ui.adsabs.harvard.edu/abs/2009ApJ...697...55G/abstract). However, in [Gnedin and Kravtsov 2011](https://ui.adsabs.harvard.edu/abs/2011ApJ...728...88G/abstract), the same author said that the equation in Gnedin et al 2009 had a typo and that a factor of 2 was missing in the denominator, and the correct equation should be $L_{Sob} = \rho/(2\nabla\rho)$ (Equation A10). Later work of this author [Gnedin and Draine 2014](https://ui.adsabs.harvard.edu/abs/2014ApJ...795...37G/abstract) also used $L_{Sob} = \rho/(2\nabla\rho)$ in their analysis. Therefore, a factor of 2 should be added to the formula on line 1201. 
