### PR TITLE
Minor tweak: differentiate between optional testing/documentation dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
               make install
               cd ../../ # go back to the root level
 
-              PYGRACKLE_LEGACY_LINK=classic pip install -v -e .[dev]
+              PYGRACKLE_LEGACY_LINK=classic pip install -v -e .[test]
             else # this branch builds grackle with cmake
 
               cmake -DGRACKLE_USE_DOUBLE=ON                   \
@@ -118,7 +118,7 @@ commands:
                     -Bbuild
               cmake --build build
               
-              Grackle_DIR=${PWD}/build pip install -v -e .[dev]
+              Grackle_DIR=${PWD}/build pip install -v -e .[test]
             fi
 
   install-standalone-pygrackle:
@@ -133,7 +133,7 @@ commands:
           command: |
             source $HOME/venv/bin/activate
             git checkout << parameters.tag >>
-            pip install -e .[dev]
+            pip install -e .[test]
 
   install-docs-dependencies:
     description: "Install dependencies for docs build."
@@ -216,7 +216,7 @@ commands:
             source $HOME/venv/bin/activate
             pip uninstall --yes pygrackle # it's ok if pygrackle wasn't installed yet
             git checkout << parameters.gold-standard-tag >>
-            pip install -e .[dev]
+            pip install -e .[test]
       - run-pygrackle-tests:
           omp: 'false'
           build_kind: 'standalone-pygrackle'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,13 @@ Source = 'https://github.com/grackle-project/grackle'
 Tracker = 'https://github.com/grackle-project/grackle/issues'
 
 [project.optional-dependencies]
-dev = [
-  'flake8',
-  'packaging',
-  'pytest',
-  'sphinx',
-  'sphinx-tabs',
-  'sphinx_rtd_theme',
+test = [
+  'flake8', 'packaging', 'pytest'
 ]
+doc = [
+  'sphinx', 'sphinx-tabs', 'sphinx_rtd_theme'
+]
+dev = ['pygrackle[doc,test]']
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
In the future, we can modify the CI to take advantage of this