### PR TITLE
Optimize circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
           tag: $CIRCLE_BRANCH
       - run:
           name: "pygrackle-tests (no answer-tests) on latest commit (corelib manually built with CMake)"
-          command: py.test
+          command: source $BASH_ENV && source $HOME/venv/bin/activate && py.test
 
       # run full pygrackle test-suite on latest commit (classic-build)
       - install-grackle:
@@ -298,7 +298,7 @@ jobs:
           tag: $CIRCLE_BRANCH
       - run:
           name: "pygrackle-tests (no answer-tests) on latest commit (corelib manually created with classic-build)"
-          command: py.test
+          command: source $BASH_ENV && source $HOME/venv/bin/activate && py.test
 
   corelib-tests:
     # we're only using a python docker-image out of convenience (We only care

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,17 @@ jobs:
       - download-test-data
       - store-pygrackle-suite-gold-standard-answers
 
+      - run:
+          name: "Build Standalone Pygrackle from the commit that triggered CI."
+          command: |
+            source $HOME/venv/bin/activate
+            git checkout $CIRCLE_BRANCH
+            pip install -e .[dev]
+      - run-pygrackle-tests:
+          omp: 'false'
+          build_kind: 'standalone-pygrackle'
+          generate: 'false'
+
       # run full pygrackle test-suite on latest commit (CMake-build)
       - install-grackle:
           omp: 'false'
@@ -289,35 +300,6 @@ jobs:
       - run-pygrackle-tests:
           omp: 'false'
           build_kind: 'classic'
-          generate: 'false'
-
-  test-standalone-pygrackle:
-    parameters:
-      tag:
-        type: string
-        default: latest
-    executor:
-      name: python
-      tag: << parameters.tag >>
-      resource_class: small  # <- 1 core
-
-    working_directory: ~/grackle
-
-    steps:
-      - checkout
-      - set-env
-      - install-dependencies
-      - download-test-data
-      - store-pygrackle-suite-gold-standard-answers
-      - run:
-          name: "Build Pygrackle from the commit that triggered CI."
-          command: |
-            source $HOME/venv/bin/activate
-            git checkout $CIRCLE_BRANCH
-            pip install -e .[dev]
-      - run-pygrackle-tests:
-          omp: 'false'
-          build_kind: 'standalone-pygrackle'
           generate: 'false'
 
   corelib-tests:
@@ -392,10 +374,6 @@ workflows:
            name: "Pygrackle test suite - Python 3.8"
            tag: "3.8.14"
 
-       - test-standalone-pygrackle:
-           name: "Standalone Pygrackle tests - Python 3.8"
-           tag: "3.8.14"
-
        - corelib-tests:
            name: "Core library test suite"
 
@@ -414,10 +392,6 @@ workflows:
      jobs:
        - test-suite:
            name: "Pygrackle test suite - Python 3.8"
-           tag: "3.8.14"
-
-       - test-standalone-pygrackle:
-           name: "Standalone Pygrackle tests - Python 3.8"
            tag: "3.8.14"
 
        - corelib-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,20 +227,6 @@ commands:
             pip uninstall --yes pygrackle
 
 
-  run-classic-omp-test:
-    description: "Run the OpenMP test with the classic build-system"
-    steps:
-      - run:
-          name: "Run the OpenMP test with the classic build system"
-          command: |
-            source $BASH_ENV
-            cd src
-            export OMP_NUM_THREADS=4
-            cd example
-            make cxx_omp_example
-            ./cxx_omp_example
-            make clean
-
   build-docs:
     description: "Test the docs build."
     steps:
@@ -300,13 +286,6 @@ jobs:
           build_kind: 'classic'
           generate: 'false'
 
-      # setup and run classic-omp-test on latest commit
-      - install-grackle:
-          omp: 'true'
-          classic_build: 'true'
-          tag: $CIRCLE_BRANCH
-      - run-classic-omp-test
-
   test-standalone-pygrackle:
     parameters:
       tag:
@@ -362,6 +341,23 @@ jobs:
           command: |
             cd build
             ctest --output-on-failure
+            cd -
+      - run:
+          name: "Build libgrackle with OpenMP enabled"
+          command: |
+            # we explicitly use Makefiles rather than Ninja due
+            # to a documented bug between gfortran/omp/ninja
+            cmake -DGRACKLE_USE_DOUBLE=ON                   \
+                  -DGRACKLE_USE_OPENMP=ON                   \
+                  -DGRACKLE_BUILD_TESTS=OFF                 \
+                  -DCMAKE_BUILD_TYPE=Release                \
+                  -Bbuild-omp
+            cmake --build build-omp
+      - run:
+          name: "run the OpenMP example"
+          command: cd build-omp/examples && ./cxx_omp_example
+          environment:
+            OMP_NUM_THREADS: 4
 
   docs-build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,8 +243,12 @@ executors:
       tag:
         type: string
         default: latest
+      resource_class:
+        type: string
+        default: small
     docker:
       - image: cimg/python:<< parameters.tag >>
+    resource_class: << parameters.resource_class >>
 
 jobs:
   test-suite:
@@ -255,6 +259,7 @@ jobs:
     executor:
       name: python
       tag: << parameters.tag >>
+      resource_class: small  # <- 1 core
 
     working_directory: ~/grackle
 
@@ -294,6 +299,7 @@ jobs:
     executor:
       name: python
       tag: << parameters.tag >>
+      resource_class: small  # <- 1 core
 
     working_directory: ~/grackle
 
@@ -321,6 +327,7 @@ jobs:
     executor:
       name: python
       tag: 3.8.14
+      resource_class: medium  # <- 2 cores
 
     working_directory: ~/grackle
 
@@ -367,6 +374,7 @@ jobs:
     executor:
       name: python
       tag: << parameters.tag >>
+      resource_class: small  # <- 1 core
 
     working_directory: ~/grackle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,25 +282,23 @@ jobs:
           build_kind: 'standalone-pygrackle'
           generate: 'false'
 
-      # run full pygrackle test-suite on latest commit (CMake-build)
+      # run pygrackle-test (without answer-tests) on latest commit (CMake-build)
       - install-grackle:
           omp: 'false'
           classic_build: 'false'
           tag: $CIRCLE_BRANCH
-      - run-pygrackle-tests:
-          omp: 'false'
-          build_kind: 'cmake'
-          generate: 'false'
+      - run:
+          name: "pygrackle-tests (no answer-tests) on latest commit (corelib manually built with CMake)"
+          command: py.test
 
       # run full pygrackle test-suite on latest commit (classic-build)
       - install-grackle:
           omp: 'false'
           classic_build: 'true'
           tag: $CIRCLE_BRANCH
-      - run-pygrackle-tests:
-          omp: 'false'
-          build_kind: 'classic'
-          generate: 'false'
+      - run:
+          name: "pygrackle-tests (no answer-tests) on latest commit (corelib manually created with classic-build)"
+          command: py.test
 
   corelib-tests:
     # we're only using a python docker-image out of convenience (We only care

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,12 @@ if (GRACKLE_USE_OPENMP)
       "CMake. The quick fix is use Makefiles. See the docs for more info"
     )
   endif()
-  find_package(OpenMP REQUIRED COMPONENTS C Fortran)
+  if(GRACKLE_EXAMPLES)
+    set(_GRACKLE_OMP_COMPONENTS C Fortran CXX)
+  else()
+    set(_GRACKLE_OMP_COMPONENTS C Fortran)
+  endif()
+  find_package(OpenMP REQUIRED COMPONENTS ${_GRACKLE_OMP_COMPONENTS})
 endif()
 
 # define target to link the math functions of the C standard library

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(cxx_example Grackle::Grackle)
 
 if (GRACKLE_USE_OPENMP)
   add_executable(cxx_omp_example cxx_omp_example.C)
-  target_link_libraries(cxx_omp_example Grackle::Grackle)
+  target_link_libraries(cxx_omp_example Grackle::Grackle OpenMP::OpenMP_CXX)
 endif()
 
 if (GRACKLE_USE_DOUBLE)


### PR DESCRIPTION
It has come to my attention  that we are probably going to run out of time on CircleCI this month. This was partially my fault (I had meant to make some adjustments make our workflows more efficient). While doing this, I caught a minor oversight in the CMake-build of the cxx_omp_example.[^1]

I think this should make the PR should reduce the resources used by the CircleCI workflows by ~75%.

It will be easiest to review this commit-by-commit:
1. fix the aforementioned oversight with building `cxx_omp_example`
2. CI: transfer the task of running the OpenMP example from the "test-suite" job to the "corelib-tests"
3. CI: use "small" resource_class for most cases (previously, we defaulted to the "medium" resource_class for every job)
4. CI: Consolidate both jobs running the pygrackle tests
   - Originally one job ran the tests after building pygrackle as a standalone package (i.e. the core Grackle lib is compiled as part of pygrackle). The other job ran the tests with versions of pygrackle where we explicitly built the core library (with both build-systems) as a separate step from building pygrackle.
   - this saves time with generating test-answers AND it saves time with downloading dependencies
5. CI: skip answer-tests when using manually-built core-lib
   - In these cases, we only run a subset of the test-suite (the much faster component). This seems reasonable since we are already running the answer-tests with the version of pygrackle configured that automatically compiled the core-library as part of the build process.
   - This should save a significant amount of resources

[^1]: The oversight originated because it's tricky to use OpenMP on MacOS (so I hadn't been rigorously testing it). Previously we could successfully compile Grackle with OpenMP. We could also successfully compile and run `cxx_omp_example`. However, I realized I needed to link OpenMP an "extra time" in order for `cxx_omp_example` to know that it should use the `OMP_NUM_THREADS` environment variable.