### PR TITLE
fix a typo in a CMake variable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ the structure of this directory
 endif()
 
 # create a directory where we will store auto-generated generated public headers
-set(GRACKLE_GENRATED_PUBLIC_HEADERS
+set(GRACKLE_GENERATED_PUBLIC_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/generated_public_headers)
 
 # Dependencies

--- a/cmake/installation_rules.cmake
+++ b/cmake/installation_rules.cmake
@@ -121,7 +121,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/include/
   REGEX "grackle_float.h$" EXCLUDE # <- can be removed after GH-203 or after we
 )                                  #    remove the traditional build-system
 
-install(DIRECTORY ${GRACKLE_GENRATED_PUBLIC_HEADERS}/
+install(DIRECTORY ${GRACKLE_GENERATED_PUBLIC_HEADERS}/
   TYPE INCLUDE COMPONENT Grackle_Development
   FILES_MATCHING PATTERN "*.h" PATTERN "*.def"
 )

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
   set(GRACKLE_FLOAT_MACRO "GRACKLE_FLOAT_4")
 endif()
 configure_file(../include/grackle_float.h.in
-  ${GRACKLE_GENRATED_PUBLIC_HEADERS}/grackle_float.h @ONLY)
+  ${GRACKLE_GENERATED_PUBLIC_HEADERS}/grackle_float.h @ONLY)
 
 # next, declare recipe for generating auto_general.c:
 
@@ -123,7 +123,7 @@ add_library(Grackle_Grackle
   # -> In that scenario, CMake doesn't realize it needs to generate the
   #    header(s) because the compiler can finds versions of the headers from
   #    the prior build in the standard system location.
-  ${GRACKLE_GENRATED_PUBLIC_HEADERS}/grackle_float.h
+  ${GRACKLE_GENERATED_PUBLIC_HEADERS}/grackle_float.h
 
   # although not strictly necessary, listing out other header files is a "best
   # practice" (and is needed to make them show up in certain IDEs)
@@ -214,7 +214,7 @@ target_include_directories(Grackle_Grackle
   # grackle AND when linking against grackle under inclusion approach #1
   # -> while it may seem unnecessary to specify the ordinary headers' directory
   #    while building grackle, it's necessary to compile auto_general.c
-  PUBLIC $<BUILD_INTERFACE:${GRACKLE_GENRATED_PUBLIC_HEADERS}> # generated hdrs
+  PUBLIC $<BUILD_INTERFACE:${GRACKLE_GENERATED_PUBLIC_HEADERS}> # generated hdrs
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> # public hdrs
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> # private hdrs
 


### PR DESCRIPTION
This is extremely simple and self-explanatory