### PR TITLE
Introduce a simplified tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For more about installation see our [Pygrackle installation guide](https://grack
 
 To help you start using Grackle, we provide:
 
+- a [Tutorial](https://grackle.readthedocs.io/en/latest/Tutorial.html)
 - a [Usage Guide](https://grackle.readthedocs.io/en/latest/Interaction.html)
 - example Grackle programs written in [C, C++, and Fortran](https://github.com/grackle-project/grackle/tree/main/src/example)
 - an [Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) (for linking Grackle)

--- a/doc/source/Interaction.rst
+++ b/doc/source/Interaction.rst
@@ -148,8 +148,8 @@ density, length, time, and the expansion factor must be set
 manually. Units for velocity are then set by calling
 :c:data:`set_velocity_units`. When using the proper frame (i.e.,
 setting :c:data:`comoving_coordinates` to 0), :c:data:`a_units` (units
-for the expansion factor) must be set to 1.0. See below for
-recommendations on choosing appropriate units.
+for the expansion factor) must be set to 1.0.
+:ref:`See below <choosing_appropriate_units>` for recommendations on choosing appropriate units.
 
 .. c:type:: code_units
 
@@ -210,6 +210,8 @@ recommendations on choosing appropriate units.
   my_units.a_value = 1. / (1. + current_redshift) / my_units.a_units;
   // set velocity units
   set_velocity_units(&my_units);
+
+.. _choosing_appropriate_units:
 
 Choosing Appropriate Units
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/Tutorial.rst
+++ b/doc/source/Tutorial.rst
@@ -1,0 +1,158 @@
+Tutorial
+========
+
+Overview
+--------
+In this tutorial we walk through a minimal example of using Grackle to perform radiative cooling.
+We provide a more detailed guide for using Grackle's API :ref:`here <integration>`.
+
+Background
+----------
+
+It's instructive to understand the Grackle library universally adopts the convention:
+
+  **fluid state is primarily represented by specific internal energy and mass density.**
+
+These quantities are always used to describe the fluid's state when calling Grackle, Grackle uses them to derive other properties (e.g. temperature/pressure) and they are evolved by Grackle (when evolving chemistry/cooling).
+
+Specific internal energy, :math:`e`, is a temperature-like quantity that characterizes the fluid's thermodynamic state.
+For a calorically perfect ideal gas,\ [#perfect-ideal]_  :math:`e = k_B T/ ((\gamma -1) m_H \mu)`, where :math:`\gamma` is adiabatic index, :math:`m_H` is Hydrogen mass, :math:`k_B` is the Boltzmann constant, :math:`\mu` is the (composition-dependent) mean molecular weight.
+
+The total mass density, :math:`\rho`, describes the "amount" of a fluid.
+Other mass densities can be used to describe the fluid's composition (not relevant to the current example).
+Note: Grackle never evolves the total mass density.
+
+The Scenario
+------------
+
+We calculate the specific internal energy of a gas parcel after it has undergone radiative cooling for :math:`10^13\ {\rm s}` (or :math:`{\approx}0.32` Myr).
+The mass density is :math:`\rho = 5 \times 10^{-24}\ {\rm g}\ {\rm cm}^{-3}` (or :math:`{\approx}3` Hydrogen masses per cubic centimeter), initial specific internal energy is :math:`e_0 = 2\times 10^{12}\ {\rm cm}^2\ {\rm s}^{-2}`, and :math:`\gamma = 5/3`.
+
+We make 3 simplifying assumptions about the parcel's composition:\ [#composition-assumptions]_ (i) there are no metals (i.e. the heaviest particle is He), (ii) the parcel is always in ionization equilibrium, and (iii) the Hydrogen to Helium ratio is described :any:`here <HydrogenFractionByMass>`.
+
+Under these assumptions, the initial temperature is :math:`T\approx 1.5\times 10^4\ {\rm K}`.
+
+The Example Program
+-------------------
+
+The following example program performs the calculation described just above.
+The program is intended to be compiled with a C99 compiler (or newer).
+To keep the program short, the error-handling is fairly crude.
+
+.. gr-include-snippet:: ../../src/example/c99_simple_example.c
+   :language: c
+
+This example illustrates some essential aspects of using Grackle.
+We highlight these aspects down blow.
+
+Setting Up the Scenario
+^^^^^^^^^^^^^^^^^^^^^^^
+
+At the start of :c:func:`!main`, we define some variables that store inputs for our calculation.
+The details are influenced by conventions of simulation codes.
+
+.. literalinclude:: ../../src/example/c99_simple_example.c
+   :language: c
+   :start-after: //@![[[ANCHOR:ScenarioSetup]]]
+   :end-before: //@![[[ANCHOR:SanityChecks]]]
+
+On the first line, we define variables, (:c:var:`!densU`, :c:var:`!lenU`, and :c:var:`!timeU`) that describe a custom unit system [#about-code-units]_ that our sample-program uses to encode the input quantities.
+We define a custom unit-system because it's standard convention *and* Grackle assumes that input values are defined with an :ref:`appropriate unit-system <choosing_appropriate_units>`.\ [#require-reasonable-units]_
+Our unit system use rounded numbers roughly corresponding to a density unit of 1 Hydrogen masses per cubic centimeter, a length unit of kpc, and a time unit of Mpc.
+
+On the second line, we define :c:var:`!energyU` to hold the conversion factor for specific energy units.
+(**BE AWARE:** Grackle internally relates specific energy-units, length-units and time-units somewhat differently when using comoving coordinates).
+
+Next, we define variables that hold data describing fluid properties.
+We crudely approximate the standard pattern (sometimes called `struct of arrays <https://en.wikipedia.org/wiki/AoS_and_SoA>`_ or `parallel arrays <https://en.wikipedia.org/wiki/Parallel_array>_`) from grid-codes: each quantity is tracked in a distinct 1D buffer (usually called a field).
+Each location in a field typically maps to 3D indices (corresponding to 3D space).
+Since our example-program only considers a single parcel of gas, we store data in buffers corresponding to a ``(1,1,1)`` field.
+
+Finally, the :c:var:`!dt` variable holds the timestep we will evolve the timestep over.
+
+Sanity Checks
+^^^^^^^^^^^^^
+
+The next chunk of logic performs some quick sanity checks.
+It confirms that Grackle configured with the correct precision and that it is properly linked.
+
+.. literalinclude:: ../../src/example/c99_simple_example.c
+   :language: c
+   :start-after: //@![[[ANCHOR:SanityChecks]]]
+   :end-before: //@![[[ANCHOR:SetupChemistrySolver]]]
+
+Configuring the Solver
+^^^^^^^^^^^^^^^^^^^^^^
+Next, we move onto configuring the Grackle solver.
+
+.. literalinclude:: ../../src/example/c99_simple_example.c
+   :language: c
+   :start-after: //@![[[ANCHOR:SetupChemistrySolver]]]
+   :end-before: //@![[[ANCHOR:SetupGrackleFieldData]]]
+
+The :c:type:`chemistry_data` type encodes runtime parameter, :c:type:`code_units` is used to describe the chosen unit-system, and :c:type:`chemistry_data_storage` is used to manage internal data.
+
+.. note::
+
+   As long as you don't mutate these data-structures after you configure them, they can be used in as many operations as you want.
+   If you want to mutate anything, you must generally configure fresh data structures.
+   :ref:`The linked page <integration>` describes a few exceptions to this rule (they're mostly related to cosmology).
+
+Preparing to communicate Field Data to Solver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+At this point, we are ready to setup an instance of :c:type:`grackle_field_data`, which is used to communicate the field data to the Grackle solver.
+
+.. literalinclude:: ../../src/example/c99_simple_example.c
+   :language: c
+   :start-after: //@![[[ANCHOR:SetupGrackleFieldData]]]
+   :end-before: //@![[[ANCHOR:ApplySolver]]]
+
+In this snippet, we have configured :c:var:`grid_start` and :c:var:`grid_end` such that the solver operates on every fluid element (yes, exactly 1 fluid element).
+
+Calling the Solver
+^^^^^^^^^^^^^^^^^^
+
+After all that, we can actually run the calculation and print the result
+
+.. literalinclude:: ../../src/example/c99_simple_example.c
+   :language: c
+   :start-after: //@![[[ANCHOR:ApplySolver]]]
+   :end-before: //@![[[ANCHOR:Exit]]]
+
+Exitting
+^^^^^^^^
+Since the program is finished, we can exit (we cut some corners here with cleanup).
+
+Running the Example
+-------------------
+
+After you perform a CMake-build in a build-directory called ``<build-dir>``, you can execute:
+
+.. code-block:: shell-session
+
+   <build-dir>/examples $ ./c99_simple_example
+
+.. warning::
+
+   The examples make certain assumptions about the location of the input files.
+   The examples are only guaranteed to work if both:
+
+      1. you execute the example-binary from the same-directory where the example-binary is found
+
+      2. ``<build-dir>`` is a top-level directory in the grackle repository (e.g. something like ``my-build`` is fine, but choices like ``../my-grackle-build`` and ``my_builds/my-first-build`` are problematic).
+
+.. rubric:: Footnotes
+
+.. [#perfect-ideal] A calorically perfect ideal gas, satisfies :math:`p = (\gamma - 1) \rho e` and the ideal gas law.
+
+.. [#composition-assumptions] To be clear, we're only making these assumptions to simplify the example.
+     Grackle is perfectly capable of relaxing these assumptions.
+
+.. [#about-code-units] In this case, :c:var:`!timeU` stores the number of seconds in 1 time unit, :c:var:`!lenU` holds the number of cm in 1 length unit, and :c:var:`densU` holds the number of :math:`{\rm g}\ {\rm cm}^{-3}` in 1 density unit.
+     For the uninitiated, it is standard practice for simulation codes to define a custom unit system.
+     This practice aims to avoid numerical issue by adopting a unit-system such that the :ref:`the density, length, and time values are always close to 1 <choosing_appropriate_units>`.
+
+.. [#require-reasonable-units] Grackle has special logic to deal with cases where physical quantities are "tiny."
+     For historical reasons, Grackle identifies "tiny" quantities using hardcoded values assuming that they specified with an :ref:`appropriate unit system <choosing_appropriate_units>`.
+     This is something we would like to change in the future.

--- a/doc/source/_ext/gr_include_snippet.py
+++ b/doc/source/_ext/gr_include_snippet.py
@@ -1,0 +1,82 @@
+"""
+This is a simple extension, gr_include_snippet, that introduces a Directive
+that acts like Sphinx's literalinclude directive
+
+In more detail, the idea is to:
+- have an external example that has specially-escaped anchors
+- the gr-include-snippet is used to skip over these anchors
+- we use the anchors to extract snippets of the code in literalinclude snippets
+  to annotate parts of the example.
+"""
+
+from __future__ import annotations
+import re
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util.typing import ExtensionMetadata
+
+_IGNORE_REGEX = re.compile(r"^\s*" + re.escape(r"//@%"))
+
+
+def _filtered_lines(fname, *, encoding=None):
+    # produces an iterator over valid lines in fname (trailing whitespace is removed)
+    yielded_any = False
+    with open(fname, encoding=encoding) as f:
+        for line in f:
+            if _IGNORE_REGEX.match(line) is not None:
+                continue
+            elif line.isspace() and not yielded_any:  # skip any leading whitespace
+                continue
+            yielded_any = True
+            yield line.rstrip()
+
+
+class GrIncludeSnippetDirective(SphinxDirective):
+    required_arguments = 1
+    optional_arguments = 0
+    option_spec = {
+        "encoding": directives.encoding,
+        "language": directives.unchanged_required,
+        # below, we use directives.unchanged to make forwarding easier
+        "caption": directives.unchanged,
+        "class": directives.unchanged,
+        "name": directives.unchanged,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        # get path to the file that will be read
+        rel_path_to_docroot, abs_path = self.env.relfn2path(self.arguments[0])
+        self.env.note_dependency(rel_path_to_docroot)
+
+        lines = []
+        _indent = "   "
+        lines.append(f".. code-block:: {self.options['language']}")
+        for optname in self.option_spec:
+            val = self.options.get(optname, None)
+            if optname in ["encoding", "language"] or val is None:
+                continue
+            elif val == "":
+                lines.append(f"{_indent}:{optname}:")
+            else:
+                lines.append(f"{_indent}:{optname}: {val}")
+        lines.append(f"{_indent}")
+
+        it = _filtered_lines(abs_path, encoding=self.options.get("encoding", None))
+        for line in it:
+            lines.append(f"{_indent}{line}")
+
+        # the following line is inspired by yt:
+        self.state_machine.insert_input(
+            input_lines=lines, source=self.state_machine.document.attributes["source"]
+        )
+        return []
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_directive("gr-include-snippet", GrIncludeSnippetDirective)
+
+    return {"version": "0.1", "parallel_read_safe": True, "parallel_write_save": False}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,6 +19,7 @@ import sys, os
 #sys.path.insert(0, os.path.abspath('.'))
 
 sys.path.insert(0, os.path.abspath('../../config'))
+sys.path.append(os.path.abspath('_ext'))
 
 from query_version import query_version
 
@@ -30,7 +31,8 @@ from query_version import query_version
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_tabs.tabs',
-              'sphinx_rtd_theme']
+              'sphinx_rtd_theme',
+              'gr_include_snippet']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -80,6 +80,7 @@ To help you start using Grackle, we provide:
 
    Installation.rst
    Testing.rst
+   Tutorial.rst
    Integration.rst
    Interaction.rst
    Parameters.rst

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -11,6 +11,12 @@
 #    should ensure that the paths to the datafiles are correct
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../examples)
 
+if (GRACKLE_USE_DOUBLE)
+  # this example requires C99 or newer since it uses designated initializers
+  add_executable(c99_simple_example c99_simple_example.c)
+  target_link_libraries(c99_simple_example Grackle::Grackle)
+  target_compile_features(c99_simple_example PUBLIC c_std_99)
+endif()
 
 add_executable(c_example c_example.c)
 target_link_libraries(c_example Grackle::Grackle)

--- a/src/example/Make.config.targets
+++ b/src/example/Make.config.targets
@@ -99,6 +99,23 @@ c_local_example: $(MODULES) c_local_example.o
          fi)
 
 #-----------------------------------------------------------------------
+# C99 SIMPLIFIED EXAMPLE
+#-----------------------------------------------------------------------
+c99_simple_example: $(MODULES) c99_simple_example.o
+	@rm -f $@
+	@echo "Linking"
+	-@$(CC) $(LDFLAGS) -o c99_simple_example c99_simple_example.o -lm $(LIBS) $(GRACKLE_LIB) >& $(OUTPUT)
+	@(if [ -e $@ ]; then \
+             echo "Success!"; \
+         else \
+             echo "$(CC) $(LDFLAGS) -o c99_simple_example c99_simple_example.o -lm $(LIBS) $(GRACKLE_LIB)" >> temp1; \
+             cat temp1 $(OUTPUT) > temp2; \
+             rm -f temp1; \
+             mv -f temp2 $(OUTPUT); \
+             echo "Failed! See $(OUTPUT) for error messages"; \
+         fi)
+
+#-----------------------------------------------------------------------
 # FORTRAN EXAMPLE
 #-----------------------------------------------------------------------
 

--- a/src/example/Makefile
+++ b/src/example/Makefile
@@ -100,7 +100,7 @@ help:
 
 
 clean:
-	-@rm -f *.o *.mod *.f *.f90 *~ *.exe $(OUTPUT) cxx_example cxx_omp_example c_example c_local_example fortran_example
+	-@rm -f *.o *.mod *.f *.f90 *~ *.exe $(OUTPUT) cxx_example cxx_omp_example c_example c_local_example fortran_example c99_simple_example
 
 #-----------------------------------------------------------------------
 # Include configuration targets

--- a/src/example/c99_simple_example.c
+++ b/src/example/c99_simple_example.c
@@ -1,0 +1,62 @@
+//@% IF YOU ARE A NEW USER: you should go to the documentation page where we
+//@% describe this example
+//@%
+//@% This is a minimal example of how to use Grackle:
+//@% - we talk about sections of logic chunk-by-chunk in the documentation
+//@% - lines starting with ``//@!`` are not rendered in the documentation.
+//@% - lines of the form ``//@![[[ANCHOR:<description>]]]`` are generally used
+//@%   as "anchors" to help us include snippets of text in the documentation
+//@%
+//@% Whenever you change the contents of this file, you should ensure that the
+//@% the corresponding page of documentation still makes sense
+
+#include <grackle.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+const char* path = "../../input/CloudyData_UVB=HM2012.h5";  // may need changing
+typedef double Real;  // <- precision of our field data
+
+int main(int argc, char** argv) {
+  //@![[[ANCHOR:ScenarioSetup]]]
+  const double densU = 1.67e-24, lenU = 3.086e21, timeU = 3.16e13;
+  double energyU = (lenU*lenU)/(timeU*timeU);   // <- internal energy units
+  int dims[3]  = {1, 1, 1};                     // <- shape of our fields
+  Real rho[1]  = { (Real)(2.0e-24 / densU) };   // <- density field data
+  Real eint[1] = { (Real)(2.0e12 / energyU) };  // <- internal energy field data
+
+  // we want to apply radiative cooling over the following timestep
+  double dt = 1.0e13 / timeU; // corresponds to ~0.32 Myr
+
+  //@![[[ANCHOR:SanityChecks]]]
+  if (sizeof(gr_float) != sizeof(Real))  abort();     // config sanity check!
+  if (gr_check_consistency() != GR_SUCCESS)  abort(); // linking sanity check!
+
+  //@![[[ANCHOR:SetupChemistrySolver]]]
+  // set up the chemistry solver
+  chemistry_data par; // holds runtime parameters
+  if (local_initialize_chemistry_parameters(&par) != GR_SUCCESS)  abort();
+  par.use_grackle  = 1;             par.with_radiative_cooling = 1;
+  par.Gamma        = 5.0/3.0;       par.primordial_chemistry   = 0;
+  par.UVbackground = 1;             par.grackle_data_file      = path;
+  code_units u = {.comoving_coordinates=0, .a_units=1.0, .a_value=1.0,
+                  .density_units=densU, .length_units=lenU, .time_units=timeU};
+  chemistry_data_storage sto; // <- stores data tables & rate data
+  if (local_initialize_chemistry_data(&par, &sto, &u) != GR_SUCCESS)  abort();
+
+  //@![[[ANCHOR:SetupGrackleFieldData]]]
+  grackle_field_data f; // <- used to communicate field data to solver
+  if (gr_initialize_field_data(&f) != GR_SUCCESS)  abort();
+  int start[3] = {0, 0, 0};
+  int end[3] = {dims[0]-1, dims[1]-1, dims[2]-1};
+  f.grid_dimension = dims; f.grid_start = start; f.grid_end = end;
+  f.grid_rank = 3;         f.density    = rho;   f.internal_energy = eint;
+
+  //@![[[ANCHOR:ApplySolver]]]
+  // apply the solver
+  if (local_solve_chemistry(&par, &sto, &u, &f, dt) != GR_SUCCESS) abort();
+  printf("energy after timestep: %24.16e cm^2/s^2\n", eint[0]*energyU);
+
+  //@![[[ANCHOR:Exit]]]
+  return 0; // we skipped cleanup of solver (see local_free_chemistry_data)
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,19 @@ set_tests_properties(GrExample.cmp_omp PROPERTIES
 )
 endif()
 
+# this case simply runs the c99_simple_example and verifies that it exits with an
+# exit code of 0 (we may want to check the outputs in the future, but this is
+# good enough to start)
+if (TARGET c99_simple_example)
+  add_test(NAME GrExample.c99_simple_example
+    COMMAND c99_simple_example
+    WORKING_DIRECTORY ${example_exec_dir}
+  )
+  set_tests_properties(GrExample.c99_simple_example PROPERTIES
+    FIXTURES_REQUIRED GREXAMPLE_PREREQS
+  )
+endif()
+
 # the remaining tests are more rigorous:
 #
 # first, we check the results of c_example against the historical results


### PR DESCRIPTION
Motivation
----------

At present, we provide several extremely useful resources for teaching Grackle. But, I've long felt that there's initially something of a learning curve. While all of the examples and the ["Interacting with Grackle in Your Simulation Code"](https://grackle.readthedocs.io/en/latest/Interaction.html) section are extremely rich, detailed, and informative, I always feel like they may include a little **too much** information...

**Every** usage of Grackle, boils down to the following flow:

1. We have some data about parcels of gas & we want to know something about it (mostly how chemistry/cooling cause it to evolve)

2. We need to encode information about the gas and the physics we care about in a format that Grackle understands.[^1]

3. We package up the data about the gas parcels into a format that Grackle understands (the ``grackle_field_data`` struct).

4. We call the appropriate function.

Unfortunately, this flow is not very obvious from the existing resources (i.e. there's just a little too much going on). But, once you understand the flow ("the big picture"), I think our existing resources are extremely useful.

Overview
--------

This patch tries to bridge this gap. I came up with the shortest and simplest possible example. (I probably could save a line or 2 if I used the global API, but that was a conscious choice). Then, I wrote a tutorial to try to walk the reader through the example chunk by chunk.

To help annotate the example, I wrote a really simple sphinx extension.

Future Thoughts
---------------

Honestly, this is far from perfect, but I think its a good start. Some thoughts for the future:

- It would be nice if Grackle could operate with CGS units. The tutorial could then gloss over a number of details.

  * Since we already use double-precision within Grackle, I think don't think there are any problems with doing this. But clearly, it needs to wait

  * I think it would also be nice for teaching the pygrackle bindings

- It would be better if the example were even shorter:

  * the `gr_fields` type proposed within #271 will help

  * a number of my other "experimental APIs" will also help

  * in the 4.0 release, we may want to revisit the default values for the ``use_grackle`` and ``with_radiative_cooling`` parameters (the current defaults are pretty silly).

- if we merge in #235, #237, and #246, then we could easily add a section describing how to try out the example without git commands (those PRs are essential for crafting a sample CMake configuration that can automatically install data-files)

[^1]: Of course, Grackle is designed to let callers avoid repeating step 2 over and over again.