### PR TITLE
Use builtin GitHub feature to nicely redirect to Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+You can find the Grackle Community Code of Conduct [here](https://grackle.readthedocs.io/en/latest/Conduct.html).


### PR DESCRIPTION
I was deleting some old branches and realized that I never made a PR for this branch.

------------

By adding this file, GitHub adds a nicely labeled tab when you scroll down to the README

Numpy and Scipy both do something similar (but I'm honestly not sure where the file that does this is in the Numpy repository)

To see this change, go to [my branch with this change](https://github.com/mabruzzo/grackle/tree/code-of-conduct-redirect?tab=readme-ov-file) and you will be able to see a "Code of conduct" tab between the "README" tab and the "License" tab

![image](https://github.com/user-attachments/assets/6e42c05b-b968-403f-9bfb-63831e40fa9b)
