### PR TITLE
[newchem-cpp] Speedup test_models.py by direct importing

### DIFF
--- a/src/python/examples/cooling_cell.py
+++ b/src/python/examples/cooling_cell.py
@@ -32,7 +32,7 @@ from pygrackle.utilities.data_path import grackle_data_dir
 from pygrackle.utilities.model_tests import \
     get_test_variables
 
-output_name = os.path.basename(__file__[:-3]) # strip off ".py"
+_MODEL_NAME = os.path.basename(__file__[:-3]) # strip off ".py"
 
 def gen_plot(fc,  data, fname):
     p1, = pyplot.loglog(data["time"].to("Myr"),
@@ -51,15 +51,10 @@ def gen_plot(fc,  data, fname):
     pyplot.savefig(fname)
 
 
-def main(args=None, output_name=output_name):
+def main(args=None):
     args = sys.argv[1:] if args is None else args
-    # If we are running the script through the testing framework,
-    # then we will pass in two integers corresponding to the sets
-    # of parameters and inputs.
-    if len(args) > 1:
-        par_index = int(args[0])
-        input_index = int(args[1])
-        my_vars = get_test_variables(output_name, par_index, input_index)
+    if len(args) != 0:  # we are using the testing framework
+        my_vars = get_test_variables(_MODEL_NAME, args)
 
         metallicity = my_vars["metallicity"]
         redshift = my_vars["redshift"]
@@ -69,8 +64,7 @@ def main(args=None, output_name=output_name):
 
         in_testing_framework = True
 
-    # Just run the script as is.
-    else:
+    else:  # Just run the script as is.
         metallicity = 0.1 # Solar
         redshift = 0.
         # dictionary to store extra information in output dataset
@@ -85,6 +79,7 @@ def main(args=None, output_name=output_name):
         my_chemistry.grackle_data_file = \
           os.path.join(grackle_data_dir, "CloudyData_UVB=HM2012.h5")
 
+        output_name = _MODEL_NAME
         in_testing_framework = False
 
     density = 0.1 * mass_hydrogen_cgs # g /cm^3

--- a/src/python/examples/cooling_cell.py
+++ b/src/python/examples/cooling_cell.py
@@ -51,16 +51,21 @@ def gen_plot(fc,  data, fname):
     pyplot.savefig(fname)
 
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 1:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_vars = get_test_variables(output_name, par_index, input_index)
-        for var, val in my_vars.items():
-            globals()[var] = val
+
+        metallicity = my_vars["metallicity"]
+        redshift = my_vars["redshift"]
+        extra_attrs = my_vars["extra_attrs"]
+        my_chemistry = my_vars["my_chemistry"]
+        output_name = my_vars["output_name"]
 
         in_testing_framework = True
 
@@ -116,3 +121,7 @@ if __name__ == "__main__":
     # save data arrays as a yt dataset
     yt.save_as_dataset({}, f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/python/examples/cooling_cell.py
+++ b/src/python/examples/cooling_cell.py
@@ -123,5 +123,6 @@ def main(args=None, output_name=output_name):
                        data=data, extra_attrs=extra_attrs)
     return 0
 
+
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -28,7 +28,7 @@ from pygrackle.utilities.physical_constants import \
 from pygrackle.utilities.model_tests import \
     get_test_variables
 
-output_name = os.path.basename(__file__[:-3]) # strip off ".py"
+_MODEL_NAME = os.path.basename(__file__[:-3]) # strip off ".py"
 
 def gen_plot(fc, data, fname):
     pyplot.loglog(data["temperature"], np.abs(data["cooling_rate"]),
@@ -39,15 +39,10 @@ def gen_plot(fc, data, fname):
     pyplot.savefig(fname)
 
 
-def main(args=None, output_name=output_name):
+def main(args=None):
     args = sys.argv[1:] if args is None else args
-    # If we are running the script through the testing framework,
-    # then we will pass in two integers corresponding to the sets
-    # of parameters and inputs.
-    if len(args) > 0:
-        par_index = int(args[0])
-        input_index = int(args[1])
-        my_vars = get_test_variables(output_name, par_index, input_index)
+    if len(args) != 0:  # we are using the testing framework
+        my_vars = get_test_variables(_MODEL_NAME, args)
 
         metallicity = my_vars["metallicity"]
         redshift = my_vars["redshift"]
@@ -59,8 +54,7 @@ def main(args=None, output_name=output_name):
 
         in_testing_framework = True
 
-    # Just run the script as is.
-    else:
+    else:  # Just run the script as is.
         metallicity = 1. # Solar
         redshift = 0.
         specific_heating_rate = 0.
@@ -83,6 +77,7 @@ def main(args=None, output_name=output_name):
         my_chemistry.use_specific_heating_rate = 1
         my_chemistry.use_volumetric_heating_rate = 1
 
+        output_name = _MODEL_NAME
         in_testing_framework = False
 
     # max_iterations needs to be increased for the colder temperatures

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -39,16 +39,23 @@ def gen_plot(fc, data, fname):
     pyplot.savefig(fname)
 
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 0:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_vars = get_test_variables(output_name, par_index, input_index)
-        for var, val in my_vars.items():
-            globals()[var] = val
+
+        metallicity = my_vars["metallicity"]
+        redshift = my_vars["redshift"]
+        specific_heating_rate = my_vars["specific_heating_rate"]
+        volumetric_heating_rate = my_vars["volumetric_heating_rate"]
+        extra_attrs = my_vars["extra_attrs"]
+        my_chemistry = my_vars["my_chemistry"]
+        output_name = my_vars["output_name"]
 
         in_testing_framework = True
 
@@ -115,3 +122,7 @@ if __name__ == "__main__":
 
     yt.save_as_dataset({}, filename=f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -124,5 +124,6 @@ def main(args=None, output_name=output_name):
                        data=data, extra_attrs=extra_attrs)
     return 0
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -141,5 +141,6 @@ def main(args=None, output_name=output_name):
                        data=data, extra_attrs=extra_attrs)
     return 0
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -29,7 +29,7 @@ from pygrackle.utilities.data_path import grackle_data_dir
 from pygrackle.utilities.model_tests import \
     get_test_variables
 
-output_name = os.path.basename(__file__[:-3]) # strip off ".py"
+_MODEL_NAME = os.path.basename(__file__[:-3]) # strip off ".py"
 
 def gen_plot(fc, data, fname):
     plots = pyplot.loglog(data["density"], data["temperature"],
@@ -52,15 +52,10 @@ def gen_plot(fc, data, fname):
     pyplot.savefig(fname)
 
 
-def main(args=None, output_name=output_name):
+def main(args=None):
     args = sys.argv[1:] if args is None else args
-    # If we are running the script through the testing framework,
-    # then we will pass in two integers corresponding to the sets
-    # of parameters and inputs.
-    if len(args) > 0:
-        par_index = int(args[0])
-        input_index = int(args[1])
-        my_vars = get_test_variables(output_name, par_index, input_index)
+    if len(args) != 0:  # we are using the testing framework
+        my_vars = get_test_variables(_MODEL_NAME, args)
 
         metallicity = my_vars["metallicity"]
         extra_attrs = my_vars["extra_attrs"]
@@ -69,8 +64,7 @@ def main(args=None, output_name=output_name):
 
         in_testing_framework = True
 
-    # Just run the script as is.
-    else:
+    else:  # Just run the script as is.
         metallicity = 0.
         # dictionary to store extra information in output dataset
         extra_attrs = {}
@@ -91,6 +85,7 @@ def main(args=None, output_name=output_name):
         my_chemistry.grackle_data_file = os.path.join(
             grackle_data_dir, "cloudy_metals_2008_3D.h5")
 
+        output_name = _MODEL_NAME
         in_testing_framework = False
 
     redshift = 0.

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -125,7 +125,7 @@ def main(args=None, output_name=output_name):
     # down to a lower temperature to get the species fractions in a
     # reasonable state.
     cooling_temperature = 100.
-    data0 = evolve_constant_density(
+    data0 = evolve_constant_density(  # noqa: F841
         fc, final_temperature=cooling_temperature,
         safety_factor=0.1)
 

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -52,16 +52,20 @@ def gen_plot(fc, data, fname):
     pyplot.savefig(fname)
 
 
-if __name__=="__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 0:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_vars = get_test_variables(output_name, par_index, input_index)
-        for var, val in my_vars.items():
-            globals()[var] = val
+
+        metallicity = my_vars["metallicity"]
+        extra_attrs = my_vars["extra_attrs"]
+        my_chemistry = my_vars["my_chemistry"]
+        output_name = my_vars["output_name"]
 
         in_testing_framework = True
 
@@ -135,3 +139,7 @@ if __name__=="__main__":
     # save data arrays as a yt dataset
     yt.save_as_dataset({}, f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/examples/yt_grackle.py
+++ b/src/python/examples/yt_grackle.py
@@ -17,23 +17,19 @@ import yt
 
 from pygrackle import add_grackle_fields
 from pygrackle.utilities.data_path import grackle_data_dir
-from pygrackle.utilities.model_tests import model_test_format_version
+from pygrackle.utilities.model_tests import get_test_variables
 
-output_name = os.path.basename(__file__[:-3]) # strip off ".py"
+_MODEL_NAME = os.path.basename(__file__[:-3]) # strip off ".py"
 
 DS_NAME = "IsolatedGalaxy/galaxy0030/galaxy0030"
 ds_path = os.path.join(os.environ.get('YT_DATA_DIR', default='.'), DS_NAME)
 
-def main(args=None, output_name=output_name):
+def main(args=None):
     args = sys.argv[1:] if args is None else args
-    # If we are running the script through the testing framework,
-    # then we will pass in two integers corresponding to the sets
-    # of parameters and inputs.
-    if len(args) > 1:
-        par_index = int(args[0])
-        input_index = int(args[1])
-        output_name = f"{output_name}_{par_index}_{input_index}"
-        extra_attrs = {"format_version": model_test_format_version}
+    if len(args) != 0:  # we are using the testing framework
+        my_vars = get_test_variables(_MODEL_NAME, args)
+        extra_attrs = my_vars["extra_attrs"]
+        output_name = my_vars["output_name"]
 
         if 'YT_DATA_DIR' not in os.environ:
             raise RuntimeError(
@@ -44,6 +40,7 @@ def main(args=None, output_name=output_name):
     else:
         # dictionary to store extra information in output dataset
         extra_attrs = {}
+        output_name = _MODEL_NAME
 
     ds = yt.load(ds_path)
 

--- a/src/python/examples/yt_grackle.py
+++ b/src/python/examples/yt_grackle.py
@@ -24,13 +24,14 @@ output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 DS_NAME = "IsolatedGalaxy/galaxy0030/galaxy0030"
 ds_path = os.path.join(os.environ.get('YT_DATA_DIR', default='.'), DS_NAME)
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 1:
+        par_index = int(args[0])
+        input_index = int(args[1])
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
 
@@ -70,3 +71,7 @@ if __name__ == "__main__":
     data = {field: sp[field] for field in fields}
     yt.save_as_dataset(ds, filename=f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/examples/yt_grackle.py
+++ b/src/python/examples/yt_grackle.py
@@ -73,5 +73,6 @@ def main(args=None, output_name=output_name):
                        data=data, extra_attrs=extra_attrs)
     return 0
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/python/pygrackle/utilities/testing.py
+++ b/src/python/pygrackle/utilities/testing.py
@@ -57,18 +57,3 @@ def requires_module(module):
         return ffalse
     else:
         return ftrue
-
-def run_command(command, timeout=None, cwd=None):
-    try:
-        proc = subprocess.run(command, shell=True, timeout=timeout, cwd=cwd)
-        if proc.returncode == 0:
-            success = True
-        else:
-            success = False
-    except subprocess.TimeoutExpired:
-        print ("Process reached timeout of %d s. (%s)" % (timeout, command))
-        success = False
-    except KeyboardInterrupt:
-        print ("Killed by keyboard interrupt!")
-        success = False
-    return success

--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -145,14 +145,9 @@ def test_model(answertestspec, tmp_path, model_name, par_index, input_index):
     if (model_name == "yt_grackle") and ("YT_DATA_DIR" not in os.environ):
         pytest.skip("YT_DATA_DIR env variable isn't defined")
 
-    # TODO: figure out how to instruct the examples where to store the results as a
-    #       function argument (so we can stop using os.chdir)
-    original_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        return_val = model_fns[model_name](args=[str(par_index), str(input_index)])
-    finally:
-        os.chdir(original_cwd)
+    return_val = model_fns[model_name](
+        args=[f"--out-dir={tmp_path!s}", str(par_index), str(input_index)],
+    )
 
     model_par = f"{model_name}_{par_index}_{input_index}"
     assert return_val == 0, f"Model {model_par} didn't complete succesfully."

--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -10,7 +10,6 @@ from numpy.testing import assert_allclose
 
 from pygrackle.__config__ import _is_editable_installation
 from pygrackle.utilities.model_tests import model_parametrization
-from pygrackle.utilities.testing import run_command
 
 from testing_common import grackle_python_dir
 


### PR DESCRIPTION
We talked about this last week. This tweaks `src/python/examples/*.py` and `src/python/tests/test_models.py` so that we avoid using subprocess (and directly import code instead).

On my machine, this shaves ~22 seconds off of the tests (i.e. ~20% of the runtime)