### PR TITLE
tests: gracefully handle `yt_grackle` test-case when `YT_DATA_DIR` isn't defined

### DIFF
--- a/src/python/examples/yt_grackle.py
+++ b/src/python/examples/yt_grackle.py
@@ -22,11 +22,7 @@ from pygrackle.utilities.model_tests import model_test_format_version
 output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 
 DS_NAME = "IsolatedGalaxy/galaxy0030/galaxy0030"
-
-if 'YT_DATA_DIR' in os.environ:
-    ds_path = os.sep.join([os.environ['YT_DATA_DIR'], DS_NAME])
-else:
-    ds_path = DS_NAME
+ds_path = os.path.join(os.environ.get('YT_DATA_DIR', default='.'), DS_NAME)
 
 if __name__ == "__main__":
     # If we are running the script through the testing framework,
@@ -37,6 +33,11 @@ if __name__ == "__main__":
         input_index = int(sys.argv[2])
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
+
+        if 'YT_DATA_DIR' not in os.environ:
+            raise RuntimeError(
+                "YT_DATA_DIR env var must be defined when called by test suite"
+            )
 
     # Just run the script as is.
     else:

--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -36,12 +36,15 @@ def test_model(answertestspec, tmp_path, model_name, par_index, input_index):
         temporary directory that is named for the current test
     """
 
+    if (model_name == "yt_grackle") and ("YT_DATA_DIR" not in os.environ):
+        pytest.skip("YT_DATA_DIR env variable isn't defined")
+
     script_path = os.path.join(python_example_dir, f"{model_name}.py")
     command = f"{sys.executable} {script_path} {par_index} {input_index}"
 
     if True:
         rval = run_command(command, timeout=60, cwd=tmp_path)
-        assert rval
+        assert rval, "example didn't complete succesfully"
 
         output_basename = f"{model_name}_{par_index}_{input_index}.h5"
         output_file = os.path.join(str(tmp_path), output_basename)


### PR DESCRIPTION
Prior to this PR,  the `yt_grackle` test-case will fail with an error-message if the ``YT_DATA_DIR`` env variable isn't defined. This PR adds logic to gracefully skip the `yt_grackle` test-case in this scenario (with an explanatory message). This is something that has annoyed me for years.

While I would prefer a more robust solution, I think we should just go with this PR. We can always replace it later if we come up with something better.