### PR TITLE
Packaging Pygrackle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,8 +24,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Optional, use if you use setuptools_scm
-          submodules: true # Optional, use if you have submodules
+          # fetch the full git history to let us run all our tests
+          fetch-depth: 0
+          # fetch the submodules to let us run the tests
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Build SDist
         run: pipx run build --sdist
@@ -33,7 +40,11 @@ jobs:
       - name: Test sdist
         run: |
           sudo apt-get install libhdf5-dev
-          python -m pip install "$(echo dist/*.tar.gz)[dev]"
+          # it may not be necessary to setup a venv
+          python -m venv my-venv
+          source my-venv/bin/activate
+          pip install --upgrade pip
+          python -m pip install --group test "$(echo dist/*.tar.gz)"
           python -m pip list
           pytest
 
@@ -57,6 +68,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # fetch the full git history to let us run all our tests
+          fetch-depth: 0
+          # fetch the submodules to let us run the tests
+          submodules: true
 
       - name: Set MACOSX_DEPLOYMENT_TARGET
         if: startsWith( matrix.os, 'macos-' )

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,15 +69,15 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
-  upload_all:
-    name: Publish to PyPI
-    needs: [build_wheels, make_sdist]
-    environment: testpypi
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
+#  upload_all:
+#    name: Publish to PyPI
+#    needs: [build_wheels, make_sdist]
+#    environment: testpypi
+#    permissions:
+#      id-token: write
+#      attestations: write
+#      contents: read
+#
 #    runs-on: ubuntu-latest
 #    #if: github.event_name == 'release' && github.event.action == 'published'
 #    # upload to PyPI on every tag starting with 'grackle-'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,6 +55,9 @@ jobs:
           # macos-13,  # (runs on intel-CPUs)
           macos-14  #(runs on arm cpus)
         ]
+        include:
+          - os: macos-14
+            env: MACOSX_DEPLOYMENT_TARGET=12.3  # required by gfortran
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,6 +46,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [
           ubuntu-latest,

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,29 +69,32 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
-#  upload_all:
-#    name: Publish to
-#    needs: [build_wheels, make_sdist]
-#    environment: pypi
-#    permissions:
-#      id-token: write
-#      attestations: write
-#      contents: read
-#
-#    runs-on: ubuntu-latest
-#    #if: github.event_name == 'release' && github.event.action == 'published'
-#    # upload to PyPI on every tag starting with 'grackle-'
-#    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
-#    steps:
-#      - uses: actions/download-artifact@v4
-#        with:
-#          pattern: cibw-*
-#          path: dist
-#          merge-multiple: true
-#
-#      - name: Generate artifact attestations
-#        uses: actions/attest-build-provenance@v2
-#        with:
-#          subject-path: "dist/*"
-#
-#      - uses: pypa/gh-action-pypi-publish@release/v1
+  upload_all:
+    name: Publish to PyPI
+    needs: [build_wheels, make_sdist]
+    environment: testpypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    runs-on: ubuntu-latest
+    #if: github.event_name == 'release' && github.event.action == 'published'
+    # upload to PyPI on every tag starting with 'grackle-'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish to pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,12 +55,17 @@ jobs:
           # macos-13,  # (runs on intel-CPUs)
           macos-14  #(runs on arm cpus)
         ]
-        include:
-          - os: macos-14
-            env: MACOSX_DEPLOYMENT_TARGET=12.3  # required by gfortran
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set MACOSX_DEPLOYMENT_TARGET on ARM
+        if: matrix.os == 'macos-14'
+        run: |
+          # we may be able to reduce the following version number (or pick
+          # something consistent with Intel-Macs once all fortran code is
+          # removed)
+          echo "CIBW_ENVIRONMENT=MACOSX_DEPLOYMENT_TARGET=12.3" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,23 +78,23 @@ jobs:
       attestations: write
       contents: read
 
-    runs-on: ubuntu-latest
-    #if: github.event_name == 'release' && github.event.action == 'published'
-    # upload to PyPI on every tag starting with 'grackle-'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: cibw-*
-          path: dist
-          merge-multiple: true
-
-      - name: Generate artifact attestations
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
-
-      #- name: Publish to pypi
-      #  uses: pypa/gh-action-pypi-publish@release/v1
-      #    password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #    repository-url: https://test.pypi.org/legacy/
+#    runs-on: ubuntu-latest
+#    #if: github.event_name == 'release' && github.event.action == 'published'
+#    # upload to PyPI on every tag starting with 'grackle-'
+#    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
+#    steps:
+#      - uses: actions/download-artifact@v4
+#        with:
+#          pattern: cibw-*
+#          path: dist
+#          merge-multiple: true
+#
+#      - name: Generate artifact attestations
+#        uses: actions/attest-build-provenance@v2
+#        with:
+#          subject-path: "dist/*"
+#
+#      - name: Publish to pypi
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,13 +69,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
-        # env:
-        #   CIBW_SOME_OPTION: value
-        #    ...
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
+        with:
+          output-dir: dist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,20 +52,26 @@ jobs:
         os: [
           ubuntu-latest,
           # ubuntu-24.04-arm,
-          # macos-13,  # (runs on intel-CPUs)
+          macos-13,  # (runs on intel-CPUs)
           macos-14  #(runs on arm cpus)
         ]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set MACOSX_DEPLOYMENT_TARGET on ARM
-        if: matrix.os == 'macos-14'
+      - name: Set MACOSX_DEPLOYMENT_TARGET
+        if: startsWith( matrix.os, 'macos-' )
         run: |
-          # we may be able to reduce the following version number (or pick
-          # something consistent with Intel-Macs once all fortran code is
-          # removed)
-          echo "CIBW_ENVIRONMENT=MACOSX_DEPLOYMENT_TARGET=12.3" >> "$GITHUB_ENV"
+          # we may be able to reduce the following version numbers (or pick
+          # something consistent b/t Intel & Arm) once all fortran code is
+          # removed
+          RUNNER=${{ matrix.OS }}
+          if [ "$RUNNER" = "macos-14" ]; then  # ARM-builds
+            echo "CIBW_ENVIRONMENT=MACOSX_DEPLOYMENT_TARGET=12.3" >> "$GITHUB_ENV"
+          elif [ "$RUNNER" = "macos-13" ]; then  # Intel-builds
+            echo "CIBW_ENVIRONMENT=MACOSX_DEPLOYMENT_TARGET=10.14" >> "$GITHUB_ENV"
+          fi
+
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Test sdist
         run: |
+          sudo apt-get install libhdf5-dev
           python -m pip install "$(echo dist/*.tar.gz)[dev]"
           python -m pip list
           project_dir=$(pwd)
@@ -48,8 +49,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14] # ubuntu-24.04-arm
+        os: [
+          ubuntu-latest,
+          # ubuntu-24.04-arm,
+          # macos-13,  # (runs on intel-CPUs)
+          macos-14  #(runs on arm cpus)
+        ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,9 +35,7 @@ jobs:
           sudo apt-get install libhdf5-dev
           python -m pip install "$(echo dist/*.tar.gz)[dev]"
           python -m pip list
-          project_dir=$(pwd)
-          python -c "from pygrackle import chemistry_data"
-          # todo: run some more tests
+          pytest
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           subject-path: "dist/*"
 
-      - name: Publish to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+      #- name: Publish to pypi
+      #  uses: pypa/gh-action-pypi-publish@release/v1
+      #    password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #    repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Build SDist
         run: pipx run build --sdist
 
+      - name: Check README rendering for PyPI
+        run: |
+          python -mpip install twine
+          twine check dist/*
+
       - name: Test sdist
         run: |
           sudo apt-get install libhdf5-dev

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,8 +61,8 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          # ubuntu-24.04-arm,
-          macos-13,  # (runs on intel-CPUs)
+          ubuntu-24.04-arm,
+          macos-13, # (runs on intel-CPUs)
           macos-14  #(runs on arm cpus)
         ]
 
@@ -98,32 +98,30 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
-#  upload_all:
-#    name: Publish to PyPI
-#    needs: [build_wheels, make_sdist]
-#    environment: testpypi
-#    permissions:
-#      id-token: write
-#      attestations: write
-#      contents: read
-#
-#    runs-on: ubuntu-latest
-#    #if: github.event_name == 'release' && github.event.action == 'published'
-#    # upload to PyPI on every tag starting with 'grackle-'
-#    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
-#    steps:
-#      - uses: actions/download-artifact@v4
-#        with:
-#          pattern: cibw-*
-#          path: dist
-#          merge-multiple: true
-#
-#      - name: Generate artifact attestations
-#        uses: actions/attest-build-provenance@v2
-#        with:
-#          subject-path: "dist/*"
-#
-#      - name: Publish to pypi
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository-url: https://test.pypi.org/legacy/
+  upload_all:
+    name: Publish to PyPI
+    needs: [build_wheels, make_sdist]
+    environment: testpypi
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    runs-on: ubuntu-latest
+    #if: github.event_name == 'release' && github.event.action == 'published'
+    # upload to PyPI on every tag starting with 'grackle-'
+    #if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish to pypi
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,10 +2,23 @@
 # - https://learn.scientific-python.org/development/guides/gha-wheels/
 # - https://cibuildwheel.pypa.io/en/stable/setup/#github-actions
 # - https://github.com/yt-project/yt/blob/main/.github/workflows/wheels.yaml
+#
+# the numpy action that does the exact same thing
+#   https://github.com/numpy/numpy/blob/main/.github/workflows/wheels.yml
+# illustrates a nifty trick for configuring the action to run whenever a commit
+# is pushed where the commit-message is prefixed with [wheel build]
 
 name: Wheel
 
 on:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    - cron: "17 0 * * MON"
   push:
     branches:
       - main
@@ -62,7 +75,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: false # don't exit abruptly if another wheel can't be built
       matrix:
         os: [
           ubuntu-latest,
@@ -108,15 +121,15 @@ jobs:
   upload_all:
     name: Publish to PyPI
     needs: [build_wheels, make_sdist]
-    environment: testpypi
+    environment: testpypi # CHANGEME to pypi (to start uploading to PyPI)
     permissions:
       id-token: write
       attestations: write
       contents: read
 
     runs-on: ubuntu-latest
-    #if: github.event_name == 'release' && github.event.action == 'published'
     # upload to PyPI on every tag starting with 'grackle-'
+    # uncomment the following line when we start uploading to PyPI
     #if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
     steps:
       - uses: actions/download-artifact@v4
@@ -132,5 +145,5 @@ jobs:
 
       - name: Publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
+        with:  # DELETEME (and the next line) to start uploading to PyPI
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,97 @@
+# inspired by
+# - https://learn.scientific-python.org/development/guides/gha-wheels/
+# - https://cibuildwheel.pypa.io/en/stable/setup/#github-actions
+# - https://github.com/yt-project/yt/blob/main/.github/workflows/wheels.yaml
+
+name: Wheel
+
+on:
+  push:
+    branches:
+      - main
+      - stable
+    tags:
+      - 'grackle-*'
+  pull_request:
+    paths:
+      - '.github/workflows/wheels.yaml'
+  workflow_dispatch:
+
+jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Optional, use if you use setuptools_scm
+          submodules: true # Optional, use if you have submodules
+
+      - name: Build SDist
+        run: pipx run build --sdist
+
+      - name: Test sdist
+        run: |
+          python -m pip install "$(echo dist/*.tar.gz)[dev]"
+          python -m pip list
+          project_dir=$(pwd)
+          python -c "from pygrackle import chemistry_data"
+          # todo: run some more tests
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, macos-13, macos-14] # ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23.3
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #    ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./dist/*.whl
+
+#  upload_all:
+#    name: Publish to
+#    needs: [build_wheels, make_sdist]
+#    environment: pypi
+#    permissions:
+#      id-token: write
+#      attestations: write
+#      contents: read
+#
+#    runs-on: ubuntu-latest
+#    #if: github.event_name == 'release' && github.event.action == 'published'
+#    # upload to PyPI on every tag starting with 'grackle-'
+#    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/grackle-')
+#    steps:
+#      - uses: actions/download-artifact@v4
+#        with:
+#          pattern: cibw-*
+#          path: dist
+#          merge-multiple: true
+#
+#      - name: Generate artifact attestations
+#        uses: actions/attest-build-provenance@v2
+#        with:
+#          subject-path: "dist/*"
+#
+#      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-      - stable
+      - binary-wheel  # just for initial testing purposes
     tags:
       - 'grackle-*'
   pull_request:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,7 +61,9 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          ubuntu-24.04-arm,
+          # we should revisit arm-based builds in the future
+          # -> the tests run REALLY slowly because wheels aren't shipped by yt/matplotlib
+          #ubuntu-24.04-arm,
           macos-13, # (runs on intel-CPUs)
           macos-14  #(runs on arm cpus)
         ]
@@ -125,3 +127,5 @@ jobs:
 
       - name: Publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
 #    test-skip = "*-musllinux*"
 before-build = "python {project}/scripts/wheels/cibw_before_build.py --compile-hl-h5 3rdparty {project}"
 # once we deal with removing the editable-install requirement, we should use:
-test-extras = "dev"  # <- this installs the test dependencies
+test-groups = "test"  # <- this installs the test dependencies
 test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,15 +114,25 @@ minimum-version = "build-system.requires"
 sdist.exclude = [
     # exclude continuous integration:
     ".circleci", ".readthedocs.yml", ".github",
-    # exclude data files (the sdist is subject to the same rules as wheels)
-    "input", "grackle_data_files",
     # exclude files related to creating precompiled wheels
     "scripts/wheels",
+    # exclude data files since we want the sdist to follow the same rules as wheels
+    # when it comes to data file distribution (for simplicity).
+    # -> the main value of including the files would be if somebody wanted to download
+    #    the sdist, untar it, and run tests. But, I would argue that they should be
+    #    cloning the git repository for that purpose
+    # -> this would also make the sdist ~65 times bigger
+    "input", "grackle_data_files",
+    # if we aren't including data-files, there's no reason to include pygrackle-tests
+    # (all meaningful tests will currently fail)
+    "src/python/tests",
+    # if we aren't including data-files, there's no reason to include the pygrackle
+    # code examples (they currently require editable installations)
+    "src/python/examples",
+    # for consistency, we exclude the core-library tests and examples
+    "tests", "src/examples",
     # exclude miscellaneous classic-build-system machinery
-    "configure", "src/Makefile", "src/examples/Make*",
-    # exclude classic-build-system machinery from src/clib
-    "src/clib/Makefile", "src/clib/Make.*"
-    # should we exclude "tests" and "src/examples"?
+    "configure", "src/Makefile", "src/examples/Make*", "src/clib/Make*"
 ]
 
 # A list of packages to auto-copy into the wheel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ sdist.exclude = [
     # code examples (they currently require editable installations)
     "src/python/examples",
     # for consistency, we exclude the core-library tests and examples
-    "tests", "src/examples",
+    "tests", "src/example",
     # exclude miscellaneous classic-build-system machinery
     "configure", "src/Makefile", "src/examples/Make*", "src/clib/Make*"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,21 +38,25 @@ classifiers=[
   "Operating System :: POSIX :: Linux",
   "Operating System :: Unix",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 keywords=[
   "simulation", "chemistry", "cooling", "astronomy", "astrophysics"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
   'h5py',
   'numpy',
   'matplotlib',
   'yt>=4.0.2'
 ]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
 
 [project.license]
 text = "BSD 3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,8 @@ build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
 before-build = "python {project}/scripts/wheels/cibw_before_build.py --compile-hl-h5 3rdparty {project}"
 # once we deal with removing the editable-install requirement, we should use:
 test-groups = "test"  # <- this installs the test dependencies
-test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
+#test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
+test-command = "cd {project} && pytest --color=yes"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ sdist.exclude = [
     # exclude files related to creating precompiled wheels
     "scripts/wheels",
     # exclude miscellaneous classic-build-system machinery
-    "configure", "src/Makefile", "src/examples/Make*"
+    "configure", "src/Makefile", "src/examples/Make*",
     # exclude classic-build-system machinery from src/clib
     "src/clib/Makefile", "src/clib/Make.*"
     # should we exclude "tests" and "src/examples"?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ For more context:
 
 
 [tool.cibuildwheel]
-build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
+build = "cp310-* cp311-* cp312-* cp313-*"
 skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 # we compile high-level hdf5 api purely so we can run the test-command on musllinux
 # -> h5py doesn't ship binary-wheels for that platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,19 @@ minimum-version = "build-system.requires"
 
 # Files to exclude from the SDist (even if they're included by default).
 # Supports gitignore syntax.
-sdist.exclude = [".circleci",".readthedocs.yml"]
+sdist.exclude = [
+    # exclude continuous integration:
+    ".circleci", ".readthedocs.yml", ".github",
+    # exclude data files (the sdist is subject to the same rules as wheels)
+    "input", "grackle_data_files",
+    # exclude files related to creating precompiled wheels
+    "scripts/wheels",
+    # exclude miscellaneous classic-build-system machinery
+    "configure", "src/Makefile", "src/examples/Make*"
+    # exclude classic-build-system machinery from src/clib
+    "src/clib/Makefile", "src/clib/Make.*"
+    # should we exclude "tests" and "src/examples"?
+]
 
 # A list of packages to auto-copy into the wheel.
 wheel.packages = ["./src/python/pygrackle"]
@@ -125,3 +137,19 @@ wheel.exclude = [
     # No need to package template files
     "**.py.in"
 ]
+
+
+[tool.cibuildwheel]
+build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
+# we compile high-level hdf5 api purely so we can run the test-command on musllinux
+# -> h5py doesn't ship binary-wheels for that platform
+# -> depending on how long h5py takes to compile, it may be better to simply use
+#    test-skip = "*-musllinux*"
+before-build = "python {project}/scripts/wheels/cibw_before_build.py --compile-hl-h5 3rdparty {project}"
+# once we deal with removing the editable-install requirement, we should use:
+#test-extras = "dev"  # <- this installs the test dependencies
+#test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
+test-command = 'python -c "from pygrackle import chemistry_data"'
+
+[tool.cibuildwheel.linux]
+archs = "x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,15 +190,11 @@ For more context:
 
 [tool.cibuildwheel]
 build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
+skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 # we compile high-level hdf5 api purely so we can run the test-command on musllinux
 # -> h5py doesn't ship binary-wheels for that platform
 # -> depending on how long h5py takes to compile, it may be better to simply use
 #    test-skip = "*-musllinux*"
 before-build = "python {project}/scripts/wheels/cibw_before_build.py --compile-hl-h5 3rdparty {project}"
-# once we deal with removing the editable-install requirement, we should use:
 test-groups = "test"  # <- this installs the test dependencies
-#test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
-test-command = "cd {project} && pytest --color=yes"
-
-[tool.cibuildwheel.linux]
-archs = "x86_64"
+test-command = "bash {project}/scripts/wheels/cibw_test_command.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,45 @@ wheel.exclude = [
     "**.py.in"
 ]
 
+[[tool.scikit-build.overrides]]
+# we are using scikit-build-core's override-functionality to provide a detailed
+# error message when a build from a sdist fails
+if.from-sdist = true
+# maybe we should move most of this message to the website and provide a link
+# to the website
+messages.after-failure = """
+{bold.red}Your build of pygrackle from a sdist failed.{normal} (You should
+ignore the rest of this message if you were explicitly want to install from an
+sdist).
+
+For more context:
+
+- The sdist and wheel formats are the 2 modern standardized formats for python
+  package distribution. At a high-level, both of them handle a package's python
+  code in a similar manner. The largest differences occurs when packages (like
+  grackle) have extension modules, written in compiled languages (like C).
+  1. A sdist (source-distribution) includes the extension modules' source code.
+     When installing an sdist, your package manager (e.g. pip) directly compiles
+     the extension module & links it against dependencies, as part of process.
+  2. A wheel ships a precompiled copy of extension module (& copies of external
+     dependencies). During installation, your package manager copies the
+     precompiled extension module & any dependencies to the installation
+
+- Since your package manager tried to install pygrackle from a sdist, that
+  probably means that a wheel isn't available for your current python version
+  on the {platform.platform} (with the {platform.machine}). If this is a common
+  Unix platform, please let the us (the Grackle developers know) and we can
+  consider adding wheels for this platform in the future.
+
+- Your build probably failed because you are missing a compiler, your compiler
+  is too old, you are missing a dependency (e.g. hdf5), or the build-system
+  can't automatically infer some of this info.
+
+- We recommend installing pygrackle directly from the git repository. We provide
+  detailed instructions on our website (https://grackle.readthedocs.io). If you
+  encounter further problems, please reach out.
+"""
+
 
 [tool.cibuildwheel]
 build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,9 +147,8 @@ build = "cp310-*"  # <- FIXME: "cp310-* cp311-* cp312-* cp313-*"
 #    test-skip = "*-musllinux*"
 before-build = "python {project}/scripts/wheels/cibw_before_build.py --compile-hl-h5 3rdparty {project}"
 # once we deal with removing the editable-install requirement, we should use:
-#test-extras = "dev"  # <- this installs the test dependencies
-#test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
-test-command = 'python -c "from pygrackle import chemistry_data"'
+test-extras = "dev"  # <- this installs the test dependencies
+test-command = "pytest -c {project}/pyproject.toml --color=yes {project}"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"

--- a/scripts/configure_file.py
+++ b/scripts/configure_file.py
@@ -23,7 +23,7 @@ def is_valid_varname(s, start = None, stop = None):
     return re.fullmatch(_VALID_VARNAME_STR, s[slice(start, stop)]) is not None
     
 
-def configure_file(lines, variable_map, out_fname):
+def configure_file(lines, variable_map, out_fname, literal_linenos):
     """
     Writes a new file to out_fname, line-by-line, while performing variable
     substituions
@@ -53,14 +53,17 @@ def configure_file(lines, variable_map, out_fname):
         # make sure to drop any trailing '\n'
         assert line[-1] == '\n', "sanity check!"
         line = line[:-1]
-        match_count = 0
-
-        out_f.write(_PATTERN.sub(replace,line))
+        if line_num in literal_linenos:
+            subbed = line
+        else:
+            match_count = 0
+            subbed = _PATTERN.sub(replace,line)
+        out_f.write(subbed)
         out_f.write('\n')
         if err_msg is not None:
             out_f.close()
             os.remove(out_fname)
-            raise RuntimeError(rslt)
+            raise RuntimeError(err_msg)
 
     unused_variables = used_variable_set.symmetric_difference(variable_map)
 
@@ -134,12 +137,16 @@ def main(args):
     _parse_variables(variable_map, args.variable_use_file_contents,
                      val_is_file_path = True)
 
+    literal_linenos = set()
+    if args.literal_linenos is not None:
+        literal_linenos = set(args.literal_linenos)
     # use variable_map to actually create the output file
     with open(args.input, 'r') as f_input:
         line_iterator = iter(f_input)
         configure_file(lines = line_iterator,
                        variable_map = variable_map,
-                       out_fname = out_fname)
+                       out_fname = out_fname,
+                       literal_linenos=literal_linenos)
 
     return 0
 
@@ -164,6 +171,10 @@ parser.add_argument(
 parser.add_argument(
     "--clobber", action = "store_true",
     help = "overwrite the output file if it already exists"
+)
+parser.add_argument(
+    "--literal-linenos", nargs="*", type=int,
+    help = "line numbers corresponding to lines that are treated as literals"
 )
 
 if __name__ == '__main__':

--- a/scripts/wheels/README.md
+++ b/scripts/wheels/README.md
@@ -1,0 +1,3 @@
+This directory holds scripts/resources used for precompiling wheels.
+
+It probably makes sense to make this a separate directory so we avoid distributing the license-annex within the sdist

--- a/scripts/wheels/README.md
+++ b/scripts/wheels/README.md
@@ -1,3 +1,13 @@
-This directory holds scripts/resources used for precompiling wheels.
+This directory holds scripts/resources used for precompiling wheels. They are all launched by cibuildwheel.
 
-It probably makes sense to make this a separate directory so we avoid distributing the license-annex within the sdist
+## Background
+
+To precompile wheels, we make use of [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/), which is a tool maintained by the [Python Packaging Authority](https://www.pypa.io/en/latest/). ``cibuildwheel`` is an extremely popular tool used for creating binary wheels (e.g. numpy, scipy, h5py, yt, pandas, astropy).
+
+cibuildwheel is run by GitHub Actions, and its configuration values are stored within **pyproject.toml**.
+
+## About the scripts
+
+Pygrackle is similar to packages like numpy/scipy/h5py in the sense that its extension modules rely upon external shared libraries that aren't are always provided by external platforms (or external platforms may provide incompatible versions of the dependencies). Consequently, we need to retrieve/compile external dependencies and distribute precompiled-copies of these dependencies as part of the binary wheel. Currently, we redistribute libhdf5, HDF5's runtime dependencies, and gfortran's runtime libraries (the precise details vary with platform). Of course, we also need to distribute the associated licenses in the binary wheel.
+
+To properly configure wheels to do all of this, we instruct cibuildwheel to invoke the scripts in this directory. Specifically, the scripts with the prefix "cibw_" are the ones that are directly invoked from cibuildwheel.

--- a/scripts/wheels/binary_license_annex.txt.in
+++ b/scripts/wheels/binary_license_annex.txt.in
@@ -106,7 +106,7 @@ License: HDF5
   -----------------------------------------------------------------------------
 
 Name: GCC runtime library
-Files: @PREFIX@/libgfortran*
+Files: @PREFIX@/libgfortran* @PREFIX@/libgcc_s*
 Description: dynamically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
 License: GPL-3.0-or-later WITH GCC-exception-3.1

--- a/scripts/wheels/binary_license_annex.txt.in
+++ b/scripts/wheels/binary_license_annex.txt.in
@@ -104,6 +104,39 @@ Availability: https://github.com/HDFGroup/hdf5
   
   -----------------------------------------------------------------------------
 
+Name: libaec - Adaptive Entropy Coding library
+Files: @PREFIX@/libaec*
+Description: provides compression (we use it for hdf5's builtin SZIP filter)
+Availability: https://github.com/MathisRosenhauer/libaec
+License: BSD-2-Clause
+
+Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
 Name: GCC runtime library
 Files: @PREFIX@/libgfortran*
 Description: dynamically linked to files compiled with gcc

--- a/scripts/wheels/binary_license_annex.txt.in
+++ b/scripts/wheels/binary_license_annex.txt.in
@@ -7,6 +7,7 @@ Name: HDF5
 Files: @PREFIX@/libhdf5*
 Description: bundled as a dynamically linked library
 Availability: https://github.com/HDFGroup/hdf5
+License: HDF5
   Copyright Notice and License Terms for
   HDF5 (Hierarchical Data Format 5) Software Library and Utilities
   -----------------------------------------------------------------------------
@@ -108,7 +109,7 @@ Name: GCC runtime library
 Files: @PREFIX@/libgfortran*
 Description: dynamically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
-License: GPL-3.0-with-GCC-exception
+License: GPL-3.0-or-later WITH GCC-exception-3.1
      Copyright (C) 2002-2025 Free Software Foundation, Inc.
      Contributed by Paul Brook <paul@nowt.org>, and
      Andy Vaught <andy@xena.eas.asu.edu>

--- a/scripts/wheels/binary_license_annex.txt.in
+++ b/scripts/wheels/binary_license_annex.txt.in
@@ -1,0 +1,1430 @@
+
+-------
+
+This binary distribution of Pygrackle also distributes the following software:
+
+Name: HDF5
+Files: @PREFIX@/libhdf5*
+Description: bundled as a dynamically linked library
+Availability: https://github.com/HDFGroup/hdf5
+  Copyright Notice and License Terms for
+  HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+  -----------------------------------------------------------------------------
+  
+  HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+  Copyright 2006 by The HDF Group.
+  
+  NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+  Copyright 1998-2006 by The Board of Trustees of the University of Illinois.
+  
+  All rights reserved.
+  
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted for any purpose (including commercial purposes)
+  provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions, and the following disclaimer.
+  
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions, and the following disclaimer in the documentation
+     and/or materials provided with the distribution.
+  
+  3. Neither the name of The HDF Group, the name of the University, nor the
+     name of any Contributor may be used to endorse or promote products derived
+     from this software without specific prior written permission from
+     The HDF Group, the University, or the Contributor, respectively.
+  
+  DISCLAIMER:
+  THIS SOFTWARE IS PROVIDED BY THE HDF GROUP AND THE CONTRIBUTORS
+  "AS IS" WITH NO WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED. IN NO
+  EVENT SHALL THE HDF GROUP OR THE CONTRIBUTORS BE LIABLE FOR ANY DAMAGES
+  SUFFERED BY THE USERS ARISING OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  
+  You are under no obligation whatsoever to provide any bug fixes, patches, or
+  upgrades to the features, functionality or performance of the source code
+  ("Enhancements") to anyone; however, if you choose to make your Enhancements
+  available either publicly, or directly to The HDF Group, without imposing a
+  separate written license agreement for such Enhancements, then you hereby
+  grant the following license: a non-exclusive, royalty-free perpetual license
+  to install, use, modify, prepare derivative works, incorporate into other
+  computer software, distribute, and sublicense such enhancements or derivative
+  works thereof, in binary and source code form.
+  
+  -----------------------------------------------------------------------------
+  -----------------------------------------------------------------------------
+  
+  Contributors:   National Center for Supercomputing Applications (NCSA) at
+  the University of Illinois, Fortner Software, Unidata Program Center
+  (netCDF), The Independent JPEG Group (JPEG), Jean-loup Gailly and Mark Adler
+  (gzip), and Digital Equipment Corporation (DEC).
+  
+  -----------------------------------------------------------------------------
+  
+  Portions of HDF5 were developed with support from the Lawrence Berkeley
+  National Laboratory (LBNL) and the United States Department of Energy
+  under Prime Contract No. DE-AC02-05CH11231.
+  
+  -----------------------------------------------------------------------------
+  
+  Portions of HDF5 were developed with support from Lawrence Livermore
+  National Laboratory and the United States Department of Energy under
+  Prime Contract No. DE-AC52-07NA27344.
+  
+  -----------------------------------------------------------------------------
+  
+  Portions of HDF5 were developed with support from the University of
+  California, Lawrence Livermore National Laboratory (UC LLNL).
+  The following statement applies to those portions of the product and must
+  be retained in any redistribution of source code, binaries, documentation,
+  and/or accompanying materials:
+  
+     This work was partially produced at the University of California,
+     Lawrence Livermore National Laboratory (UC LLNL) under contract
+     no. W-7405-ENG-48 (Contract 48) between the U.S. Department of Energy
+     (DOE) and The Regents of the University of California (University)
+     for the operation of UC LLNL.
+  
+     DISCLAIMER:
+     THIS WORK WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF
+     THE UNITED STATES GOVERNMENT. NEITHER THE UNITED STATES GOVERNMENT NOR
+     THE UNIVERSITY OF CALIFORNIA NOR ANY OF THEIR EMPLOYEES, MAKES ANY
+     WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY OR RESPONSIBILITY
+     FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY INFORMATION,
+     APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE
+     WOULD NOT INFRINGE PRIVATELY- OWNED RIGHTS. REFERENCE HEREIN TO ANY
+     SPECIFIC COMMERCIAL PRODUCTS, PROCESS, OR SERVICE BY TRADE NAME,
+     TRADEMARK, MANUFACTURER, OR OTHERWISE, DOES NOT NECESSARILY CONSTITUTE
+     OR IMPLY ITS ENDORSEMENT, RECOMMENDATION, OR FAVORING BY THE UNITED
+     STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA. THE VIEWS AND
+     OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE OR REFLECT
+     THOSE OF THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA,
+     AND SHALL NOT BE USED FOR ADVERTISING OR PRODUCT ENDORSEMENT PURPOSES.
+  
+  -----------------------------------------------------------------------------
+
+Name: GCC runtime library
+Files: @PREFIX@/libgfortran*
+Description: dynamically linked to files compiled with gcc
+Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
+License: GPL-3.0-with-GCC-exception
+     Copyright (C) 2002-2025 Free Software Foundation, Inc.
+     Contributed by Paul Brook <paul@nowt.org>, and
+     Andy Vaught <andy@xena.eas.asu.edu>
+  
+  This file is part of the GNU Fortran runtime library (libgfortran).
+  
+  Libgfortran is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3, or (at your option)
+  any later version.
+  
+  Libgfortran is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  Under Section 7 of GPL version 3, you are granted additional
+  permissions described in the GCC Runtime Library Exception, version
+  3.1, as published by the Free Software Foundation.
+  
+  You should have received a copy of the GNU General Public License and
+  a copy of the GCC Runtime Library Exception along with this program;
+  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+  <http://www.gnu.org/licenses/>.
+
+----
+
+Full text of license texts referred to above follows (that they are
+listed below does not necessarily imply the conditions apply to the
+present binary release):
+
+----
+
+GCC RUNTIME LIBRARY EXCEPTION
+
+Version 3.1, 31 March 2009
+
+Copyright (C) 2009 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+This GCC Runtime Library Exception ("Exception") is an additional
+permission under section 7 of the GNU General Public License, version
+3 ("GPLv3"). It applies to a given file (the "Runtime Library") that
+bears a notice placed by the copyright holder of the file stating that
+the file is governed by GPLv3 along with this Exception.
+
+When you use GCC to compile a program, GCC may combine portions of
+certain GCC header files and runtime libraries with the compiled
+program. The purpose of this Exception is to allow compilation of
+non-GPL (including proprietary) programs to use, in this way, the
+header files and runtime libraries covered by this Exception.
+
+0. Definitions.
+
+A file is an "Independent Module" if it either requires the Runtime
+Library for execution after a Compilation Process, or makes use of an
+interface provided by the Runtime Library, but is not otherwise based
+on the Runtime Library.
+
+"GCC" means a version of the GNU Compiler Collection, with or without
+modifications, governed by version 3 (or a specified later version) of
+the GNU General Public License (GPL) with the option of using any
+subsequent versions published by the FSF.
+
+"GPL-compatible Software" is software whose conditions of propagation,
+modification and use would permit combination with GCC in accord with
+the license of GCC.
+
+"Target Code" refers to output from any compiler for a real or virtual
+target processor architecture, in executable form or suitable for
+input to an assembler, loader, linker and/or execution
+phase. Notwithstanding that, Target Code does not include data in any
+format that is used as a compiler intermediate representation, or used
+for producing a compiler intermediate representation.
+
+The "Compilation Process" transforms code entirely represented in
+non-intermediate languages designed for human-written code, and/or in
+Java Virtual Machine byte code, into Target Code. Thus, for example,
+use of source code generators and preprocessors need not be considered
+part of the Compilation Process, since the Compilation Process can be
+understood as starting with the output of the generators or
+preprocessors.
+
+A Compilation Process is "Eligible" if it is done using GCC, alone or
+with other GPL-compatible software, or if it is done without using any
+work based on GCC. For example, using non-GPL-compatible Software to
+optimize any GCC intermediate representations would not qualify as an
+Eligible Compilation Process.
+
+1. Grant of Additional Permission.
+
+You have permission to propagate a work of Target Code formed by
+combining the Runtime Library with Independent Modules, even if such
+propagation would otherwise violate the terms of GPLv3, provided that
+all Target Code was generated by Eligible Compilation Processes. You
+may then convey such a combination under terms of your choice,
+consistent with the licensing of the Independent Modules.
+
+2. No Weakening of GCC Copyleft.
+
+The availability of this Exception does not imply any general
+presumption that third-party software is unaffected by the copyleft
+requirements of the license of GCC.
+
+----
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+
+Name: libquadmath
+Files: @PREFIX@/libquadmath*
+Description: dynamically linked to files compiled with gcc
+Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libquadmath
+License: LGPL-2.1-or-later
+     GCC Quad-Precision Math Library
+     Copyright (C) 2010-2019 Free Software Foundation, Inc.
+     Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
+   
+  This file is part of the libquadmath library.
+  Libquadmath is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+  
+  Libquadmath is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+  
+  You should have received a copy of the GNU Library General Public
+  License along with libquadmath; see the file COPYING.LIB.  If
+  not, write to the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+  Boston, MA 02110-1301, USA.
+
+----
+
+Full text of license text referred to above follows (that it is
+listed below does not necessarily imply the conditions apply to the
+present binary release):
+
+----
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/scripts/wheels/binary_license_annex.txt.in
+++ b/scripts/wheels/binary_license_annex.txt.in
@@ -104,39 +104,6 @@ Availability: https://github.com/HDFGroup/hdf5
   
   -----------------------------------------------------------------------------
 
-Name: libaec - Adaptive Entropy Coding library
-Files: @PREFIX@/libaec*
-Description: provides compression (we use it for hdf5's builtin SZIP filter)
-Availability: https://github.com/MathisRosenhauer/libaec
-License: BSD-2-Clause
-
-Copyright 2024 Mathis Rosenhauer, Moritz Hanke, Joerg Behrens, Luis Kornblueh
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-----
-
 Name: GCC runtime library
 Files: @PREFIX@/libgfortran*
 Description: dynamically linked to files compiled with gcc

--- a/scripts/wheels/check_packaged_dependency_licenses.py
+++ b/scripts/wheels/check_packaged_dependency_licenses.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""
+Check that the vendored dependencies & binary licenses all match
+
+This is intended to be installed once the pygrackle wheel has been installed
+"""
+
+from dataclasses import dataclass
+import fnmatch
+import re
+import os
+import pathlib
+import platform
+from typing import Optional
+import sys
+
+
+@dataclass
+class LicenseInfo:
+    name: str
+    location: str  # location where the info was parsed from
+    availability: Optional[str] = None
+    description: Optional[str] = None
+    files: Optional[str] = None # specifies file(s) that the license applies to
+
+
+def parse_license_file(path):
+
+    def _chunks(f):
+        chunk = None
+        for lineno, line in enumerate(f, start=1):
+            m = re.match(r"^(?P<field>[A-Za-z]+):\s*(?P<value>\S(.*\S)?)$", line)
+            if m is None:
+                yield chunk
+                chunk = None
+            elif m.group("field").lower() == "name":
+                yield chunk
+                chunk = LicenseInfo(name=m.group("value"), location=f"{path!s}:{lineno}")
+            elif m is not None:
+                setattr(chunk, m.group("field").lower(), m.group("value"))
+        yield chunk
+
+    out = {}
+    with open(path, "r") as f:
+        return [chunk for chunk in _chunks(f) if chunk is not None]
+
+
+def get_vendored_libs(pygrackle_dir):
+    if platform.system() == "Darwin":
+        lib_dir = pygrackle_dir / ".dylibs"
+    else:
+        lib_dir = pygrackle_dir.parent / "pygrackle.libs"
+    lib_paths = []
+    with os.scandir(lib_dir) as it:
+        for entry in it:
+            if entry.is_file():
+                lib_paths.append(entry.path)
+            else:
+                raise RuntimeError(f"{lib_dir} holds a non-file: {entry.path}")
+    return set(lib_paths)
+
+
+def main():
+    try:
+        import pygrackle
+    except ImportError:
+        print("ERROR: this check requires pygrackle to be installed")
+        return 1
+    pygrackle_dir = pathlib.Path(pygrackle.__file__).parent
+
+    # get a list of external libraries that we have packaged
+    lib_paths = get_vendored_libs(pygrackle_dir)
+
+    # find and parse the license file
+    distinfo = list(pygrackle_dir.parent.glob("pygrackle-*.dist-info"))[0]
+    license_entries = parse_license_file(distinfo / "licenses" / "LICENSE")
+
+    # now, we will go through and make sure every license_entry corresponds to 1 or more
+    # lib_path entries (and vice-versa)
+    all_matches = set()
+    for entry in license_entries:
+        patterns = entry.files.split()  # patterns may be separated by whitespace
+        for pat in patterns:
+            matches = fnmatch.filter(lib_paths, str(pygrackle_dir.parent / pat))
+            if len(matches) == 0:
+                print(
+                    f"ERROR: the file pattern `{pat}` describe a packaged library. This "
+                    f"pattern describes `{entry.location}`, from `{entry.location}`"
+                )
+                return 1
+            all_matches.update(matches)
+    if len(all_matches) != len(lib_paths):
+        no_matches = lib_paths.difference(all_matches)
+        tmp = "ERROR: packaged libs don't have license entries"
+        print(tmp, *no_matches, sep="\n   ")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wheels/check_packaged_dependency_licenses.py
+++ b/scripts/wheels/check_packaged_dependency_licenses.py
@@ -82,10 +82,15 @@ def main():
         patterns = entry.files.split()  # patterns may be separated by whitespace
         for pat in patterns:
             matches = fnmatch.filter(lib_paths, str(pygrackle_dir.parent / pat))
-            if len(matches) == 0:
+            if len(matches) == 0 and pat.endswith("libgcc_s*"):
+                # this we make an exception for this case because it's needed for some
+                # linux-wheels, but not all of them
+                continue
+            elif len(matches) == 0:
                 print(
-                    f"ERROR: the file pattern `{pat}` describe a packaged library. This "
-                    f"pattern describes `{entry.location}`, from `{entry.location}`"
+                    f"ERROR: the file pattern `{pat}` doesn't describe a packaged "
+                    f"library. This pattern describes `{entry.location}`, which is "
+                    f"defined, starting at `{entry.location}`"
                 )
                 return 1
             all_matches.update(matches)

--- a/scripts/wheels/cibw_before_build.py
+++ b/scripts/wheels/cibw_before_build.py
@@ -1,0 +1,205 @@
+# the goal is for this script to be very portable
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+_LOCAL_DIR = os.path.dirname(__file__)
+_IS_MACOS = platform.system() == "Darwin"
+
+
+def _run(*args, check=True, **kwargs):
+    print(">", *args, sep=" ")
+    return subprocess.run(args, check=check, **kwargs)
+
+
+def calc_checksum(fname, *, alg_name, chunksize=8192):
+    """Calculate the checksum for a given fname"""
+
+    # logic is duplicated by scripts in PR #235 AND #307
+
+    hash_obj = hashlib.new(alg_name)
+    with open(fname, "rb") as f:
+        buffer = bytearray(chunksize)
+        while True:
+            nbytes = f.readinto(buffer)
+            if nbytes == chunksize:
+                hash_obj.update(buffer)
+            elif nbytes:  # equivalent to: (nbytes is not None) and (nbytes > 0)
+                hash_obj.update(buffer[:nbytes])
+            else:
+                break
+    return f"{alg_name.lower()}:{hash_obj.hexdigest()}"
+
+
+def download_file(url, *, dst=None, dst_dir=None, quiet=None, cksum=None):
+    """download the file from url to dst"""
+
+    # logic is duplicated by scripts in PR #235 AND #307
+
+    basename = os.path.basename(url if dst is None else dst)
+    if (dst is not None) and (dst_dir is not None):
+        raise ValueError("dst and dst_dir can't both be specified")
+    elif dst is None:
+        dst = os.path.join("." if dst_dir is None else dst_dir, basename)
+
+    quiet = quiet if quiet is not None else "true" == os.getenv("CI", None)
+
+    choices = [
+        ("wget", None, "--output-document", "--quiet"),
+        ("curl", "-L", "--output", "--silent"),
+    ]
+    for tool, loc_flag, outflag, quietflag in choices:
+        if shutil.which(tool) is not None:
+            quiet_args = [quietflag] if quiet else []
+            url_args = [url] if loc_flag is None else [loc_flag, url]
+            _cmd = [tool, outflag, dst] + quiet_args + url_args
+            _run(*_cmd, check=True)
+
+            if cksum is not None:
+                alg_name, _ = cksum.split(":")
+                actual = calc_checksum(fname=dst, alg_name=alg_name)
+                if cksum != actual:
+                    raise RuntimeError(
+                        f"cksum mismatch for {basename}\n"
+                        f"  expected={cksum}\n  actual={actual}"
+                    )
+            return dst
+    raise RuntimeError("neither wget nor curl is installed")
+
+
+def get_gfortran(depend_dir):
+    if not _IS_MACOS:
+        return None  # gfortran already exists on Linux
+    print("downloading gfortran")
+
+    release, _, machine = platform.mac_ver()
+    if machine == "arm64":
+        # this branch is inspired by scipy's tool/wheels/cibw_before_build_macos.sh
+        dmg_path = download_file(
+            url="https://github.com/fxcoudert/gfortran-for-macOS/releases/download/12.1-monterey/gfortran-ARM-12.1-Monterey.dmg",
+            cksum="sha256:e2e32f491303a00092921baebac7ffb7ae98de4ca82ebbe9e6a866dd8501acdf",
+            dst=f"{depend_dir}/gfortran.dmg",
+        )
+    else:
+        dmg_path = download_file(
+            url="https://github.com/fxcoudert/gfortran-for-macOS/releases/download/12.1-monterey/gfortran-Intel-12.1-Monterey.dmg",
+            cksum="sha256:ef3e1b4fa981c60bbe97aea8a67691d0040a74bc0962d9d9eaf9b00b536b97e0",
+            dst=f"{depend_dir}/gfortran.dmg",
+        )
+
+    # install the disk image
+    _run("hdiutil", "attach", "-mountpoint", "/Volumes/gfortran", dmg_path)
+    _run(
+        "sudo", "installer", "-pkg", "/Volumes/gfortran/gfortran.pkg", "-target", "/"
+    )
+    _run("type", "-p", "gfortran")
+
+
+
+def get_hdf5(depend_dir, compile_hl_api=False):
+    # this logic could ostensibly be placed into src/python/CMakeLists.txt (to be
+    # invoked by scikit-build-core)
+    # -> if we do that, we need to make it **VERY** clear not to use the logic within
+    #    the CMake build of the core grackle-library (people almost never want that
+    #    because it means that downstream simulation codes can't link against hdf5)
+    # -> The advantage to keeping this separate is that we can avoid recompiling hdf5
+    #    for each time we compile a wheel with a different ABI (py310, py311, on a
+    #    given platform)
+    archive_path = download_file(
+        url="https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz",
+        cksum="sha256:09ee1c671a87401a5201c06106650f62badeea5a3b3941e9b1e2e1e08317357f",
+        dst_dir=depend_dir,
+    )
+
+    src_dir, build_dir = [os.path.join(depend_dir, p) for p in ("h5-src", "h5-build")]
+    os.mkdir(src_dir)
+    _run("tar", "-xf", archive_path, "-C", src_dir, "--strip-components=1")
+    _run(  # configure the build
+        "cmake",
+        f"-S{src_dir}",
+        f"-B{build_dir}",
+        "-DCMAKE_INSTALL_PREFIX=/usr/local/",
+        "-DBUILD_STATIC_LIBS=OFF",
+        # we only compile the high-level api if we want to be able to compile h5py on
+        # platforms (e.g. musllinux) where h5py doesn't provide binary wheels
+        f"-DHDF5_BUILD_HL_LIB={compile_hl_api!s}",
+        # here we just disable a bunch of unneeded components
+        "-DBUILD_TESTING=OFF",
+        "-DHDF5_BUILD_CPP_LIB=OFF",
+        "-DHDF5_BUILD_EXAMPLES=OFF",
+        "-DHDF5_BUILD_FORTRAN=OFF",
+        "-DHDF5_BUILD_JAVA=OFF",
+        "-DHDF5_BUILD_TOOLS=OFF",
+        "-DHDF5_BUILD_PARALLEL_TOOLS=OFF",
+        "-DHDF5_BUILD_STATIC_TOOLS=OFF",
+        # at this time, we don't need the following:
+        "-DHDF5_ENABLE_SZIP_SUPPORT=OFF",
+        "-DHDF5_ENABLE_Z_LIB_SUPPORT=OFF",  # the option-name changes in HDF5 2.0
+    )
+    _run("cmake", "--build", build_dir)  # compile hdf5
+    _run("cmake", "--install", build_dir)  # install hdf5 to install_dir
+
+
+def handle_license(project_dir):
+    prefix = "pygrackle/.dylibs" if _IS_MACOS else "pygrackle.libs"
+    template_path = os.path.join(_LOCAL_DIR, "binary_license_annex.txt.in")
+    print(f"replacing @PREFIX@ with {prefix} in {template_path}")
+    configure_bin = os.path.join(_LOCAL_DIR, "..", "configure_file.py")
+    annex_path = os.path.join(_LOCAL_DIR, "_binary_license_annex.txt")
+    literal_linenos = ["112", "113", "902"]
+    _run(
+        configure_bin,
+        f"--input={template_path}",
+        f"--output={annex_path}",
+        "--clobber",
+        f"PREFIX={prefix}",
+        "--literal-linenos",
+        *literal_linenos
+    )
+
+
+    license_path = os.path.join(project_dir, "LICENSE")
+    assert os.path.isfile(license_path)
+    print(f"append binary-license-annex to {license_path}")
+    with open(license_path, "a") as fout:
+        with open(annex_path, "r") as fsrc:
+            shutil.copyfileobj(fsrc, fout)
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--compile-hl-h5", action="store_true", help="compile high-level h5 api"
+)
+parser.add_argument("depend_dir", help="scratch-space while setting up dependencies")
+parser.add_argument("project_dir", help="path to the project-dir")
+
+if __name__ == "__main__":
+    if sys.platform.startswith("win32"):
+        raise ValueError("there's currently no support for windows")
+    args = parser.parse_args()
+    depend_dir, project_dir = args.depend_dir, args.project_dir
+
+    print("Showing Environment")
+    for key, value in os.environ.items():
+        print(f"  {key!s}={value!s}")
+
+    handle_license(args.project_dir)
+
+    # make the dependency-directory
+    print(f"creating: {depend_dir}")
+    if os.path.isdir(args.depend_dir):
+        print("the directory already exists -- nothing needs to be done")
+    else:
+        os.mkdir(args.depend_dir)
+
+        # install gfortran (does nothing on linux -- where gfortran is already installed)
+        get_gfortran(args.depend_dir)
+
+        # download, build, and install HDF5
+        get_hdf5(args.depend_dir, compile_hl_api=args.compile_hl_h5)

--- a/scripts/wheels/cibw_before_build.py
+++ b/scripts/wheels/cibw_before_build.py
@@ -236,7 +236,7 @@ def handle_license(project_dir):
     print(f"replacing @PREFIX@ with {prefix} in {template_path}")
     configure_bin = os.path.join(_LOCAL_DIR, "..", "configure_file.py")
     annex_path = os.path.join(_LOCAL_DIR, "_binary_license_annex.txt")
-    literal_linenos = ["112", "113", "902"]
+    literal_linenos = ["113", "114", "903"]
     _run(
         configure_bin,
         f"--input={template_path}",

--- a/scripts/wheels/cibw_before_build.py
+++ b/scripts/wheels/cibw_before_build.py
@@ -142,7 +142,10 @@ def get_hdf5(depend_dir, compile_hl_api=False):
         "-DHDF5_ENABLE_Z_LIB_SUPPORT=OFF",  # the option-name changes in HDF5 2.0
     )
     _run("cmake", "--build", build_dir)  # compile hdf5
-    _run("cmake", "--install", build_dir)  # install hdf5 to install_dir
+    if _IS_MACOS:
+        _run("sudo", "cmake", "--install", build_dir)
+    else:
+        _run("cmake", "--install", build_dir)
 
 
 def handle_license(project_dir):

--- a/scripts/wheels/cibw_before_build.py
+++ b/scripts/wheels/cibw_before_build.py
@@ -74,7 +74,7 @@ def download_file(url, *, dst=None, dst_dir=None, quiet=None, cksum=None):
 def get_gfortran(depend_dir):
     if not _IS_MACOS:
         return None  # gfortran already exists on Linux
-    print("downloading gfortran")
+    print("downloading gfortran", flush=True)
 
     release, _, machine = platform.mac_ver()
 
@@ -162,12 +162,11 @@ def get_hdf5(depend_dir, compile_hl_api=False, build_type="Release"):
     if sys.platform.startswith("win32"):
         raise RuntimeError("we need to implement logic to download & install zlib")
     elif _IS_MACOS:
-        zlib_version, zlib_url, zlib_cksum = (
-            "1.3.1",
-            "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
-            "sha256:9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
+        zlib_version = "1.3.1"
+        zlib_url, zlib_cksum = (
+            f"https://github.com/madler/zlib/archive/refs/tags/v{zlib_version}.tar.gz",
+            "sha256:17e88863f3600672ab49182f217281b6fc4d3c762bde361935e436a95214d05c"
         )
-        assert f"/v{zlib_version}/" in zlib_url # sanity-check!
         with open(f"{h5_srcdir}/config/cmake/ZLIB/CMakeLists.txt", "r") as f:
             assert f'set(VERSION "{zlib_version}")' in f.read() # sanity-check!
         zlib_archive_path = download_file(
@@ -260,13 +259,14 @@ if __name__ == "__main__":
     print("Showing Environment")
     for key, value in os.environ.items():
         print(f"  {key!s}={value!s}")
+    print("", end="\n", flush=True)
 
     handle_license(args.project_dir)
 
     # make the dependency-directory
-    print(f"creating: {depend_dir}")
+    print(f"creating: {depend_dir}",flush=True)
     if os.path.isdir(args.depend_dir):
-        print("the directory already exists -- nothing needs to be done")
+        print("the directory already exists -- nothing needs to be done", flush=True)
     else:
         os.mkdir(args.depend_dir)
 

--- a/scripts/wheels/cibw_test_command.sh
+++ b/scripts/wheels/cibw_test_command.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "USAGE: $0 <PROJECT_PATH>"
+fi
+PROJECT_PATH="$1"
+
+# check that all libraries included in the wheel have a license entry
+# and confirm that we didn't include any unnecessary licenses
+python ${PROJECT_PATH}/scripts/wheels/check_packaged_dependency_licenses.py
+
+# launch the tests
+cd ${PROJECT_PATH} && pytest --color=yes

--- a/scripts/wheels/zlib_license_for_macos.txt
+++ b/scripts/wheels/zlib_license_for_macos.txt
@@ -1,0 +1,30 @@
+----
+
+Name: zlib
+Files: pygrackle/.dylibs/libz*
+Description: general purpose compression library
+Availability: https://github.com/madler/zlib
+License: Zlib
+
+Copyright notice:
+
+ (C) 1995-2024 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu

--- a/src/python/tests/test_get_grackle_version.py
+++ b/src/python/tests/test_get_grackle_version.py
@@ -14,8 +14,11 @@
 from pygrackle.grackle_wrapper import get_grackle_version
 from packaging.version import Version, InvalidVersion
 
+import shutil
 import os
 import subprocess
+
+import pytest
 
 def query_grackle_version_props():
     # retrieve the current version information with git
@@ -51,6 +54,7 @@ def query_grackle_version_props():
     tagged_on_current_revision = revision == revision_of_tag
     return latest_tagged_version, branch, revision, tagged_on_current_revision
 
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required")
 def test_get_grackle_version():
     # this test assumes that Grackle was compiled with the currently checked
     # out version of the repository

--- a/src/python/tests/test_get_grackle_version.py
+++ b/src/python/tests/test_get_grackle_version.py
@@ -64,6 +64,10 @@ def test_get_grackle_version():
         raise RuntimeError(
             "get_grackle_version should return a dictionary with the 3 items"
         )
+    elif results["branch"] == "N/A" and results["revision"] == "N/A":
+        # in this scenario the core library was compiled outside of a git repository
+        # so we skip checks of branch and revision
+        pass
     elif results['branch'] != branch:
         raise RuntimeError(
             f"expected get_grackle_version()['branch'] to be '{branch}', not "


### PR DESCRIPTION
EDIT: This is ready to go

> [!NOTE]
> The large number of changed lines is misleading. Most of the lines are for the licenses that are bundled with the wheels (since the binary wheels uploaded to PyPI need to include some shared libraries)

----------

This PR set up the continuous integration to test creation and uploading of wheels.

Here is the [test.pypi page for pygrackle](https://test.pypi.org/project/pygrackle/). 

You can try installing pygrackle from PyPI by invoking

```sh
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pygrackle
```

We are going to need to do a followup PR after this one (I want to test uploading to test.pypi from the main grackle repository before uploading a wheel to pypi).

----------

## Checklist:
- [x] Have we gone through all the files in a sample sdist? Do we want to remove more?
- [x] Have we uncommented various python ABIs? (currently disabled for testing purpose
- [x] Have we fixed the testing? (ideally we would fix the tests so that we can run the (at least some) non answer-tests without an editable install)
- [x] Have we switched to compiling with the full version of hdf5? (following a discussion with Britton, we decided we should ship a version that enables the various compression options)
- [x] Have we gotten wheels to build for Intel-based Macs?
- [x] Have we adjusted the minimum python version. It sounds like we will adopt yt's minimum python version.

## Future Thoughts
It might be useful to refactor the logic to download and setup HDF5 so that the sdist can use the logic:
- In other words, we could let people enable an option to automatically download and build HDF5 as part of the build process.
- While this would be nice, it's a somewhat moot point since people will still need to install a fortran compiler. There's no benefit to just waiting until we remove fortran. At that people will still need to worry about installing a recent-ish C++ compiler that implements a small subset of C++17 features[^1]
- we aren't doing this in this PR since it involves some work and it would be a little tricky to get "right."
  - In particular, we want to make sure that the standard [auditwheel](https://github.com/pypa/auditwheel) and [delocate](https://pypi.org/project/delocate/) tools (for renaming and packaging library dependencies) work properly. (it's definitely doable and would be "nice to have", but is not essential)
  - moreover, things will be more messy now that we have decided to install hdf5 with various enabled compression options. We need to decide whether to ship zlib (I think cibuildwheel assumes it's present on some platforms -- but I need to check all platforms we support). We will also be shipping libaec (which appears to be used over szip)

 
In the future, it might be cool to ship wheels using the CPython's Limited API:
- Essentially, we would ship 3 binary wheels per platform (platforms include macosx-arm64, macosx-x86_64, manylinux-x86_64, multilinux-x86_64, etc.):
  1. a wheel compatible with CPython == 3.10.x (full api)
  2. a wheel compatible with CPython == 3.11.x (full api)
  3. a wheel compatible with CPython >= 3.12.x (uses limited-api)
- According to this [Cython document](https://docs.cython.org/en/latest/src/userguide/limited_api.html) the limited API is slower (I found some issues suggesting a lot slower), and is still somewhat experimental.
- I'm leaving this for the future, since we would definitely need to test the staple-API wheel with every supported minor version of CPython.
  - In other words, we compile the wheel with 3.12, but then we should run tests with that wheel against 3.12, 3.13, (and soon 3.14)
  - This is doable, but it would take some finagling with GitHub Actions and it feels a little beyond the scope of this PR

[^1]: This won't be a significant burden and should be easy for everyone to do. But the point still stands that some platforms may not ship this by default.