### PR TITLE
[newchem-cpp] 2 minor bugfixes following last week's merge

### DIFF
--- a/src/example/fortran_example.F
+++ b/src/example/fortran_example.F
@@ -226,6 +226,9 @@ c     get the temperature_units
 c        solar metallicity
          metal_density(i) = grackle_data%SolarMetalFractionByMass *
      &        density(i)
+c        local dust to gas ratio
+         dust_density(i) = grackle_data%local_dust_to_gas_ratio *
+     &        density(i)
 
          x_velocity(i) = 0.0
          y_velocity(i) = 0.0

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -3,8 +3,19 @@
 add_library(testdeps INTERFACE)
 target_link_libraries(testdeps INTERFACE Grackle::Grackle GTest::gtest_main)
 
-# short-term hack to let tests invoke Fortran functions from C
-target_compile_definitions(testdeps INTERFACE "$<$<PLATFORM_ID:Linux,Darwin>:LINUX>")
+# compiler defs are short-term hacks to help tests invoke internal functions
+# from Grackle (both of these will become unnecessary in the near future)
+target_compile_definitions(testdeps
+  # needed to invoke Fortran functions from C
+  INTERFACE "$<$<PLATFORM_ID:Linux,Darwin>:LINUX>"
+  # suppresses warnings about C internal headers using our deprecated public
+  # headers (the files should include grackle.h instead). We're currently
+  # holding off on properly fixing this to minimize conflicts with pending PRs
+  # on the newchem-cpp branch
+  INTERFACE GRIMPL_PUBLIC_INCLUDE=1
+)
+
+# needed to let tests call internal functions from C
 target_include_directories(testdeps INTERFACE ${PROJECT_SOURCE_DIR}/src/clib)
 
 # declare the grtest utility library


### PR DESCRIPTION
Last Wednesday, I resolved a few minor problems when we merged in main into newchem-cpp. But 2 minor issues crept by me (that I should have addressed last week):

1. We were missing a line from fortran_example.F (I suspect I deleted the line during the merge)
2. I hadn't realized that the changes from #288 would start producing some warnings in the unit-tests. I fixed this (the commit-message explains why I chose to address it in the way that I did)