### PR TITLE
Support running subset of pygrackle test without a an editable install

### DIFF
--- a/src/python/pygrackle/utilities/model_tests.py
+++ b/src/python/pygrackle/utilities/model_tests.py
@@ -15,7 +15,6 @@ import itertools
 import os
 
 from pygrackle import chemistry_data
-from pygrackle.utilities.data_path import grackle_data_dir
 
 model_test_format_version = 1
 
@@ -140,6 +139,10 @@ def get_model_set(model_name, parameter_index, input_index):
     Create objects and variables to be used in testing one
     of the Python example scripts.
     """
+
+    # we import this here, rather than at global scope to let us import the
+    # module when we don't have an editable install (for testing purposes)
+    from pygrackle.utilities.data_path import grackle_data_dir
 
     if model_name not in model_sets:
         raise ValueError("Unkown model name: {model_name}.")

--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -5,10 +5,16 @@ import yt
 
 from numpy.testing import assert_allclose
 
+from pygrackle.__config__ import _is_editable_installation
 from pygrackle.utilities.model_tests import model_sets
 from pygrackle.utilities.testing import run_command
 
 from testing_common import grackle_python_dir
+
+pytestmark = pytest.mark.skipif(
+    not _is_editable_installation(),
+    reason="this module currently requires an editable installation"
+)
 
 python_example_dir = os.path.join(grackle_python_dir, "examples")
 

--- a/src/python/tests/testing_common.py
+++ b/src/python/tests/testing_common.py
@@ -14,15 +14,8 @@
 
 import os
 
-from pygrackle.__config__ import _is_editable_installation
 from pygrackle.utilities.misc import dirname
 
-if _is_editable_installation():
-    grackle_install_dir = dirname(os.path.abspath(__file__), level=4)
-    grackle_data_dir = os.path.join(grackle_install_dir, "input")
-    grackle_python_dir = os.path.join(grackle_install_dir, "src", "python")
-else:
-    raise RuntimeError(
-        "the current version of pygrackle is not an editable installation. No "
-        "tests that must import from {__file__} can be run"
-    )
+grackle_install_dir = dirname(os.path.abspath(__file__), level=4)
+grackle_data_dir = os.path.join(grackle_install_dir, "input")
+grackle_python_dir = os.path.join(grackle_install_dir, "src", "python")


### PR DESCRIPTION
Prior to this PR, our test suite would fail unless we had an editable install. In reality, all test-cases outside of test_models infer the location of the data files based on the location of the test-files, which are never part of the wheel.[^1] Therefore, this PR introduces a few small tweaks to support testing all test-cases outside of test_models.

Overall, this will be really useful for providing a more rigorous check of the correctness of our precompiled wheels (see PR #320).

[^1]: I know that some packages do ship their test-suites as part of the wheel, but that currently makes absolutely no sense for us unless we provide users with an easy way to get the datafiles. We can always revisit this choice in the future after we merge PRs #235 & #237 (or come up with an equivalent)