### PR TITLE
Address Less Common CMake Configuration Issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,14 @@ endif()
 
 option(GRACKLE_USE_OPENMP "Use OpenMP" OFF)
 if (GRACKLE_USE_OPENMP)
+  if (CMAKE_GENERATOR STREQUAL "Ninja")
+    message(WARNING
+      "using Ninja with GRACKLE_USE_OPENMP=ON may cause compilation problems."
+      "The issues manifest as error with finding the \"omp_lib.h\" header "
+      "that is conditionally included by some Fortran source files when using "
+      "CMake. The quick fix is use Makefiles. See the docs for more info"
+    )
+  endif()
   find_package(OpenMP REQUIRED COMPONENTS C Fortran)
 endif()
 

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -255,7 +255,7 @@ This first table describes the Grackle-specific options to configure the build.
    * - ``GRACKLE_USE_DOUBLE``
      - Turn off to build Grackle with single precision.
      - ``"ON"``
-   * - ``GRACKLE_USE_OPENMP``
+   * - ``GRACKLE_USE_OPENMP``\ [#about-cmake-openmp]_
      - Turn on to build Grackle with OpenMP
      - ``"OFF"``
    * - ``GRACKLE_BUILD_TESTS``
@@ -392,6 +392,75 @@ While embedded builds currently respect ``GRACKLE_OPTIMIZATION_FLIST_INIT``, tha
 
    * after we update the minimum required CMake version for compiling Grackle to at least 3.19, we may transition to using these features.
 
+CMake Troubleshooting
++++++++++++++++++++++
+
+This section discusses how to resolve some common issues that could arise while building Grackle with the CMake build-system.
+
+"Could NOT find HDF5"
+~~~~~~~~~~~~~~~~~~~~~
+CMake could not find the hdf5 installation.
+
+If you are on a local machine (not a cluster) consider the following scenarios:
+
+* Did you remember to install hdf5?
+* If you installed hdf5 with a package manager, did you make sure that the package includes files for development?
+  (For example, apt commonly supports a ``libhdf5-<vers>`` package that only contains a shared library and a ``libhdf5-dev`` package that supports everything you need).
+
+If you are confident that HDF5 is installed, you can provide a hint about its location with the ``HDF5_ROOT`` cmake-configuration variable (you can also use ``HDF5_DIR``, but the semantics are a little different).
+
+.. _ninja-openmp:
+
+"Fatal Error: omp_lib.h: No such file or directory"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This error appears when configuring a CMake build using the `Ninja <https://ninja-build.org>`__ backend\ [#about-ninja]_ and with ``GRACKLE_USE_OPENMP=ON``.
+The most robust solution: **"have CMake use the default (Makefile) backend."**
+
+In more detail, this error seems related to a preprocessing step of Fortran source files that is related to Ninja.
+This preprocessing step may be for generating module dependency information (`as described here <https://cmake.org/cmake/help/latest/prop_tgt/Fortran_PREPROCESS.html>`__).
+
+.. note::
+
+   There are ongoing efforts to convert all internal source code from Fortran to C++.
+   By the 3.5 release, the core library should no longer contain any Fortran code (and this problem will be moot)
+
+.. COMMENT-BLOCK
+
+   I've only encountered this issue with gfortran (but I don't currently have any other Fortran compilers at my disposal).
+   It appears to be some kind of weird cross-reaction between the ``-fopenmp`` and ``-E`` flag.
+   I think we could probably work around this issue by injecting the following block of logic
+
+   .. code-block:: cmake
+
+     target_include_directories(Grackle_Grackle SYSTEM
+       PRIVATE $<$<BOOL:${GRACKLE_USE_OPENMP}>:${OpenMP_Fortran_INCLUDE_DIRS}>
+     )
+
+   But, I am not sure its worth the effort. As the next section notes, there are some generic issues with using Fortran
+
+Generic Fortran Compiler Errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are some well-known bugs between Fortran and CMake's `Ninja <https://ninja-build.org>`__ backend\ [#about-ninja]_ (these seem more prominent if you are using a compiler other than gfortran).
+You could try to update CMake and Ninja to their latest versions.
+The most robust solution: **"have CMake use the default (Makefile) backend."**
+
+.. note::
+
+   There are ongoing efforts to convert all internal source code from Fortran to C++.
+   By the 3.5 release, the core library should no longer contain any Fortran code (and this problem will be moot)
+
+
+.. COMMENT-BLOCK
+
+   I'm not totally sure that these problems are "real."
+   I encountered these issues almost a year ago when the CMake build-system was less polished -- it's possible that I resolved the underlying issues as I refined things.
+   I don't currently have access to non-CMake build files to try to replicate things.
+   (I honestly forgot about it until describing the omp_lib.h issues since the problems went away when I used the Makefile-backend or gfortran with the Ninja-backend)
+
+   I've only encountered this issue with gfortran (but I don't currently have any other Fortran compilers at my disposal).
+   It appears to be some kind of weird cross-reaction between the ``-fopenmp`` and ``-E`` flag.
+   I think we could probably work around this issue by injecting the following block of logic
 
 .. _classic_build:
 
@@ -677,14 +746,16 @@ For example, adding GPU-support with the likes of CUDA or HIP would involve link
 .. [#f1] For the uninitiated, Grackle performs "out of source builds," in which the build-artifacts, like generated headers, object files, linked libraries, are placed inside a build directory (rather than putting them inside the source-directory next to the source files).
          There are a couple of advantages to this approach such as (i) you can maintain multiple builds at the same time (e.g. if you are switching between development branches) or (ii) it's really easy to clean up from a build (you just delete the build-directory).
 
-
-
 .. [#f2] CMake boolean variables map a variety of values to ``true`` (e.g. ``1``, ``ON``, ``TRUE``, ``YES``, ``Y``) and a variety of values to ``false`` (e.g. ``0``, ``OFF``, ``FALSE``, ``NO``, ``N``).
+
+.. [#about-cmake-openmp] Using Ninja with ``GRACKLE_USE_OPENMP=ON`` has been known to cause compilation problems (more detail provided :ref:`here <ninja-openmp>`).
 
 .. [#f3] If you are simply following the above compilation instructions, you definitely don't need to worry about the distinction between a single-configuration generator (e.g. Makefiles and standard Ninja) and multi-configuration generators.
 
 .. [#f4] Aside: performing these 2 separate CMake builds compiles the source files the same number of times as the Classic build system.
          Behind the scenes, the classic build system always compile each source file twice (once with position independent code and once without).
 
-
-
+.. [#about-ninja] For the uninitiated: if you're simply following the above compilation instructions, you probably aren't using CMake's Ninja backend.
+   In more detail, CMake can be configured with different backends; on the command line, it uses Makefiles (by default) or Ninja.
+   Many CMake guides suggest using Ninja since its faster than Makefile (since it's a more specialized tool).
+   However, as noted above, this may cause some esoteric Fortran issues.

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -153,18 +153,20 @@ The remainder of this subsection is primarily intended for readers who are relat
 
    .. code-block:: shell-session
 
-      ~/grackle $ cmake --build <build-dir>
-      ~/grackle $ cmake --install <build-dir>
+      ~/grackle $ cmake --build <build-dir>    # the build-step
+      ~/grackle $ cmake --install <build-dir>  # the install-step
 
-   .. note::
+   .. hint::
 
-      The above commands show the most generic commands that can be executed.
+      The above snippet show the most generic commands that can be executed.
       Other tutorials that you see online may show slight variations in these commands (where you manually make the build directory) and then manually execute the build-system from within the build-directory...
 
    .. note::
 
-      Just like with the classic build-system, Grackle currently needs to be installed to be used.
-      If you install it in a non-standard location, then you also need to ensure that you properly set the LD_LIBRARY_PATH (or DYLD_LIBRARY_PATH on macOS) to make use of it.
+      In some cases, projects can use Grackle, built with CMake, with requiring a full installation.
+      But, for historical reasons, you should generally assume that an external project requires a full installation step (unless that's project tells you otherwise).
+
+      If you install Grackle in a non-standard location, then you also need to ensure that you properly set the ``LD_LIBRARY_PATH`` (or ``DYLD_LIBRARY_PATH`` on macOS) env variable to make use of it.
 
 
 4. Test your Build.

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -129,17 +129,17 @@ The remainder of this subsection is primarily intended for readers who are relat
       This is be specified via the ``CMAKE_INSTALL_PREFIX`` cmake configuration variable.
       On UNIX-like systems, it defaults to ``/usr/local/``.
 
-   To configure a build where Grackle is compiled as a static library, use
+   The following snippets illustrates how to configure Grackle as a static/shared library:
 
-   .. code-block:: shell-session
+   .. tabs::
 
-      ~/grackle $ cmake -DCMAKE_INSTALL_PREFIX=<install-prefix> -B <build-dir>
+      .. code-tab:: shell-session static lib
 
-   To configure a build where Grackle is compiled as a shared library, use
+         ~/grackle $ cmake -DCMAKE_INSTALL_PREFIX=<install-prefix> -B <build-dir>
 
-   .. code-block:: shell-session
+      .. code-tab:: shell-session shared lib
 
-      ~/grackle $ cmake -DCMAKE_INSTALL_PREFIX=<install-prefix> -DBUILD_SHARED_LIBS=ON -B <build-dir>
+         ~/grackle $ cmake -DCMAKE_INSTALL_PREFIX=<install-prefix> -DBUILD_SHARED_LIBS=ON -B <build-dir>
 
    .. note::
 
@@ -230,12 +230,13 @@ These host-files should generally not be necessary, but they may specify archite
 This should be specified during the configuration stage with the ``-C`` flag followed by the path to the host-file.
 For example, one might invoke:
 
-   .. code-block:: shell-session
+.. code-block:: shell-session
 
-      ~/grackle $ cmake -C config/host-config/tacc-frontera-intel.cmake \
-      > -D CMAKE_INSTALL_PREFIX=<install-prefix> \
-      > -D BUILD_SHARED_LIBS=ON \
-      > -B <build-dir>
+   ~/grackle $ cmake \
+       -C config/host-config/tacc-frontera-intel.cmake \
+       -D CMAKE_INSTALL_PREFIX=<install-prefix> \
+       -D BUILD_SHARED_LIBS=ON \
+       -B <build-dir>
 
 The order of ``-D`` and ``-C`` flags matters.
 If they are both used to specify values for a given variable, the last one to appear "wins."

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -74,244 +74,6 @@ following command from anywhere within the repository:
     ~ $ git submodule update --init
 
 
-.. _classic_build:
-
-Building with Classic Build-System
-----------------------------------
-
-The classic compilation process for grackle is very similar to that of
-`Enzo <http://enzo-project.org>`_.  For more details on the Enzo build 
-system, see the `Enzo build documentation 
-<https://enzo.readthedocs.org/en/latest/tutorials/building_enzo.html>`_.
-To compile Grackle, complete the following procedure:
-
-1. Initialize the build system.
-
-.. highlight:: none
-
-::
-
-    ~ $ cd grackle
-    ~/grackle $ ./configure
-
-2. Proceed to the source directory.
-
-.. highlight:: none
-
-::
-
-    ~/grackle $ cd src/clib
-
-3. Configure the build system.
-
-.. note:: 
-   As of version 2.1, Grackle uses ``libtool`` for building and installation.  
-   As such, both shared and static libraries will be built automatically and 
-   it is not necessary to add the -fPIC compiler flag.
-
-Compile settings for different systems are stored in files starting with 
-"Make.mach" in the source directory.  Grackle comes with three sample make 
-macros: ``Make.mach.darwin`` for Mac OSX, ``Make.mach.linux-gnu`` for 
-Linux systems, and an unformatted ``Make.mach.unknown``.  If you have a make 
-file prepared for an Enzo install, it cannot be used straight away, but is a 
-very good place to start.
-
-Once you have chosen the make file to be used, a few variables should be set:
-
-    * ``MACH_LIBTOOL`` - path to ``libtool`` executable.  Note, on a Mac, 
-      this should point to ``glibtool``, which can be installed with macports 
-      or homebrew.
-
-    * ``LOCAL_HDF5_INSTALL`` - path to your hdf5 installation.  
-
-    * ``LOCAL_FC_INSTALL`` - path to Fortran compilers (not including the bin 
-      subdirectory).
-
-    * ``MACH_INSTALL_PREFIX`` - path where grackle header and library files 
-      will be installed.
-
-    * ``MACH_INSTALL_LIB_DIR`` - path where libgrackle will be installed (only 
-      set if different from MACH_INSTALL_PREFIX/lib).
-
-    * ``MACH_INSTALL_INCLUDE_DIR`` - path where grackle header files will be 
-      installed (only set if different from MACH_INSTALL_PREFIX/include).
-
-Once the proper variables are set, they are loaded into the build system by 
-doing the following:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make machine-<system>
-
-Where system refers to the make file you have chosen.  For example, if you 
-chose ``Make.mach.darwin``, type:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make machine-darwin
-
-Custom make files can be saved and loaded from a **.grackle** directory in the 
-home directory.
-
-.. _compiler-settings:
-
-Compiler Settings
-+++++++++++++++++
-
-There are three compile options available for setting the precision of 
-baryon fields, compiler optimization, and enabling OpenMP.  To see them,
-type:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make show-config
-
-   MACHINE: Darwin (OSX)
-   MACHINE-NAME: darwin
-
-   CONFIG_PRECISION  [precision-{32,64}]                     : 64
-   CONFIG_OPT  [opt-{warn,debug,high,aggressive}]            : high
-   CONFIG_OMP  [omp-{on,off}]                                : off
-
-For example, to change the optimization to high, type:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make opt-high
-
-.. warning::
-   Compiling Grackle in single precision (with ``make precision-32``) is **not**
-   recommended. Because of the high dynamic range involved in calculating many
-   chemistry and cooling rates, running Grackle in single precision can produce
-   unreliable results. This is especially true when running with
-   :c:data:`primordial_chemistry` >= 1.
-
-Custom settings can be saved for later use by typing:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make save-config-<keyword>
-
-They will be saved in the **.grackle** directory in your home directory.  To 
-reload them, type:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make load-config-<keyword>
-
-For a list of all available make commands, type:
-
-.. highlight:: none
-
-::
-
-    ~/grackle/src/clib $ make help
-
-    ========================================================================
-       Grackle Makefile Help
-    ========================================================================
-    
-       make                Compile and generate librackle
-       make install        Copy the library somewhere
-       make help           Display this help information
-       make clean          Remove object files, executable, etc.
-       make dep            Create make dependencies in DEPEND file
-    
-       make show-version   Display revision control system branch and revision
-       make show-diff      Display local file modifications
-    
-       make help-config    Display detailed help on configuration make targets
-       make show-config    Display the configuration settings
-       make show-flags     Display specific compilation flags
-       make default        Reset the configuration to the default values
-
-4. Compile and Install
-
-To build the code, type:
-
-::
-
-    ~/grackle/src/clib $ make 
-    Updating DEPEND
-    Compiling calc_rates.F
-    Compiling cool1d_multi.F
-    ....
-    
-    Linking
-    Success!
-
-Then, to install:
-
-::
-
-    ~/grackle/src/clib $ make install
-
-5. Test your Installation
-
-Once installed, you can test your installation with the provided example to
-assure it is functioning correctly.  If something goes wrong in this process,
-check the ``out.compile`` file to see what went wrong during compilation,
-or use ``ldd`` (``otool -L`` on Mac) on your executable to determine what went 
-wrong during linking.
-
-::
-
-    ~/grackle/src/clib $ cd ../example
-    ~/grackle/src/example $ make clean 
-    ~/grackle/src/example $ make 
-
-    Compiling cxx_example.C
-    Linking
-    Success!
-  
-    ~/grackle/src/example $ ./cxx_example
-
-    The Grackle Version 2.2
-    Mercurial Branch   default
-    Mercurial Revision b4650914153d
-
-    Initializing grackle data.
-    with_radiative_cooling: 1.
-    primordial_chemistry: 3.
-    metal_cooling: 1.
-    UVbackground: 1.
-    Initializing Cloudy cooling: Metals.
-    cloudy_table_file: ../../input/CloudyData_UVB=HM2012.h5.
-    Cloudy cooling grid rank: 3.
-    Cloudy cooling grid dimensions: 29 26 161.
-    Parameter1: -10 to 4 (29 steps).
-    Parameter2: 0 to 14.849 (26 steps).
-    Temperature: 1 to 9 (161 steps).
-    Reading Cloudy Cooling dataset.
-    Reading Cloudy Heating dataset.
-    Initializing UV background.
-    Reading UV background data from ../../input/CloudyData_UVB=HM2012.h5.
-    UV background information:
-    Haardt & Madau (2012, ApJ, 746, 125) [Galaxies & Quasars]
-    z_min =  0.000
-    z_max = 15.130
-    Setting UVbackground_redshift_on to 15.130000.
-    Setting UVbackground_redshift_off to 0.000000.
-    Cooling time = -1.434987e+13 s.
-    Temperature = 4.637034e+02 K.
-    Pressure = 3.345738e+34.
-    gamma = 1.666645e+00.
-
-In order to verify that Grackle is fully functional, try :ref:`running the
-test suite <testing>`.
-
 .. _cmake_build:
 
 Building with CMake
@@ -634,6 +396,245 @@ While embedded builds currently respect ``GRACKLE_OPTIMIZATION_FLIST_INIT``, tha
      These can be read by IDEs.
 
    * after we update the minimum required CMake version for compiling Grackle to at least 3.19, we may transition to using these features.
+
+
+.. _classic_build:
+
+Building with Classic Build-System
+----------------------------------
+
+The classic compilation process for grackle is very similar to that of
+`Enzo <http://enzo-project.org>`_.  For more details on the Enzo build 
+system, see the `Enzo build documentation 
+<https://enzo.readthedocs.org/en/latest/tutorials/building_enzo.html>`_.
+To compile Grackle, complete the following procedure:
+
+1. Initialize the build system.
+
+.. highlight:: none
+
+::
+
+    ~ $ cd grackle
+    ~/grackle $ ./configure
+
+2. Proceed to the source directory.
+
+.. highlight:: none
+
+::
+
+    ~/grackle $ cd src/clib
+
+3. Configure the build system.
+
+.. note:: 
+   As of version 2.1, Grackle uses ``libtool`` for building and installation.  
+   As such, both shared and static libraries will be built automatically and 
+   it is not necessary to add the -fPIC compiler flag.
+
+Compile settings for different systems are stored in files starting with 
+"Make.mach" in the source directory.  Grackle comes with three sample make 
+macros: ``Make.mach.darwin`` for Mac OSX, ``Make.mach.linux-gnu`` for 
+Linux systems, and an unformatted ``Make.mach.unknown``.  If you have a make 
+file prepared for an Enzo install, it cannot be used straight away, but is a 
+very good place to start.
+
+Once you have chosen the make file to be used, a few variables should be set:
+
+    * ``MACH_LIBTOOL`` - path to ``libtool`` executable.  Note, on a Mac, 
+      this should point to ``glibtool``, which can be installed with macports 
+      or homebrew.
+
+    * ``LOCAL_HDF5_INSTALL`` - path to your hdf5 installation.  
+
+    * ``LOCAL_FC_INSTALL`` - path to Fortran compilers (not including the bin 
+      subdirectory).
+
+    * ``MACH_INSTALL_PREFIX`` - path where grackle header and library files 
+      will be installed.
+
+    * ``MACH_INSTALL_LIB_DIR`` - path where libgrackle will be installed (only 
+      set if different from MACH_INSTALL_PREFIX/lib).
+
+    * ``MACH_INSTALL_INCLUDE_DIR`` - path where grackle header files will be 
+      installed (only set if different from MACH_INSTALL_PREFIX/include).
+
+Once the proper variables are set, they are loaded into the build system by 
+doing the following:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make machine-<system>
+
+Where system refers to the make file you have chosen.  For example, if you 
+chose ``Make.mach.darwin``, type:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make machine-darwin
+
+Custom make files can be saved and loaded from a **.grackle** directory in the 
+home directory.
+
+.. _compiler-settings:
+
+Compiler Settings
++++++++++++++++++
+
+There are three compile options available for setting the precision of 
+baryon fields, compiler optimization, and enabling OpenMP.  To see them,
+type:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make show-config
+
+   MACHINE: Darwin (OSX)
+   MACHINE-NAME: darwin
+
+   CONFIG_PRECISION  [precision-{32,64}]                     : 64
+   CONFIG_OPT  [opt-{warn,debug,high,aggressive}]            : high
+   CONFIG_OMP  [omp-{on,off}]                                : off
+
+For example, to change the optimization to high, type:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make opt-high
+
+.. warning::
+   Compiling Grackle in single precision (with ``make precision-32``) is **not**
+   recommended. Because of the high dynamic range involved in calculating many
+   chemistry and cooling rates, running Grackle in single precision can produce
+   unreliable results. This is especially true when running with
+   :c:data:`primordial_chemistry` >= 1.
+
+Custom settings can be saved for later use by typing:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make save-config-<keyword>
+
+They will be saved in the **.grackle** directory in your home directory.  To 
+reload them, type:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make load-config-<keyword>
+
+For a list of all available make commands, type:
+
+.. highlight:: none
+
+::
+
+    ~/grackle/src/clib $ make help
+
+    ========================================================================
+       Grackle Makefile Help
+    ========================================================================
+    
+       make                Compile and generate librackle
+       make install        Copy the library somewhere
+       make help           Display this help information
+       make clean          Remove object files, executable, etc.
+       make dep            Create make dependencies in DEPEND file
+    
+       make show-version   Display revision control system branch and revision
+       make show-diff      Display local file modifications
+    
+       make help-config    Display detailed help on configuration make targets
+       make show-config    Display the configuration settings
+       make show-flags     Display specific compilation flags
+       make default        Reset the configuration to the default values
+
+4. Compile and Install
+
+To build the code, type:
+
+::
+
+    ~/grackle/src/clib $ make 
+    Updating DEPEND
+    Compiling calc_rates.F
+    Compiling cool1d_multi.F
+    ....
+    
+    Linking
+    Success!
+
+Then, to install:
+
+::
+
+    ~/grackle/src/clib $ make install
+
+5. Test your Installation
+
+Once installed, you can test your installation with the provided example to
+assure it is functioning correctly.  If something goes wrong in this process,
+check the ``out.compile`` file to see what went wrong during compilation,
+or use ``ldd`` (``otool -L`` on Mac) on your executable to determine what went 
+wrong during linking.
+
+::
+
+    ~/grackle/src/clib $ cd ../example
+    ~/grackle/src/example $ make clean 
+    ~/grackle/src/example $ make 
+
+    Compiling cxx_example.C
+    Linking
+    Success!
+  
+    ~/grackle/src/example $ ./cxx_example
+
+    The Grackle Version 2.2
+    Mercurial Branch   default
+    Mercurial Revision b4650914153d
+
+    Initializing grackle data.
+    with_radiative_cooling: 1.
+    primordial_chemistry: 3.
+    metal_cooling: 1.
+    UVbackground: 1.
+    Initializing Cloudy cooling: Metals.
+    cloudy_table_file: ../../input/CloudyData_UVB=HM2012.h5.
+    Cloudy cooling grid rank: 3.
+    Cloudy cooling grid dimensions: 29 26 161.
+    Parameter1: -10 to 4 (29 steps).
+    Parameter2: 0 to 14.849 (26 steps).
+    Temperature: 1 to 9 (161 steps).
+    Reading Cloudy Cooling dataset.
+    Reading Cloudy Heating dataset.
+    Initializing UV background.
+    Reading UV background data from ../../input/CloudyData_UVB=HM2012.h5.
+    UV background information:
+    Haardt & Madau (2012, ApJ, 746, 125) [Galaxies & Quasars]
+    z_min =  0.000
+    z_max = 15.130
+    Setting UVbackground_redshift_on to 15.130000.
+    Setting UVbackground_redshift_off to 0.000000.
+    Cooling time = -1.434987e+13 s.
+    Temperature = 4.637034e+02 K.
+    Pressure = 3.345738e+34.
+    gamma = 1.666645e+00.
+
+In order to verify that Grackle is fully functional, try :ref:`running the
+test suite <testing>`.
 
 
 .. _compiler_toolchain_compatability:

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -50,8 +50,8 @@ Although many systems already have them installed, both build systems have addit
 
 .. _download_grackle:
 
-Downloading
------------
+Downloading Source Code
+-----------------------
 
 Grackle is available in a git repository
 `here <https://github.com/grackle-project/grackle>`__. Excellent guides
@@ -59,21 +59,11 @@ to git and GitHub are available at
 `guides.github.com <https://guides.github.com/>`__. To clone the Grackle
 repo, do the following:
 
-.. highlight:: none
+.. code-block:: shell-session
 
-::
+    ~ $ git clone --recursive https://github.com/grackle-project/grackle
 
-    ~ $ git clone https://github.com/grackle-project/grackle
-
-Additional files containing cooling tables and test results are stored in
-a submodule linked to the Grackle repository. To get these, run the
-following command from anywhere within the repository:
-
-.. highlight:: none
-
-::
-
-    ~ $ git submodule update --init
+The presences of the ``--recursive`` flag in the above snippet instructs git to fetch additional files, containing cooling tables, from a submodule linked to the Grackle repository.
 
 
 .. _cmake_build:

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -5,17 +5,17 @@ Installation
 
 There are 3 steps to setting up Grackle on your system
 
-   1. :ref:`Install Grackle's Dependencies <install_grackle_dependencies>`
+1. :ref:`Install Grackle's Dependencies <install_grackle_dependencies>`
 
-   2. :ref:`Download Grackle <download_grackle>`
+2. :ref:`Download Grackle <download_grackle>`
 
-   3. Build and install Grackle using the :ref:`classic build system <classic_build>` or the :ref:`CMake build system <cmake_build>`.
+3. :ref:`Build and install Grackle <cmake_build>`.
 
+.. attention::
 
-.. note::
+   Please use the :ref:`CMake build system <cmake_build>` (it is far more robust and maintainable) and :doc:`let us know <Help>` if you encounter **any problems**.
 
-   Given a smooth roll-out of the :ref:`CMake build system <cmake_build>`, it is our intention to deprecate and remove the :ref:`classic build system <classic_build>`.
-   If you encounter any problems with the CMake system or anticipate any issues with this plan, :doc:`please let us know <Help>`.
+   The :ref:`classic build system <classic_build>` is **deprecated since version 3.4** and is **scheduled for removal in version 3.5**.
 
 We include a :ref:`note on compiler toolchain compatability <compiler_toolchain_compatability>` at the end of this page.
 
@@ -32,19 +32,21 @@ also be installed:
      HDF5 also may require the szip and zlib libraries, which can be
      found at the HDF5 website.
 
-     * For the :ref:`classic build system <classic_build>`, compiling with HDF5 1.8 or greater requires that the ``H5_USE_16_API`` compatability directive is manually specified.
-       This can be done by adding ``-DH5_USE_16_API`` to the list of compiler flags given in machine-specific make files.
+     .. note::
 
-     * The :ref:`CMake build system <cmake_build>`, automatically handles these details for you.
+        If using the :ref:`classic build system <classic_build>`: compiling with HDF5 1.8 or greater requires that the ``H5_USE_16_API`` compatability directive is manually specified.
+        This can be done by manually adding ``-DH5_USE_16_API`` to the list of compiler flags given in machine-specific make files.
+
+        You don't have to think about this when using :ref:`CMake build system <cmake_build>` (it is handled automatically).
 
 Although many systems already have them installed, both build systems have additional dependencies:
-
-   * the :ref:`classic build system <classic_build>`, employs the ``makedepend`` and the `libtool <https://www.gnu.org/software/libtool/>`_ utilities.
-     It's often easiest to download these dependencies through your system's package manager.
 
    * the :ref:`CMake build system <cmake_build>` requires cmake to be installed.
      It's easiest download a binary distribution from the `CMake website <https://cmake.org/download/>`_ or use your system's package manager.
      We require version 3.16 or newer.
+
+   * the :ref:`classic build system <classic_build>`, employs the ``makedepend`` and the `libtool <https://www.gnu.org/software/libtool/>`_ utilities.
+     It's often easiest to download these dependencies through your system's package manager.
 
 .. _download_grackle:
 
@@ -79,7 +81,7 @@ following command from anywhere within the repository:
 Building with CMake
 -------------------
 
-Grackle provides a Modern CMake build-system.
+Grackle's primary build-system uses Modern CMake.
 While CMake has some baggage (primarily due to the maintenace of backwards compatability), it is arguably the most-portable mainstream build-system that is easiest to integrate with simulation codes.
 
 An overview of our design philosophy is provided :ref:`here <cmake_buildsystem_design_rationale>`.
@@ -402,6 +404,12 @@ While embedded builds currently respect ``GRACKLE_OPTIMIZATION_FLIST_INIT``, tha
 
 Building with Classic Build-System
 ----------------------------------
+
+.. attention::
+
+   This build system is **deprecated since version 3.4** and is **scheduled for removal in version 3.5**.
+
+   Please use the :ref:`CMake build system <cmake_build>` (it is far more robust and maintainable) and :doc:`let us know <Help>` if you encounter **any problems**.
 
 The classic compilation process for grackle is very similar to that of
 `Enzo <http://enzo-project.org>`_.  For more details on the Enzo build 

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -28,9 +28,14 @@ if (GRACKLE_USE_OPENMP)
   target_link_libraries(cxx_omp_example Grackle::Grackle)
 endif()
 
-# the following target uses -O1 optimization because problems can arise with
-# higher levels of optimization. A comment in fortran_example.F provides more
-# details about the problems
-add_executable(fortran_example fortran_example.F)
-target_compile_options(fortran_example PRIVATE "-O1")
-target_link_libraries(fortran_example Grackle::Grackle)
+if (GRACKLE_USE_DOUBLE)
+  # we don't really have a good reason for why this disabled. This should
+  # really be fixed to work in single precision
+
+  # the following target uses -O1 optimization because problems can arise with
+  # higher levels of optimization. A comment in fortran_example.F provides more
+  # details about the problems
+  add_executable(fortran_example fortran_example.F)
+  target_compile_options(fortran_example PRIVATE "-O1")
+  target_link_libraries(fortran_example Grackle::Grackle)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,19 +104,21 @@ set_tests_properties(GrExampleCMP.cxx PROPERTIES
   FIXTURES_REQUIRED GREXAMPLE_PREREQS
 )
 
-# we allow for the Fortran to deviate from c_example to a small degree
-# -> to require an exact match, we probably need to rewrite all of the examples
-#    so that they use hardcoded values
-add_test(
-  NAME GrExampleCMP.fortran
-  COMMAND ${checker_script} cmp
-    --target $<TARGET_FILE:fortran_example>
-    --ref $<TARGET_FILE:c_example>
-    --rtol 6e-7
-    --exec-timeout 10
-    --exec-dir ${example_exec_dir}
-)
-set_tests_properties(GrExampleCMP.fortran PROPERTIES
-  FIXTURES_REQUIRED GREXAMPLE_PREREQS
-)
+if (TARGET fortran_example)
+  # we allow for the Fortran to deviate from c_example to a small degree
+  # -> to require an exact match, we probably need to rewrite all of the
+  #    examples so that they use hardcoded values
+  add_test(
+    NAME GrExampleCMP.fortran
+    COMMAND ${checker_script} cmp
+      --target $<TARGET_FILE:fortran_example>
+      --ref $<TARGET_FILE:c_example>
+      --rtol 6e-7
+      --exec-timeout 10
+      --exec-dir ${example_exec_dir}
+  )
+  set_tests_properties(GrExampleCMP.fortran PROPERTIES
+    FIXTURES_REQUIRED GREXAMPLE_PREREQS
+  )
+endif()
 


### PR DESCRIPTION
Must be merged after #304. (the first 5 commits are part of that PR, the last 2 commits are part of this one)

-------

This addresses 2 important configuration scenarios. Specifically, these are ways that I normally don't compile Grackle, but are perfectly reasonable things for users to do. This PR is actually **REALLY IMPORTANT**.

This PR is composed of 2 commits address 2 edge-cases with the build-system:
1. Add a quick fix for when you're building Grackle with single precision.[^1] Prior to this PR, building Grackle as a standalone project with single-precision would produce a compiler error in ``fortran_example.F`` unless you explicitly disable the examples (if you are consuming Grackle as part of a separate project, this wasn't an issue). Now, we disable the Fortran example (I need to sit down and actually fix the underlying issue in the example, but I'm not sure we want that to block the 3.4 release)
2. I uncovered an issue when you use OpenMP and a non-default backend for CMake (specifically, it is directly related to gfortran). The solution is to use CMake's default backend.
   - I added a warning explaining this to the build-system
   - I also added description of this issue in the guide
   - While I was at it, I also described how to  troubleshoot 2 other edged cases. 

[^1]: I stumbled onto this while working on a problem with enzo-project/enzo-e#415. The bug I'm fixing here is totally unrelated (I stumbled onto it because I launched Grackle in an unusual manner)