### PR TITLE
Tweak  cython-handling in build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@
 [build-system]
 requires=[
   "cython",
+  "cython-cmake>=0.2",
   # since tool.scikit-build.minimum-version is set to "build-system.requires",
   # the minimum build-requirement for scikit-build-core controls some default
   # behaviors when newer versions of scikit-build-core are installed
@@ -96,9 +97,9 @@ testpaths = [
 # redirect to the appropriate CMakeLists.txt file
 cmake.source-dir = "./src/python"
 
-# if the following version of CMake isn't found, scikit-build-core will
-# download and use a compatible CMake-verison
-cmake.version = ">=3.16"
+# if the version of CMake (in {cmake.source-dir}/CMakeLists.txt) isn't found,
+# scikit-build-core will download and use a compatible CMake-verison
+cmake.version = "CMakeLists.txt"
 
 # The build type to use when building the project. Valid options are: "Debug",
 # "Release", "RelWithDebInfo", "MinSizeRel", "", etc.

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,8 +1,20 @@
+# This file is only to be used when building the pygrackle python module
+# -> the python build-backend, scikit-build-core, is responsible for reading in
+#    this file (it defines predefines certain variables and certain commands)
+# -> scikit-build-core is configured in ${GRACKLE_REPO_ROOT}/pyproject.toml
 set(GRACKLE_REPO_ROOT  ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 
 # Prologue
 # --------
-cmake_minimum_required(VERSION 3.16)
+
+# we require 3.21 at the recommendation of the cython-cmake python-package
+#   https://github.com/scikit-build/cython-cmake
+# it's ok if this exceeds the version required for the core-grackle lib (which
+# is linked to the lowest CMake version provided on common Linux distributions)
+# since the scikit-build-core backend has been configured to automatically
+# download a newer version of CMake, when necessary
+cmake_minimum_required(VERSION 3.21)
+
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 # Dependencies
@@ -10,6 +22,8 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 # find required python components
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+# read in cython utilities (provided by cython-cmake python-package)
+include(UseCython)
 
 # deal with dependency on Grackle and define _PYGRACKLE_CONSUME_MODE
 if ("$ENV{PYGRACKLE_LEGACY_LINK}" STREQUAL "classic")
@@ -82,28 +96,23 @@ endif()
 
 # Actual build Logic
 # ------------------
-# -> we build a shared-library represented by the grackle_wrapper library
 
+# take the __config__.py.in template file and use it to create __config__.py
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pygrackle/__config__.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/__config__.py @ONLY
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/__config__.py
   DESTINATION ${SKBUILD_PROJECT_NAME})
-  
 
-add_custom_command(
-  OUTPUT grackle_wrapper.c
-  COMMENT
-    "Making ${CMAKE_CURRENT_BINARY_DIR}/grackle_wrapper.c from ${CMAKE_CURRENT_SOURCE_DIR}/pygrackle/grackle_wrapper.pyx"
-  COMMAND Python::Interpreter -m cython
-          -3
-          "${CMAKE_CURRENT_SOURCE_DIR}/pygrackle/grackle_wrapper.pyx"
-          --output-file grackle_wrapper.c
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/pygrackle/grackle_wrapper.pyx
-          ${CMAKE_CURRENT_SOURCE_DIR}/pygrackle/grackle_defs.pxd
-  VERBATIM)
-
-python_add_library(grackle_wrapper MODULE grackle_wrapper.c WITH_SOABI)
+# transpile gracke_wrapper.pyx to a C file and then compile into a shared
+# represented by the grackle_wrapper target
+cython_transpile(
+  pygrackle/grackle_wrapper.pyx
+  LANGUAGE C
+  CYTHON_ARGS -3
+  OUTPUT_VARIABLE grackle_wrapper_c
+)
+python_add_library(grackle_wrapper MODULE "${grackle_wrapper_c}" WITH_SOABI)
 target_compile_definitions(grackle_wrapper
   PRIVATE TRADITIONAL_IN_SOURCE_BUILD=${traditional_in_source_build})
 target_link_libraries(grackle_wrapper PUBLIC Grackle::Grackle)


### PR DESCRIPTION
This must be reviewed after PR #330 (it turns out that CI will trigger the bug fixed by that PR when combined with changes in this PR)

----

This PR swaps out our custom handling of compiling cython files (when compiling pygrackle) to using the [cython-cmake package](https://pypi.org/project/cython-cmake/). This package is maintained by the scikit-build-core people.

## Benefits

Essentially, the main benefit of doing this is achieving better dependency tracking. This comes up with incremental rebuilds.

If you install pygrackle with:
```sh
pip install --no-build-isolation -Cbuild-dir=pygrackle-build -ve.
```
you are essentially putting intermediate build-artifacts into a directory called **pygrackle-build**. If you make a tweak to a grackle source file, you can invoke the command again and the build system is smart enough to only recompile/relink the subset of affected files.

The above snippet already worked, but previously you would have run into issues if a public header file changed (e.g. you changed a `double` to a `float`) that was a (transitive) dependency of **grackle_wrappers.pyx**. The change in this PR makes the build-system smart enough to recompile **grackle_wrappers.pyx** (but only if a header file changed).

> [!NOTE]
> Scikit-build-core also has experimental support for automatic rebuilds. If you install pygrackle with 
> ```sh
> pip install --no-build-isolation --config-settings=editable.rebuild=true -Cbuild-dir=pygrackle-build -e.
> ```
> then pygrackle or the core grackle library will be automatically (& incrementally) rebuilt if there were any changes to the source files since the last build. (I haven't actually tested this scenario)

## Costs
We are adding another build-time dependency. If that is a concern, we could vendor the 2 CMake files provided by this package. They seem like they will be fairly stable (unless cython has dramatic changes) and they actually provide machinery to help with vendoring. (But, all things being equal, I'd prefer not to vendor)