### PR TITLE
remove a line that was made obsolete by PR #224

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -107,7 +107,6 @@ python_add_library(grackle_wrapper MODULE grackle_wrapper.c WITH_SOABI)
 target_compile_definitions(grackle_wrapper
   PRIVATE TRADITIONAL_IN_SOURCE_BUILD=${traditional_in_source_build})
 target_link_libraries(grackle_wrapper PUBLIC Grackle::Grackle)
-target_include_directories(grackle_wrapper PRIVATE ${Python_NumPy_INCLUDE_DIRS})
 
 # Installation Logic
 # ------------------


### PR DESCRIPTION
The line in question was related to passing an `-I/path/to/numpy/headers` (i.e. it specified the directory containing numpy headers) to the C compiler used when compiling  **grackle_wrapper.pyx**. This line hasn't done anything since PR #224 (I simply forgot to remove it)