### PR TITLE
Mention Enzo-E as an example for auto-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Below, we list open source projects that provide out-of-the-box support for Grac
 ## Getting Grackle
 
 Currently, Grackle must be built from source.
-If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you.
+If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you ([Enzo-E](https://enzo-e.readthedocs.io/en/latest/) is an example of a code configured in this manner).
 
 If you contribute to a simulation code, our [Integration Guide](https://grackle.readthedocs.io/en/latest/Integration.html) provides guidance on simplifying the process (for you and your users) of configuring your code to use Grackle.
 

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -3,6 +3,10 @@
 Installation
 ============
 
+This page describes how to install Grackle from source.
+When installing Grackle as a dependency of a simulation code, consult the code's documentation before continuing.
+Build systems of some codes, like `Enzo-E <https://enzo-e.readthedocs.io/en/latest/>`__, are configured to automatically download & install Grackle as part of the build-process (our :doc:`Integration Guide <Integration>` provides more details).
+
 There are 3 steps to setting up Grackle on your system
 
 1. :ref:`Install Grackle's Dependencies <install_grackle_dependencies>`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -31,7 +31,7 @@ Getting Grackle
 ---------------
 
 Currently, Grackle must be built from source.
-If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you.
+If you only need Grackle as a dependency of a simulation code and that code is built with CMake, then that code's build system might be configured to automatically fetch, build, and link Grackle into the code for you (`Enzo-E <https://enzo-e.readthedocs.io/en/latest/>`__ is an example of a code configured in this manner).
 
 If you contribute to a simulation code, our `Integration Guide <https://grackle.readthedocs.io/en/latest/Integration.html>`__ provides guidance on simplifying the process (for you and your users) of configuring your code to use Grackle.
 
@@ -46,7 +46,7 @@ On most platforms, compilation with the CMake build system (3.16 or newer) is as
    cmake -B build          # configure the build-directory
    cmake --build ./build   # perform the build
 
-You can run invoke the examples from within the ``build/examples`` directory.[^1]
+You can run invoke the examples from within the ``build/examples`` directory.\ [#f1]_
 To build Grackle as a shared lib, replace the first command with ``cmake -DBUILD_SHARED_LIBS=ON -Bbuild``.
 To install Grackle, invoke ``cmake --install ./build [--prefix <prefix/path>]`` (the optional part lets you specify an install-path).
 
@@ -117,9 +117,7 @@ chemistry and cooling library (`Smith et al. 2017
 <http://adsabs.harvard.edu/abs/2017MNRAS.466.2217S>`_)."  Also, please add a
 footnote to `https://grackle.readthedocs.io/ <https://grackle.readthedocs.io/>`_.
 
+.. rubric:: Footnotes
 
-Search
-------
-
-* :ref:`search`
-
+.. [#f1] You currently **NEED** to invoke the examples from the directory where they are located.
+         We have a `"fix" in the pipeline <https://github.com/grackle-project/grackle/pull/246>`__ to make this more flexible.


### PR DESCRIPTION
This patch primarily consists of 2 changes:

1. A modification to the README (and the duplicated text on the landing page of the website) mentioning Enzo-E as an example of a code with a build system that supports automatically downloading & installing Grackle.

2. The addition of a short paragraph at the top of the Installation page encouraging people to check the documentation of the simulation code that they are using before reading through the entire page. I reference the fact that the build systems of some codes (e.g. Enzo-E) are able to automatically fetch and install Grackle as part of the build process.

I also noticed that the website's landing page had a footnote with missing text. I added the missing text (it duplicates a footnote in the README). While I was doing this, I deleted the "Search" section from the landing page (since it doesn't do anything with the RTD sphinx theme)