### PR TITLE
cython does not need to be a runtime-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ keywords=[
 ]
 requires-python = ">=3.7"
 dependencies = [
-  'cython',
   'h5py',
   'numpy',
   'matplotlib',


### PR DESCRIPTION
This is an extremely minor tweak