### PR TITLE
Remove spurious indentations (fix rendering of text)

### DIFF
--- a/doc/source/Contributing.rst
+++ b/doc/source/Contributing.rst
@@ -5,18 +5,18 @@
 Adding a New Parameter
 ----------------------
 
-  This section provides a short list of tasks to complete when a new field is introduced to the :c:data:`chemistry_data` struct:
+This section provides a short list of tasks to complete when a new field is introduced to the :c:data:`chemistry_data` struct:
 
-  1. Add a new entry to ``src/clib/grackle_chemistry_data_fields.def`` for this field. This file holds a central list of fields in :c:data:`chemistry_data`. Doing this accomplishes the following three things:
+1. Add a new entry to ``src/clib/grackle_chemistry_data_fields.def`` for this field. This file holds a central list of fields in :c:data:`chemistry_data`. Doing this accomplishes the following three things:
 
-     (i) the field is initialized to the appropriate default value.
-     (ii) the new field and its value are printed when ``grackle_verbose = 1``
-     (iii) the field can be accessed by the functions providing the dynamic access to members of :c:data:`chemistry_data` (see :ref:`dynamic-api`)
-     (iv) the new field is accessible from Pygrackle (because that interface uses the functions providing dynamic access)
+   (i) the field is initialized to the appropriate default value.
+   (ii) the new field and its value are printed when ``grackle_verbose = 1``
+   (iii) the field can be accessed by the functions providing the dynamic access to members of :c:data:`chemistry_data` (see :ref:`dynamic-api`)
+   (iv) the new field is accessible from Pygrackle (because that interface uses the functions providing dynamic access)
 
-  2. Update the fortran definition for the ``grackle_chemistry_data`` type (in ``src/clib/grackle_fortran_interface.def``). This type must exactly match the definition of :c:data:`chemistry_data` and is used to integrate Grackle into simulation codes written in Fortran.
+2. Update the fortran definition for the ``grackle_chemistry_data`` type (in ``src/clib/grackle_fortran_interface.def``). This type must exactly match the definition of :c:data:`chemistry_data` and is used to integrate Grackle into simulation codes written in Fortran.
 
-  3. Add documentation in ``doc/source/Parameters.rst`` for your new parameter.
+3. Add documentation in ``doc/source/Parameters.rst`` for your new parameter.
 
 .. _cmake_buildsystem_design_rationale:
 
@@ -62,47 +62,47 @@ Our main focus is ``pkg-config``'s ``--static`` flag, in the case where CMake wa
 
 In this scenario, the man-pages (and online discussions) for ``pkg-config`` suggest that
 
-  * ``pkg-config --cflags grackle`` and ``pkg-config --libs grackle`` respectively supply the compiler and linker flags for consuming grackle as a shared library
+* ``pkg-config --cflags grackle`` and ``pkg-config --libs grackle`` respectively supply the compiler and linker flags for consuming grackle as a shared library
 
-  * ``pkg-config --static --cflags grackle`` and ``pkg-config --static --libs grackle`` respectively supply the compiler and linker flags for consuming grackle as a static library
+* ``pkg-config --static --cflags grackle`` and ``pkg-config --static --libs grackle`` respectively supply the compiler and linker flags for consuming grackle as a static library
 
 Everything is perfectly fine in the first pair of invocations.
 In the second pair of invocations, the compiler flags are fine (other than some unnecessary information leaking through), but there are fundamentally 2 issues associated with the linker flags:
 
-  1. The primary issue relates to how ``pkg-config`` determines the static linker flags.
-     For now, we ignore dependencies like hdf5 (more on that shortly).
-     In more detail:
+1. The primary issue relates to how ``pkg-config`` determines the static linker flags.
+   For now, we ignore dependencies like hdf5 (more on that shortly).
+   In more detail:
 
-     * **grackle.pc** internally tracks the 2 set of linker flags.
-       The first set is used in the absence of the ``--static`` flag; in this scenario, these would be used for linking grackle as a shared library.
-       This currently might look something like ``-L<path/to/installed/grackle> -lgrackle``.
-       The file also separately tracks *private* linker-flags that are intended to be used for this scenario when you use Grackle as a static library.
-       These are somewhat specific to the compiler toolchain and machine/OS and depend on how Grackle was compiled.
-       At the time of running, they *usually* specify implicit dependencies.
-       For concreteness, this might look something like ``-lgomp -lgfortran -lm`` on a Linux machine (hdf5 is deliberately omitted).
+   * **grackle.pc** internally tracks the 2 set of linker flags.
+     The first set is used in the absence of the ``--static`` flag; in this scenario, these would be used for linking grackle as a shared library.
+     This currently might look something like ``-L<path/to/installed/grackle> -lgrackle``.
+     The file also separately tracks *private* linker-flags that are intended to be used for this scenario when you use Grackle as a static library.
+     These are somewhat specific to the compiler toolchain and machine/OS and depend on how Grackle was compiled.
+     At the time of running, they *usually* specify implicit dependencies.
+     For concreteness, this might look something like ``-lgomp -lgfortran -lm`` on a Linux machine (hdf5 is deliberately omitted).
 
-     * In this scenario, ``pkg-config --static --libs grackle`` determines the list of flags by ostensibly concatenating both sets of linker flags.
-       Importantly, this means that ``-lgrackle`` is specified in both cases.
+   * In this scenario, ``pkg-config --static --libs grackle`` determines the list of flags by ostensibly concatenating both sets of linker flags.
+     Importantly, this means that ``-lgrackle`` is specified in both cases.
 
-     * When a linker is provided ``-lgrackle``, it will search for a file called ``libgrackle.so`` (or ``libgrackle.dynlib`` on macOS) OR ``libgrackle.a``.
-       If both files are present (as is the case in this scenario), most linkers will prefer the shared library version.
+   * When a linker is provided ``-lgrackle``, it will search for a file called ``libgrackle.so`` (or ``libgrackle.dynlib`` on macOS) OR ``libgrackle.a``.
+     If both files are present (as is the case in this scenario), most linkers will prefer the shared library version.
 
-     * The approach to inform the linker of a preference to use the static-library that is *most* portable and easiest-to-express is to prepend a flag like ``-Bstatic`` to the start of the flags returned by ``pkg-config --static --libs grackle``. [#pc1]_
-       **Consequently, the linker will prefer to try to link every other required library statically** (we return to this shortly).
-       **MORE IMPORTANTLY,** there isn't any completely portable way to do this; some linkers (namely the one on macOS [#pc2]_ ) don't provide **ANY** convenient way to express this preference.
+   * The approach to inform the linker of a preference to use the static-library that is *most* portable and easiest-to-express is to prepend a flag like ``-Bstatic`` to the start of the flags returned by ``pkg-config --static --libs grackle``. [#pc1]_
+     **Consequently, the linker will prefer to try to link every other required library statically** (we return to this shortly).
+     **MORE IMPORTANTLY,** there isn't any completely portable way to do this; some linkers (namely the one on macOS [#pc2]_ ) don't provide **ANY** convenient way to express this preference.
 
-  2. Issues dealing with dependencies like hdf5:
+2. Issues dealing with dependencies like hdf5:
 
-     * There are actually 2 ways to deal with linker flags of private dependencies inside **grackle.pc**: (i) directly specify the private linker flags (as described in the preceeding bullets) or (ii) specify a "private requirement" on the dependency.
-       The latter option is only possible if the dependency provides its own \*.pc file (indeed, hdf5 usually comes with a **hdf5.pc**) file.
+   * There are actually 2 ways to deal with linker flags of private dependencies inside **grackle.pc**: (i) directly specify the private linker flags (as described in the preceeding bullets) or (ii) specify a "private requirement" on the dependency.
+     The latter option is only possible if the dependency provides its own \*.pc file (indeed, hdf5 usually comes with a **hdf5.pc**) file.
 
-     * Recall from the above bullets that when using ``pkg-config``'s ``--static`` flag, we effectively need to tell the linker to prefer linking **ALL** of Grackle's dependencies statically. 
-       With that in mind, we really should prefer the "private requirement" approach for specifying hdf5 as a private dependency of Grackle.
-       In slightly more detail, ``libhdf5.a`` has its own set of nontrivial private dependencies, and by using the "private requirement" approach, ``pkg-config`` should automatically handle those dependencies for us.
+   * Recall from the above bullets that when using ``pkg-config``'s ``--static`` flag, we effectively need to tell the linker to prefer linking **ALL** of Grackle's dependencies statically. 
+     With that in mind, we really should prefer the "private requirement" approach for specifying hdf5 as a private dependency of Grackle.
+     In slightly more detail, ``libhdf5.a`` has its own set of nontrivial private dependencies, and by using the "private requirement" approach, ``pkg-config`` should automatically handle those dependencies for us.
 
-     * Unfortunately, common hdf5 installations don't properly specify these private linker flags on commonly used platforms.
-       For example, on a Debian or Ubuntu system, the **hdf5.pc** file installed alongside hdf5 with ``apt`` doesn't actually specify **ANY** private linker flags (this seems to be a common occurence).
-       Additionally, the **hdf5.pc** file installed with HDF5 version 1.14.3 by Homebrew on macOS includes invalid private linker flags [#pc3]_ .
+   * Unfortunately, common hdf5 installations don't properly specify these private linker flags on commonly used platforms.
+     For example, on a Debian or Ubuntu system, the **hdf5.pc** file installed alongside hdf5 with ``apt`` doesn't actually specify **ANY** private linker flags (this seems to be a common occurence).
+     Additionally, the **hdf5.pc** file installed with HDF5 version 1.14.3 by Homebrew on macOS includes invalid private linker flags [#pc3]_ .
 
 It's for the above reasons that we have choosen not to support static-linking (via ``pkg-config``) in installations where both shared and static libraries are provided.
 If people want to use static libraries via pkg-config, we instead encourage an installation with just a static-library.
@@ -122,20 +122,20 @@ Essentially, the contents of **grackle_static.pc** would look a lot like the con
 While this wouldn't solve the issue of telling the linker to use libgrackle.a on macOS, it would solve the other issues.
 Even if we could overcome that remaining issue, this workaround is undesirable (unless there is strong user-demand) for a number of reasons:
 
-  * the primary reason is we would have more to maintain, and this workaround is totally unnecessary outside of a somewhat pathological case (Users need to go somewhat out of their way to use the CMake build-system to create a single installation that features both the static and shared versions of Grackle).
-    The much easier/more sensible/more idiomatic default behavior is to compile Grackle just as a shared library or just as a static library (in which case there isn't **any** problem).
+* the primary reason is we would have more to maintain, and this workaround is totally unnecessary outside of a somewhat pathological case (Users need to go somewhat out of their way to use the CMake build-system to create a single installation that features both the static and shared versions of Grackle).
+  The much easier/more sensible/more idiomatic default behavior is to compile Grackle just as a shared library or just as a static library (in which case there isn't **any** problem).
 
-  * this is far less "composable" than the existing alternative of requiring the end-user to compile Grackle just as a shared library or just as a static library.
-    Under the existing alternative, the build-system of a downstream application will invoke the same commands commands in either scenario.
-    If we shipped **grackle_static.pc**, the build system of a downstream application would need to embed additional logic to proactively alter the arguments passed to ``pkg-config`` based on the preference for shared and static libraries.
+* this is far less "composable" than the existing alternative of requiring the end-user to compile Grackle just as a shared library or just as a static library.
+  Under the existing alternative, the build-system of a downstream application will invoke the same commands commands in either scenario.
+  If we shipped **grackle_static.pc**, the build system of a downstream application would need to embed additional logic to proactively alter the arguments passed to ``pkg-config`` based on the preference for shared and static libraries.
 
-  * by the `principle of least surprise <https://en.wikipedia.org/wiki/Principle_of_least_astonishment>`__ there would be a solid argument to also supply the **grackle_static.pc** file in the case where we just install grackle as a static-library.
+* by the `principle of least surprise <https://en.wikipedia.org/wiki/Principle_of_least_astonishment>`__ there would be a solid argument to also supply the **grackle_static.pc** file in the case where we just install grackle as a static-library.
 
-  * the solution wouldn't scale well.
-    As development progresses, it is conceivable that we may want to easily support having multiple versions of grackle installed where we support different "backends."
-    For example, we might hypothetically support ``grackle.pc``, ``grackle_openmp.pc`` and ``grackle_cuda.pc``.
-    Alternatively, one could also imagine hypothetically imagine supporting ``grackle_float.pc`` (for a version compiled in single-precision).
-    If we ever go down any of these roads, we would also be somewhat obligated to manually manage variants of each file with/without the ``_static`` suffix.
+* the solution wouldn't scale well.
+  As development progresses, it is conceivable that we may want to easily support having multiple versions of grackle installed where we support different "backends."
+  For example, we might hypothetically support ``grackle.pc``, ``grackle_openmp.pc`` and ``grackle_cuda.pc``.
+  Alternatively, one could also imagine hypothetically imagine supporting ``grackle_float.pc`` (for a version compiled in single-precision).
+  If we ever go down any of these roads, we would also be somewhat obligated to manually manage variants of each file with/without the ``_static`` suffix.
 
 Instructions for Making a Release
 ---------------------------------
@@ -144,48 +144,48 @@ Before reading this section, please ensure you are familiar with our :ref:`versi
 
 To create a new release:
 
-  1. Draft the GitHub Release (using the GitHub website) and draft the changes to the changelog.
+1. Draft the GitHub Release (using the GitHub website) and draft the changes to the changelog.
 
-     - It's often easiest to start by drafting the GitHub release because GitHub provides the option to automatically generate a list of the titles and links to all pull-requests that have been merged since the previous release.
-       That functionality provides a list of all first-time contributors.
+   - It's often easiest to start by drafting the GitHub release because GitHub provides the option to automatically generate a list of the titles and links to all pull-requests that have been merged since the previous release.
+     That functionality provides a list of all first-time contributors.
 
-       - We recommend looking to older release notes as a guide.
-         With that said, our release generally consists of (i) a short summary about the release, (ii) a list of the changes, and (iii) a list of all contributors (that highlights first-time contributors). 
+     - We recommend looking to older release notes as a guide.
+       With that said, our release generally consists of (i) a short summary about the release, (ii) a list of the changes, and (iii) a list of all contributors (that highlights first-time contributors). 
 
-       - The automatically generated list of pull requests is an excellent way to start producing the list of changes.
-         But, the list entries may need to be slightly modified.
-         For example, PRs that simply update the version number tracked inside the repository should be removed (if present), it may make logical sense to group a series series of closely related PRs into a single entry, or an entry may need to be slightly more descriptive.
-         We also like to sort the list-entries into sections (e.g. New Features, Minor Enhancements, Bugfixes, Documentation Updates, etc.).
-         Finally, it makes sense to highlight any functions in the public API that have been deprecated or removed.
+     - The automatically generated list of pull requests is an excellent way to start producing the list of changes.
+       But, the list entries may need to be slightly modified.
+       For example, PRs that simply update the version number tracked inside the repository should be removed (if present), it may make logical sense to group a series series of closely related PRs into a single entry, or an entry may need to be slightly more descriptive.
+       We also like to sort the list-entries into sections (e.g. New Features, Minor Enhancements, Bugfixes, Documentation Updates, etc.).
+       Finally, it makes sense to highlight any functions in the public API that have been deprecated or removed.
 
-     - After you draft the GitHub release, you can take advantage of GitHub's feature to save the draft and circulate it to other developers for comments/recommendations.
+   - After you draft the GitHub release, you can take advantage of GitHub's feature to save the draft and circulate it to other developers for comments/recommendations.
 
-     - It's fairly straightforward to draft changes to the changelog based on the contents of the GitHub release.
+   - It's fairly straightforward to draft changes to the changelog based on the contents of the GitHub release.
 
-  2. Create a new PR that will serve as the final PR of the release. The PR should:
+2. Create a new PR that will serve as the final PR of the release. The PR should:
 
-     - update the changelog (the changelog is stored within the ``CHANGELOG`` file at the root of the repository).
+   - update the changelog (the changelog is stored within the ``CHANGELOG`` file at the root of the repository).
 
-     - update the version number of the c-library. This is currently tracked within the ``VERSION`` file (that can be found at the root level of the repository)
+   - update the version number of the c-library. This is currently tracked within the ``VERSION`` file (that can be found at the root level of the repository)
 
-     - (if applicable) update the version number of the python module (stored internally in `pyproject.toml`)
+   - (if applicable) update the version number of the python module (stored internally in `pyproject.toml`)
 
-  3. After the PR is merged, perform the release on GitHub.
-     Make sure to associate the release with the proper target (it should include changes from the PR).
+3. After the PR is merged, perform the release on GitHub.
+   Make sure to associate the release with the proper target (it should include changes from the PR).
 
-  4. Make a new PR composed of a single commit (this is the first commit of the next release).
-     It should **only** update the version number of the c-library to specify the next development version
- 
-      - like before, this must be updated in  the ``VERSION`` file (that can be found at the root level of the repository).
-        Instructions for choosing development version numbers are provided :ref:`here <dev-version-numbers>` (note that this changed in the version 3.3 release).
+4. Make a new PR composed of a single commit (this is the first commit of the next release).
+   It should **only** update the version number of the c-library to specify the next development version
 
-      - do **NOT** touch anything else (even the python version number)
+   - like before, this must be updated in  the ``VERSION`` file (that can be found at the root level of the repository).
+     Instructions for choosing development version numbers are provided :ref:`here <dev-version-numbers>` (note that this changed in the version 3.3 release).
 
-  5. Go to the *Read the Docs* `project webpage <https://readthedocs.org/projects/grackle/>`__ and the new release's tag to the list of "Active Versions."
-     This ensures that *Read the Docs* will maintain a version of the documentation for this particular release.
+   - do **NOT** touch anything else (even the python version number)
 
-  6. Announce the release in an email to the `Grackle mailing list <https://groups.google.com/g/grackle-cooling-users>`__.
-     This can be adapted from the GitHub Release notes.
+5. Go to the *Read the Docs* `project webpage <https://readthedocs.org/projects/grackle/>`__ and the new release's tag to the list of "Active Versions."
+   This ensures that *Read the Docs* will maintain a version of the documentation for this particular release.
+
+6. Announce the release in an email to the `Grackle mailing list <https://groups.google.com/g/grackle-cooling-users>`__.
+   This can be adapted from the GitHub Release notes.
 
 
 .. rubric:: Footnotes

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -32,25 +32,25 @@ Dependencies
 In addition to C/C++ and Fortran compilers, the following dependency must 
 also be installed:
 
-   * `HDF5 <http://www.hdfgroup.org/HDF5/>`_, the hierarchical data format.
-     HDF5 also may require the szip and zlib libraries, which can be
-     found at the HDF5 website.
+* `HDF5 <http://www.hdfgroup.org/HDF5/>`_, the hierarchical data format.
+  HDF5 also may require the szip and zlib libraries, which can be
+  found at the HDF5 website.
 
-     .. note::
+  .. note::
 
-        If using the :ref:`classic build system <classic_build>`: compiling with HDF5 1.8 or greater requires that the ``H5_USE_16_API`` compatability directive is manually specified.
-        This can be done by manually adding ``-DH5_USE_16_API`` to the list of compiler flags given in machine-specific make files.
+     If using the :ref:`classic build system <classic_build>`: compiling with HDF5 1.8 or greater requires that the ``H5_USE_16_API`` compatability directive is manually specified.
+     This can be done by manually adding ``-DH5_USE_16_API`` to the list of compiler flags given in machine-specific make files.
 
-        You don't have to think about this when using :ref:`CMake build system <cmake_build>` (it is handled automatically).
+     You don't have to think about this when using :ref:`CMake build system <cmake_build>` (it is handled automatically).
 
 Although many systems already have them installed, both build systems have additional dependencies:
 
-   * the :ref:`CMake build system <cmake_build>` requires cmake to be installed.
-     It's easiest to download a binary distribution from the `CMake website <https://cmake.org/download/>`_ or use your system's package manager.
-     We require version 3.16 or newer.
+* the :ref:`CMake build system <cmake_build>` requires cmake to be installed.
+  It's easiest to download a binary distribution from the `CMake website <https://cmake.org/download/>`_ or use your system's package manager.
+  We require version 3.16 or newer.
 
-   * the :ref:`classic build system <classic_build>`, employs the ``makedepend`` and the `libtool <https://www.gnu.org/software/libtool/>`_ utilities.
-     It's often easiest to download these dependencies through your system's package manager.
+* the :ref:`classic build system <classic_build>`, employs the ``makedepend`` and the `libtool <https://www.gnu.org/software/libtool/>`_ utilities.
+  It's often easiest to download these dependencies through your system's package manager.
 
 .. _download_grackle:
 
@@ -366,11 +366,11 @@ The most important role is to specify cluster-specific optimization flags via th
 These flags will **ONLY** be used when compiling Grackle with the ``Release`` or ``RelWithDebInfo`` build-types.
 Here are 2 illustrative examples:
 
- * First we show that in order to pass multiple flags, the flags need to be specified by a semicolon delimited list.
-   If you stored ``"-xCORE-AVX512;-funroll-loops"`` within ``GRACKLE_OPTIMIZATION_FLIST_INIT``, then all source files will be compiled with these options (they won't be passed to the linker).
+* First we show that in order to pass multiple flags, the flags need to be specified by a semicolon delimited list.
+  If you stored ``"-xCORE-AVX512;-funroll-loops"`` within ``GRACKLE_OPTIMIZATION_FLIST_INIT``, then all source files will be compiled with these options (they won't be passed to the linker).
 
- * Next we show that to properly pass "option groups" you may need to make use of CMake's shell-like quoting with the ``SHELL:`` prefix (this relates to option de-duplication performed by CMake).
-   Thus, storing ``"SHELL:-option1 A;-Wall;SHELL:-option2 B"`` within ``GRACKLE_OPTIMIZATION_FLIST_INIT`` would cause all compiler invocations for source files used in Grackle to be passed ``-option1 A -Wall -option2 B``.
+* Next we show that to properly pass "option groups" you may need to make use of CMake's shell-like quoting with the ``SHELL:`` prefix (this relates to option de-duplication performed by CMake).
+  Thus, storing ``"SHELL:-option1 A;-Wall;SHELL:-option2 B"`` within ``GRACKLE_OPTIMIZATION_FLIST_INIT`` would cause all compiler invocations for source files used in Grackle to be passed ``-option1 A -Wall -option2 B``.
 
 While embedded builds currently respect ``GRACKLE_OPTIMIZATION_FLIST_INIT``, that is something we may stop supporting.
 
@@ -720,8 +720,8 @@ Compiler Toolchain Compatability
 
 As a general rule of thumb, the easiest, most reliable thing to do is  to ensure that Grackle is built with the same compiler toolchain (or a compatible one) as the
 
-   * the downstream application itself (whether it's a simulation code or pygrackle)
-   * any other dependencies of the application (whether it's other software libraries or other python extension-modules loaded at the same time).
+* the downstream application itself (whether it's a simulation code or pygrackle)
+* any other dependencies of the application (whether it's other software libraries or other python extension-modules loaded at the same time).
 
 This is only something you need to consider on platforms with multiple compiler toolchains present. 
 

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -135,9 +135,9 @@ This file format is recognized by most popular build systems like autotools, Mes
 If your application's build system consists of bare Makefiles, you can employ this file by invoking the ``pkg-config`` directly.
 The basic usage is extremely simple:
 
-  * ``pkg-config --cflags grackle`` provides compiler flags (namely the ``-I`` flag)
+* ``pkg-config --cflags grackle`` provides compiler flags (namely the ``-I`` flag)
 
-  * ``pkg-config --libs grackle`` provides linker flags (namely the ``-L`` and ``-l`` flags)
+* ``pkg-config --libs grackle`` provides linker flags (namely the ``-L`` and ``-l`` flags)
 
 If Grackle isn't installed in a standard system installation directly, you or the end-user needs to set the ``PKG_CONFIG_PATH`` variable to tell ``pkg-config`` where to find **grackle.pc** (if Grackle is a shared library, the relevant runtime-challenges LINK still need to be addressed).
 

--- a/doc/source/Interaction.rst
+++ b/doc/source/Interaction.rst
@@ -24,15 +24,15 @@ The grackle source code contains examples for C, C++, and Fortran codes.
 They are located in the :source:`src/example` directory and provide examples
 of calling all of grackle's functions.
 
-    * :code-example:`c_example.c` - C example
+* :code-example:`c_example.c` - C example
 
-    * :code-example:`c_local_example.c` - C example using only :ref:`local_functions`
+* :code-example:`c_local_example.c` - C example using only :ref:`local_functions`
 
-    * :code-example:`cxx_example.C` - C++ example
+* :code-example:`cxx_example.C` - C++ example
 
-    * :code-example:`cxx_omp_example.C` - C++ example using OpenMP
+* :code-example:`cxx_omp_example.C` - C++ example using OpenMP
 
-    * :code-example:`fortran_example.F` - Fortran example
+* :code-example:`fortran_example.F` - Fortran example
 
 The instructions for building and executing the examples vary based on the build-system:
 
@@ -415,9 +415,9 @@ As of version 2.2, Grackle can be run with OpenMP parallelism.
 To do this, the library must be compiled with OpenMP support.
 When compiling Grackle
 
-  * with the :ref:`classic build system <classic_build>`, you should execute ``make omp-on`` before compiling (more information about modifying settings in this system are provided :ref:`here <compiler-settings>`)
+* with the :ref:`classic build system <classic_build>`, you should execute ``make omp-on`` before compiling (more information about modifying settings in this system are provided :ref:`here <compiler-settings>`)
 
-  * with the :ref:`CMake build system <cmake_build>`, you should configure the build by assigning the ``GRACKLE_USE_OPENMP`` cmake-variable a value of ``ON`` (more information about modifying settings in this system are provided :ref:`here <how_to_configure>`)
+* with the :ref:`CMake build system <cmake_build>`, you should configure the build by assigning the ``GRACKLE_USE_OPENMP`` cmake-variable a value of ``ON`` (more information about modifying settings in this system are provided :ref:`here <how_to_configure>`)
 
 For an example of how to compile your code with OpenMP, see the
 :code-example:`cxx_omp_example.C` code example (:ref:`examples`).  Once your code has
@@ -934,9 +934,9 @@ The obvious way to configure this feature is to include the following snippet in
 
 However, inclusion of the above snippet will prevent the simulation code from compiling if the user has a version of Grackle installed in which :c:data:`chemistry_data` does not have the ``use_fancy_feature`` and ``fancy_feature_param`` fields. Consequently, such users will have to update Grackle.
 
-  * This can be inconvenient when a user has no interest in using this new feature, but needs an unrelated feature/bugfix introduced to the code in a subsequent changeset
+* This can be inconvenient when a user has no interest in using this new feature, but needs an unrelated feature/bugfix introduced to the code in a subsequent changeset
 
-  * This is especially inconvenient if a user is prototying a new feature in a custom Grackle branch in which the :c:data:`chemistry_data` struct is missing these fields.
+* This is especially inconvenient if a user is prototying a new feature in a custom Grackle branch in which the :c:data:`chemistry_data` struct is missing these fields.
 
 The following snippet shows how the dynamic access API can be used in the same way for versions of Grackle that include these parameters, and don't set the features in cases 
 
@@ -960,10 +960,10 @@ The following snippet shows how the dynamic access API can be used in the same w
 
 There are a few points worth noting:
 
-  * As the above snippets show, the dynamic api clearly produces more verbose code when configuring :c:data:`chemistry_data` field-by-field. However, in codes where users configure Grackle by specifying the name of fields in the :c:data:`chemistry_data` struct and the associated values in a parameter file, the dynamic API can facillitate MUCH less verbose code. Under certain implementations, it may not even be necessary to modify a simulation code to support newly-introduced grackle parameters.
+* As the above snippets show, the dynamic api clearly produces more verbose code when configuring :c:data:`chemistry_data` field-by-field. However, in codes where users configure Grackle by specifying the name of fields in the :c:data:`chemistry_data` struct and the associated values in a parameter file, the dynamic API can facillitate MUCH less verbose code. Under certain implementations, it may not even be necessary to modify a simulation code to support newly-introduced grackle parameters.
 
-  * The dynamic API is slower than configuring :c:data:`chemistry_data` in the classic approach. However, this shouldn't be an issue since :c:data:`chemistry_data` is usually just configured once when the simulation code starts up.
+* The dynamic API is slower than configuring :c:data:`chemistry_data` in the classic approach. However, this shouldn't be an issue since :c:data:`chemistry_data` is usually just configured once when the simulation code starts up.
 
-  * The highlighted functions can also be used in tandem with other functions described in :ref:`dynamic_api_functions` to simplify (de)serialization of :c:data:`chemistry_data`.
+* The highlighted functions can also be used in tandem with other functions described in :ref:`dynamic_api_functions` to simplify (de)serialization of :c:data:`chemistry_data`.
 
-  * For completeness, the dynamic API also provides an analogous function for configuring string parameters.
+* For completeness, the dynamic API also provides an analogous function for configuring string parameters.

--- a/doc/source/Parameters.rst
+++ b/doc/source/Parameters.rst
@@ -27,20 +27,20 @@ For all on/off integer flags, 0 is off and 1 is on.
    Flag to control which primordial chemistry network is used.
    Default: 0.
 
-    - 0: no chemistry network.  Radiative cooling for primordial
-      species is solved by interpolating from lookup tables
-      calculated with Cloudy.
-    - 1: 6-species atomic H and He.  Active species: H, H\ :sup:`+`,
-      He, He\ :sup:`+`, \ :sup:`++`, e\ :sup:`-`.
-    - 2: 9-species network including atomic species above and species
-      for molecular hydrogen formation.  This network includes
-      formation from the H\ :sup:`-` and H\ :sub:`2`\ :sup:`+`
-      channels, three-body formation (H+H+H and H+H+H\ :sub:`2`),
-      H\ :sub:`2` rotational transitions, chemical heating, and
-      collision-induced emission (optional).  Active species: above +
-      H\ :sup:`-`, H\ :sub:`2`, H\ :sub:`2`\ :sup:`+`.
-    - 3: 12-species network include all above plus HD rotation cooling.
-      Active species: above + D, D\ :sup:`+`, HD.
+   - 0: no chemistry network.  Radiative cooling for primordial
+     species is solved by interpolating from lookup tables
+     calculated with Cloudy.
+   - 1: 6-species atomic H and He.  Active species: H, H\ :sup:`+`,
+     He, He\ :sup:`+`, \ :sup:`++`, e\ :sup:`-`.
+   - 2: 9-species network including atomic species above and species
+     for molecular hydrogen formation.  This network includes
+     formation from the H\ :sup:`-` and H\ :sub:`2`\ :sup:`+`
+     channels, three-body formation (H+H+H and H+H+H\ :sub:`2`),
+     H\ :sub:`2` rotational transitions, chemical heating, and
+     collision-induced emission (optional).  Active species: above +
+     H\ :sup:`-`, H\ :sub:`2`, H\ :sub:`2`\ :sup:`+`.
+   - 3: 12-species network include all above plus HD rotation cooling.
+     Active species: above + D, D\ :sup:`+`, HD.
 
 .. note:: In order to make use of the non-equilibrium chemistry
    network (:c:data:`primordial_chemistry` options 1-3), you must add
@@ -55,17 +55,17 @@ For all on/off integer flags, 0 is off and 1 is on.
    - 0: no dust-related processes included.
    - 1: adds the following processes:
 
-        #. photo-electric heating (sets :c:data:`photoelectric_heating` to 2).
-        #. cooling from electron recombination onto dust (equation 9 from
-           `Wolfire et al. 1995
-           <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__).
-           Both the photo-electric heating and recombination cooling are scaled
-           by the value of the :c:data:`interstellar_radiation_field`.
-        #. H\ :sub:`2`\  formation on dust (sets :c:data:`h2_on_dust` to 1
-           if :c:data:`primordial_chemistry` > 1).
+     #. photo-electric heating (sets :c:data:`photoelectric_heating` to 2).
+     #. cooling from electron recombination onto dust (equation 9 from
+        `Wolfire et al. 1995
+        <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__).
+        Both the photo-electric heating and recombination cooling are scaled
+        by the value of the :c:data:`interstellar_radiation_field`.
+     #. H\ :sub:`2`\  formation on dust (sets :c:data:`h2_on_dust` to 1
+        if :c:data:`primordial_chemistry` > 1).
 
-        Setting :c:data:`dust_chemistry` greater than 0 requires
-        :c:data:`metal_cooling` to be enabled.
+   Setting :c:data:`dust_chemistry` greater than 0 requires
+   :c:data:`metal_cooling` to be enabled.
 
 .. note:: Other values for :c:data:`photoelectric_heating` may also be used
    in conjunction with setting the :c:data:`dust_chemistry` parameter. It will
@@ -139,8 +139,8 @@ For all on/off integer flags, 0 is off and 1 is on.
    this parameter will be set to the lowest redshift of the UV background
    data being used.
 
-.. image:: _images/ramp.png
-   :width: 300
+   .. image:: _images/ramp.png
+      :width: 300
 
 .. c:var:: char* grackle_data_file
 
@@ -157,23 +157,23 @@ For all on/off integer flags, 0 is off and 1 is on.
 
    Flag to control which three-body H\ :sub:`2` formation rate is used.
 
-    - 0: `Abel, Bryan & Norman (2002)
-      <http://adsabs.harvard.edu/abs/2002Sci...295...93A>`_
+   - 0: `Abel, Bryan & Norman (2002)
+     <http://adsabs.harvard.edu/abs/2002Sci...295...93A>`_
 
-    - 1: `Palla, Salpeter & Stahler (1983)
-      <http://adsabs.harvard.edu/abs/1983ApJ...271..632P>`_
+   - 1: `Palla, Salpeter & Stahler (1983)
+     <http://adsabs.harvard.edu/abs/1983ApJ...271..632P>`_
 
-    - 2: `Cohen & Westberg (1983)
-      <http://adsabs.harvard.edu/abs/1983JPCRD..12..531C>`_
+   - 2: `Cohen & Westberg (1983)
+     <http://adsabs.harvard.edu/abs/1983JPCRD..12..531C>`_
 
-    - 3: `Flower & Harris (2007)
-      <http://adsabs.harvard.edu/abs/2007MNRAS.377..705F>`_
+   - 3: `Flower & Harris (2007)
+     <http://adsabs.harvard.edu/abs/2007MNRAS.377..705F>`_
 
-    - 4: `Glover (2008)
-      <http://adsabs.harvard.edu/abs/2008AIPC..990...25G>`_
+   - 4: `Glover (2008)
+     <http://adsabs.harvard.edu/abs/2008AIPC..990...25G>`_
 
-    - 5: `Forrey (2013)
-      <http://adsabs.harvard.edu/abs/2013ApJ...773L..25F>`_.
+   - 5: `Forrey (2013)
+     <http://adsabs.harvard.edu/abs/2013ApJ...773L..25F>`_.
 
    The first five options are discussed in `Turk et. al. (2011)
    <http://adsabs.harvard.edu/abs/2011ApJ...726...55T>`_.  Default: 0.
@@ -195,22 +195,22 @@ For all on/off integer flags, 0 is off and 1 is on.
    Flag to enable photo-electric heating from irradiated dust grains.
    Default: 0.
 
-    - 0: no photo-electric heating.
-    - 1: a spatially uniform heating term from `Tasker & Bryan (2008)
-      <http://adsabs.harvard.edu/abs/2008ApJ...673..810T>`__. The exact
-      heating rate used must be specified with the
-      :c:data:`photoelectric_heating_rate` parameter. For temperatures
-      above 20,000 K, the photo-electric heating rate is set to 0.
-    - 2: similar to option 1, except the heating rate is calculated
-      using equation 1 of `Wolfire et al. (1995)
-      <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__
-      and the user must supply the intensity of the interstellar radiation
-      field with the :c:data:`interstellar_radiation_field` parameter. The
-      value of epsilon is taken as a constant equal to 0.05 for gas below
-      20,000 K and 0 otherwise.
-    - 3: similar to option 1, except the value of epsilon is calculated
-      directly from equation 2 of `Wolfire et al. (1995)
-      <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__.
+   - 0: no photo-electric heating.
+   - 1: a spatially uniform heating term from `Tasker & Bryan (2008)
+     <http://adsabs.harvard.edu/abs/2008ApJ...673..810T>`__. The exact
+     heating rate used must be specified with the
+     :c:data:`photoelectric_heating_rate` parameter. For temperatures
+     above 20,000 K, the photo-electric heating rate is set to 0.
+   - 2: similar to option 1, except the heating rate is calculated
+     using equation 1 of `Wolfire et al. (1995)
+     <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__
+     and the user must supply the intensity of the interstellar radiation
+     field with the :c:data:`interstellar_radiation_field` parameter. The
+     value of epsilon is taken as a constant equal to 0.05 for gas below
+     20,000 K and 0 otherwise.
+   - 3: similar to option 1, except the value of epsilon is calculated
+     directly from equation 2 of `Wolfire et al. (1995)
+     <https://ui.adsabs.harvard.edu/abs/1995ApJ...443..152W/abstract>`__.
 
 .. c:var:: int dust_recombination_cooling
 
@@ -404,15 +404,15 @@ For all on/off integer flags, 0 is off and 1 is on.
    exist for the length scale used in calculating the H\ :sub:`2`\  column
    density. Default: 0.
 
-    - 1: Use a Sobolev-like, spherically averaged method from
-      `Wolcott-Green \& Haiman (2019)
-      <https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2467W/>`__. Prior to
-      Grackle version 3.2, this option used the method of `Wolcott-Green et. al.
-      (2011) <https://ui.adsabs.harvard.edu/abs/2011MNRAS.418..838W/>`__.
-      This option is only valid for Cartesian grid codes in 3D.
-    - 2: Supply an array of lengths using the :c:data:`H2_self_shielding_length`
-      field.
-    - 3: Use the local Jeans length.
+   - 1: Use a Sobolev-like, spherically averaged method from
+     `Wolcott-Green \& Haiman (2019)
+     <https://ui.adsabs.harvard.edu/abs/2019MNRAS.484.2467W/>`__. Prior to
+     Grackle version 3.2, this option used the method of `Wolcott-Green et. al.
+     (2011) <https://ui.adsabs.harvard.edu/abs/2011MNRAS.418..838W/>`__.
+     This option is only valid for Cartesian grid codes in 3D.
+   - 2: Supply an array of lengths using the :c:data:`H2_self_shielding_length`
+     field.
+   - 3: Use the local Jeans length.
 
 .. c:var:: int H2_custom_shielding
 
@@ -450,14 +450,14 @@ For all on/off integer flags, 0 is off and 1 is on.
    avenue of future research in developing a more complete self-shielding model.
    Each self-shielding option is described below.
 
-     - 0: No self shielding. Elements are optically thin to the UV background.
-     - 1: Not Recommended. Approximate self-shielding in HI only. 
-          HeI and HeII are left as optically thin.
-     - 2: Approximate self-shielding in both HI and HeI. HeII remains
-          optically thin.
-     - 3: Approximate self-shielding in both HI and HeI, but ignoring
-          HeII ionization and heating from the UV background entirely
-          (HeII ionization and heating rates are set to zero). 
+   - 0: No self shielding. Elements are optically thin to the UV background.
+   - 1: Not Recommended. Approximate self-shielding in HI only. 
+        HeI and HeII are left as optically thin.
+   - 2: Approximate self-shielding in both HI and HeI. HeII remains
+        optically thin.
+   - 3: Approximate self-shielding in both HI and HeI, but ignoring
+        HeII ionization and heating from the UV background entirely
+        (HeII ionization and heating rates are set to zero). 
 
    These methods only work in conjunction with using updated Cloudy
    cooling tables, denoted with "_shielding". These tables properly account
@@ -476,24 +476,24 @@ For all on/off integer flags, 0 is off and 1 is on.
    Flag which selects the formula used for calculating the ``k11`` rate 
    coefficient. Default: 1.
 
-      - 1: Equation 4 from `Savin et. al., 2004 <https://arxiv.org/abs/astro-ph/0404288>`_.
-      - 2: Table 3, Equation 11 from `Abel et. al., 1996 <https://arxiv.org/abs/astro-ph/9608040>`_.
+   - 1: Equation 4 from `Savin et. al., 2004 <https://arxiv.org/abs/astro-ph/0404288>`_.
+   - 2: Table 3, Equation 11 from `Abel et. al., 1996 <https://arxiv.org/abs/astro-ph/9608040>`_.
 
 .. c:var:: int h2_dust_rate
 
    Flag which selects the formula used for calculating the ``h2dust`` rate
    coefficient. Default: 1.
 
-      - 1: Table 1, Equation 23 from `Omukai, 2000 <https://arxiv.org/abs/astro-ph/0003212>`_.
-      - 2: Equation 3.8 from `Hollenbach & McKee, 1979 <https://ui.adsabs.harvard.edu/abs/1979ApJS...41..555H/abstract>`_.
+   - 1: Table 1, Equation 23 from `Omukai, 2000 <https://arxiv.org/abs/astro-ph/0003212>`_.
+   - 2: Equation 3.8 from `Hollenbach & McKee, 1979 <https://ui.adsabs.harvard.edu/abs/1979ApJS...41..555H/abstract>`_.
 
 .. c:var:: int h2_h_cooling_rate
 
    Flag which selects the formula for calculating the ``GAHI`` rate coefficient.
    Default: 1.
 
-      - 1: Equation based on `Lique, 2015 <https://academic.oup.com/mnras/article/453/1/810/1752438>`_. 
-      - 2: Equation 40 with fitting coefficients found in Table 8, from `Glover & Abel, 2008 <https://arxiv.org/abs/0803.1768>`_.
+   - 1: Equation based on `Lique, 2015 <https://academic.oup.com/mnras/article/453/1/810/1752438>`_. 
+   - 2: Equation 40 with fitting coefficients found in Table 8, from `Glover & Abel, 2008 <https://arxiv.org/abs/0803.1768>`_.
 
    Notes on setting 1:
       This fit is accurate to within ~5% over the temperature range 100 < T < 5000 K. Lique (2015)
@@ -571,31 +571,31 @@ solar metallicity and scaled linearly with the metallicity of the gas.
 
 Valid range:
 
- - number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 4
+- number density: -10 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 4
 
- - temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 9.
+- temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 9.
 
 Data files:
 
- - **CloudyData_noUVB.h5** - cooling rates for collisional ionization
-   equilibrium.
+- **CloudyData_noUVB.h5** - cooling rates for collisional ionization
+  equilibrium.
 
- - **CloudyData_UVB=FG2011.h5** - heating and cooling rates and UV
-   background rates from the work of `Faucher-Giguere et. al. (2009)
-   <http://adsabs.harvard.edu/abs/2009ApJ...703.1416F>`_, updated in 2011.
-   The maxmimum redshift is 10.6.  Above that, collisional ionization
-   equilibrium is assumed.
+- **CloudyData_UVB=FG2011.h5** - heating and cooling rates and UV
+  background rates from the work of `Faucher-Giguere et. al. (2009)
+  <http://adsabs.harvard.edu/abs/2009ApJ...703.1416F>`_, updated in 2011.
+  The maxmimum redshift is 10.6.  Above that, collisional ionization
+  equilibrium is assumed.
 
- - **CloudyData_UVB=HM2012.h5** - heating and cooling rates and UV
-   background rates from the work of `Haardt & Madau (2012)
-   <http://adsabs.harvard.edu/abs/2012ApJ...746..125H>`_.  The maximum
-   redshift is 15.13.  Above that, collisional ionization equilibrium is
-   assumed.
+- **CloudyData_UVB=HM2012.h5** - heating and cooling rates and UV
+  background rates from the work of `Haardt & Madau (2012)
+  <http://adsabs.harvard.edu/abs/2012ApJ...746..125H>`_.  The maximum
+  redshift is 15.13.  Above that, collisional ionization equilibrium is
+  assumed.
 
- - **CloudyData_UVB=HM2012_high_density.h5** - same as
-   **CloudyData_UVB=HM2012.h5** but goes to higher density (10\ :sup:`10`
-   atom / cm\ :sup:`3`) and was computed with a more recent version of
-   Cloudy (17.06).
+- **CloudyData_UVB=HM2012_high_density.h5** - same as
+  **CloudyData_UVB=HM2012.h5** but goes to higher density (10\ :sup:`10`
+  atom / cm\ :sup:`3`) and was computed with a more recent version of
+  Cloudy (17.06).
 
 To use the self-shielding approximation (see ``self_shielding_method``),
 one must properly account for the change in metal line cooling rates in
@@ -624,11 +624,11 @@ approximations. Currently only the HM2012 table has been recomputed.
    :c:data:`self_shielding_method` enabled. **It is not recommended to
    use these files with primordial_chemistry set to 0.**
 
- - **CloudyData_UVB=HM2012_shielded.h5** - updated heating and cooling
-   rates with the HM2012 UV background, accounting for self-shielding.
+- **CloudyData_UVB=HM2012_shielded.h5** - updated heating and cooling
+  rates with the HM2012 UV background, accounting for self-shielding.
 
- - **CloudyData_UVB=FG2011_shielded.h5** - updated heating and cooling
-   rates with the FG2011 UV background, accounting for self-shielding.
+- **CloudyData_UVB=FG2011_shielded.h5** - updated heating and cooling
+  rates with the FG2011 UV background, accounting for self-shielding.
 
 The final file includes only metal cooling rates under collisional
 ionization equilibrium, i.e., no incident radiation field.  This table
@@ -639,13 +639,13 @@ table more appropriate for simulations of collapsing gas-clouds.
 
 Valid range:
 
- - number density: -6 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 12
+- number density: -6 < log\ :sub:`10` (n\ :sub:`H` / cm\ :sup:`-3`) < 12
 
- - metallicity: -6 < log\ :sub:`10` (Z / Z\ :sub:`sun`) < 1
+- metallicity: -6 < log\ :sub:`10` (Z / Z\ :sub:`sun`) < 1
 
- - temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 8.
+- temperature: the temperature range is 1 < log\ :sub:`10` (T / K) < 8.
 
 Data file:
 
- - **cloudy_metals_2008_3D.h5** - collisional ionization equilibrium,
-   metal cooling rates only.
+- **cloudy_metals_2008_3D.h5** - collisional ionization equilibrium,
+  metal cooling rates only.

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -7,21 +7,21 @@ Grackle comes with a Python interface, called Pygrackle, which provides
 access to all of Grackle's functionality.  Pygrackle requires the following
 Python packages:
 
- - `Cython <https://cython.org/>`__
+- `Cython <https://cython.org/>`__
 
- - flake8 (only required for the test suite)
+- flake8 (only required for the test suite)
 
- - `h5py <https://www.h5py.org/>`__
+- `h5py <https://www.h5py.org/>`__
 
- - `matplotlib <https://matplotlib.org/>`__
+- `matplotlib <https://matplotlib.org/>`__
 
- - `NumPy <https://www.numpy.org/>`__
+- `NumPy <https://www.numpy.org/>`__
 
- - packaging (only required for the test suite)
+- packaging (only required for the test suite)
 
- - py.test (only required for the test suite)
+- py.test (only required for the test suite)
 
- - `yt <https://yt-project.org/>`__
+- `yt <https://yt-project.org/>`__
 
 The easiest thing to do is follow the instructions for installing yt,
 which will provide you with Cython, matplotlib, and NumPy.  Flake8 and
@@ -38,14 +38,14 @@ Currently, the only way to get Pygrackle is to build it from source.
 
 There are 3 ways to build Pygrackle:
 
- 1. As a standalone, self-contained module.
-    The build command creates a fresh build of the Grackle library and packages it with the Pygrackle module.
-    **(This is the recommended approach)**
+1. As a standalone, self-contained module.
+   The build command creates a fresh build of the Grackle library and packages it with the Pygrackle module.
+   **(This is the recommended approach)**
 
- 2. As a module that links to an external copy of Grackle that was compiled with the :ref:`Classic build system <classic_build>`.
-    (This is consistent with the legacy approach for building Pygrackle).
+2. As a module that links to an external copy of Grackle that was compiled with the :ref:`Classic build system <classic_build>`.
+   (This is consistent with the legacy approach for building Pygrackle).
 
- 3. As a module that links to an external copy of Grackle that was created with the :ref:`CMake build system <cmake_build>`.
+3. As a module that links to an external copy of Grackle that was created with the :ref:`CMake build system <cmake_build>`.
 
 Currently, Pygrackle should be used with Grackle builds where OpenMP is disabled.
 

--- a/doc/source/Reference.rst
+++ b/doc/source/Reference.rst
@@ -76,9 +76,9 @@ Primary Functions
    Returns the factor that includes unit conversions and fundamental constants that must be multiplied by :c:data:`internal_energy` (in units of :c:data:`velocity_units`\ :sup:`2`) to get temperature (in units of K).
    In more detail:
 
-     - the returned value is defined as m\ :sub:`H`\ \*\ :c:data:`velocity_units`\ :sup:`2`\ /\ k\ :sub:`b`, where m\ :sub:`H` is the Hydrogen mass and k\ :sub:`b` is the Boltzmann constant.
+   - the returned value is defined as m\ :sub:`H`\ \*\ :c:data:`velocity_units`\ :sup:`2`\ /\ k\ :sub:`b`, where m\ :sub:`H` is the Hydrogen mass and k\ :sub:`b` is the Boltzmann constant.
 
-     - under the standard assumption of an ideal gas, temperature is given by :c:data:`internal_energy`\ \*\ ``temperature_units``\ \*\ :math:`(\gamma - 1)`\ \*\ :math:`\mu`, where :math:`\gamma` is the adiabatic index and :math:`\mu` is the mean molecular weight.
+   - under the standard assumption of an ideal gas, temperature is given by :c:data:`internal_energy`\ \*\ ``temperature_units``\ \*\ :math:`(\gamma - 1)`\ \*\ :math:`\mu`, where :math:`\gamma` is the adiabatic index and :math:`\mu` is the mean molecular weight.
 
    :param code_units* my_units: code units conversions
    :rtype: double

--- a/doc/source/Testing.rst
+++ b/doc/source/Testing.rst
@@ -8,8 +8,8 @@ everything is working properly.
 
 The tests are primarily organized into 2 test suites:
 
-  1. the :ref:`core-library test suite <corelib-suite>`, which performs tests on the Core library
-  2. the :ref:`pygrackle test suite <pygrackle-suite>`, which performs tests on the pygrackle bindings
+1. the :ref:`core-library test suite <corelib-suite>`, which performs tests on the Core library
+2. the :ref:`pygrackle test suite <pygrackle-suite>`, which performs tests on the pygrackle bindings
 
 Our continuous integration system is also set up to ensure that all Python code conforms to `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`__
 
@@ -27,10 +27,10 @@ The "compilation tests" verify that all code examples build, run, and return con
 
 The core-library tests are driven by the ``ctest`` program that is shipped as part of ``CMake``.
 
-  - the ``CTest`` test-driver is integrated with ``CMake`` and it is designed to flexibly run various kinds of tests by invoking the command-line
+- the ``CTest`` test-driver is integrated with ``CMake`` and it is designed to flexibly run various kinds of tests by invoking the command-line
 
-  - the unit tests that the ``CTest`` driver invokes are all implemented using the `GoogleTest testing Framework <https://google.github.io/googletest/>`__.
-    Note: the dependency on GoogleTest is handled automatically (if you don't configure the build-system to use an existing installation, the build system will know to automatically fetch/compile the framework when instructed to compile the tests).
+- the unit tests that the ``CTest`` driver invokes are all implemented using the `GoogleTest testing Framework <https://google.github.io/googletest/>`__.
+  Note: the dependency on GoogleTest is handled automatically (if you don't configure the build-system to use an existing installation, the build system will know to automatically fetch/compile the framework when instructed to compile the tests).
 
 To configure Grackle builds to run the core-library tests, you must enable the ``GRACKLE_BUILD_TESTS`` option when you configure a CMake build of Grackle.
 This option just enables ``CTest`` and some extra build-recipes needed to run the tests (it has no impact on how libgrackle is compiled/linked).
@@ -49,11 +49,11 @@ The following snippet illustrates how you might invoke the unit tests when perfo
 In the above snippet, ``<build-dir>`` should be replaced with your chosen build-directory's name (see the section on :ref:`CMake builds <cmake_build>` for more info); a common choice might be ``build``.
 Let's quickly talk through the commands:
 
-  - First, we configure the build.
-    You can add :ref:`other configuration options <available_cmake_options>` (e.g. ``GNinja``, ``GRACKLE_USE_OPENMP``, ``BUILD_SHARED_LIBS``, ``CMAKE_BUILD_TYPE``, etc.)
-  - Next, we invoke the build
-  - The final 2 commands move into the build-directory and invoke the tests from there (the ``--output-on-failure`` flag is completely optional).
-    Starting in CMake 3.20 these 2 commands can be replaced with ``cmake --output-on-failure --test-dir <build-dir>``
+- First, we configure the build.
+  You can add :ref:`other configuration options <available_cmake_options>` (e.g. ``GNinja``, ``GRACKLE_USE_OPENMP``, ``BUILD_SHARED_LIBS``, ``CMAKE_BUILD_TYPE``, etc.)
+- Next, we invoke the build
+- The final 2 commands move into the build-directory and invoke the tests from there (the ``--output-on-failure`` flag is completely optional).
+  Starting in CMake 3.20 these 2 commands can be replaced with ``cmake --output-on-failure --test-dir <build-dir>``
 
 When you launch the tests, the output will look like the following:
 
@@ -107,16 +107,16 @@ As already noted, the pygrackle suite includes unit tests and answer tests.
 Unit tests (i.e., those with explicitly known correct answers) include
 the following:
 
- - correct library versioning
+- correct library versioning
 
- - correct behavior of the dynamic API
+- correct behavior of the dynamic API
 
- - proper and comoving unit systems are consistent
+- proper and comoving unit systems are consistent
 
- - mean molecular weight increases with metallicity
+- mean molecular weight increases with metallicity
 
- - atomic, primordial collisional ionization equilibrium agrees with
-   the analytical solution
+- atomic, primordial collisional ionization equilibrium agrees with
+  the analytical solution
 
 Answer tests are those whose correct answers must be generated from a
 prior, trusted version of Grackle (i.e., the "gold standard"). The
@@ -125,11 +125,11 @@ results (in *store-mode*), then run again on the latest version to
 compare (in *compare-mode*).
 These tests include:
 
- - all python examples run and give correct results for a range of
-   parameter values
+- all python examples run and give correct results for a range of
+  parameter values
 
- - all grackle 'calculate' functions return correct results for sets
-   of random field values
+- all grackle 'calculate' functions return correct results for sets
+  of random field values
 
 We refer to the location where the results of answer-tests are stored as the "answer-directory." This is an arbitrary user-specified location.
 
@@ -138,21 +138,21 @@ Quick Primer on the Test Runner's CLI
 
 By default, the pytest test-runner always runs all available test cases.
 
- - The suite's unit tests are **ALWAYS** available.
+- The suite's unit tests are **ALWAYS** available.
 
- - By default, **all** answer-tests are fully disabled.
-   These tests are made available, in *store-mode* or *compare-mode*, when the :option:`--answer-dir` command-line option is provided.
-   The :option:`--answer-store` command line flag enables *store-mode*, while its absence enables *compare-mode*.
+- By default, **all** answer-tests are fully disabled.
+  These tests are made available, in *store-mode* or *compare-mode*, when the :option:`--answer-dir` command-line option is provided.
+  The :option:`--answer-store` command line flag enables *store-mode*, while its absence enables *compare-mode*.
 
-   .. option:: --answer-dir=<PATH>
+  .. option:: --answer-dir=<PATH>
 
-      Specifies the path to the "answer-directory".
-      This is the custom user-specified directory where answer-tests are stored (in *store-mode*) or read from (in *compare-mode*).
+     Specifies the path to the "answer-directory".
+     This is the custom user-specified directory where answer-tests are stored (in *store-mode*) or read from (in *compare-mode*).
 
-   .. option:: --answer-store
+  .. option:: --answer-store
 
-      The presence of this flag enables *store-mode*, where answer-tests results are stored to the answer-directory (any previously recorded answers will be overwritten).
-      When :option:`--answer-dir` is specified and this flag is omitted, *compare-mode* is enabled.
+     The presence of this flag enables *store-mode*, where answer-tests results are stored to the answer-directory (any previously recorded answers will be overwritten).
+     When :option:`--answer-dir` is specified and this flag is omitted, *compare-mode* is enabled.
 
 *For contributors:* you may find pytest's `build-in command-line interface <https://docs.pytest.org/en/stable/how-to/usage.html>`__ useful during debugging (e.g. you can instruct pytest to only run a subset of all available tests).
 

--- a/doc/source/Versioning.rst
+++ b/doc/source/Versioning.rst
@@ -13,8 +13,8 @@ Our general policy to keep Grackle's main branch stable and in working order.
 Periodically, we "release" new versions of Grackle.
 A release serves 2 purposes:
 
-  1. It's way to designate a development milestone (whether it's new functionality, changes in the public API, bugfixes) at a snapshot in the project's development.
-  2. It's a way to announce the latest changes to the library since the last milestone.
+1. It's way to designate a development milestone (whether it's new functionality, changes in the public API, bugfixes) at a snapshot in the project's development.
+2. It's a way to announce the latest changes to the library since the last milestone.
 
 Currently, the repository tracks 2 separate version numbers: the primary version number (used by the documentation and the shared/static library) **and** the pygrackle version number.
 


### PR DESCRIPTION
This is **EXTREMELY** simple: we simply removed spurious indentations from documentation to fix rendering of documentation. <span style="color:red;">Importantly, no text has been edited.</span>

In more detail, the reStructuredText Markup Specification [notes that](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#toc-entry-26) all indented blocks of text (without preceding markup) as quote-blocks. There were many chunks blocks of text that unintentionally met this definition (it is common in lists)

The impetus for this change is our transition to the new "Furo" sphinx-theme since Furo applied special formatting to quote-blocks (the older themes did not do this). The collapsible section illustrates a before-and-after of how this affects rendered text:

<details>

<summary>Before-And-After-Comparison</summary>

# Rendering without modifications:

![image](https://github.com/user-attachments/assets/264eaea5-a835-4587-8301-63738168054e)

# Rendering with modifications:

![image](https://github.com/user-attachments/assets/e36607ab-5b9b-4057-bdec-c61b233f8e28)

</details>

An aside: I think that our more consistent indentation may be beneficial for newer contributors. Way back, when I was first learning to write reStructuredText, I generally got confused about indentation rules because people generally use various inconsistent indentations with lists and such