### PR TITLE
Dependency group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ commands:
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
-            pip install --group dev
+            pip install --group test
+            pip install flake8
 
   lint:
     description: "Lint."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,7 @@ commands:
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
-            pip install --upgrade wheel
-            pip install --upgrade setuptools
-            pip install flake8
+            pip install --group dev
 
   lint:
     description: "Lint."
@@ -108,7 +106,7 @@ commands:
               make install
               cd ../../ # go back to the root level
 
-              PYGRACKLE_LEGACY_LINK=classic pip install -v -e .[dev]
+              PYGRACKLE_LEGACY_LINK=classic pip install -v -e .
             else # this branch builds grackle with cmake
 
               cmake -DGRACKLE_USE_DOUBLE=ON                   \
@@ -118,7 +116,7 @@ commands:
                     -Bbuild
               cmake --build build
               
-              Grackle_DIR=${PWD}/build pip install -v -e .[dev]
+              Grackle_DIR=${PWD}/build pip install -v -e .
             fi
 
   install-standalone-pygrackle:
@@ -133,7 +131,7 @@ commands:
           command: |
             source $HOME/venv/bin/activate
             git checkout << parameters.tag >>
-            pip install -e .[dev]
+            pip install -e .
 
   install-docs-dependencies:
     description: "Install dependencies for docs build."
@@ -144,9 +142,7 @@ commands:
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
-            pip install --upgrade wheel
-            pip install --upgrade setuptools
-            pip install sphinx --requirement doc/source/requirements.txt
+            pip install --group docs
 
   download-test-data:
     description: "Download test data."
@@ -216,7 +212,7 @@ commands:
             source $HOME/venv/bin/activate
             pip uninstall --yes pygrackle # it's ok if pygrackle wasn't installed yet
             git checkout << parameters.gold-standard-tag >>
-            pip install -e .[dev]
+            pip install -e .
       - run-pygrackle-tests:
           omp: 'false'
           build_kind: 'standalone-pygrackle'
@@ -276,7 +272,7 @@ jobs:
           command: |
             source $HOME/venv/bin/activate
             git checkout $CIRCLE_BRANCH
-            pip install -e .[dev]
+            pip install -e .
       - run-pygrackle-tests:
           omp: 'false'
           build_kind: 'standalone-pygrackle'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
     # our scripts).
     executor:
       name: python
-      tag: 3.8.14
+      tag: 3.9.22
       resource_class: medium  # <- 2 cores
 
     working_directory: ~/grackle
@@ -362,15 +362,15 @@ workflows:
    tests:
      jobs:
        - test-suite:
-           name: "Pygrackle test suite - Python 3.8"
-           tag: "3.8.14"
+           name: "Pygrackle test suite - Python 3.9"
+           tag: "3.9.22"
 
        - corelib-tests:
            name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.8.14"
+           tag: "3.9.22"
 
    weekly:
      triggers:
@@ -382,12 +382,12 @@ workflows:
                 - main
      jobs:
        - test-suite:
-           name: "Pygrackle test suite - Python 3.8"
-           tag: "3.8.14"
+           name: "Pygrackle test suite - Python 3.9"
+           tag: "3.9.22"
 
        - corelib-tests:
            name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.8.14"
+           tag: "3.9.22"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,12 +298,11 @@ jobs:
           command: source $BASH_ENV && source $HOME/venv/bin/activate && py.test
 
   corelib-tests:
-    # we're only using a python docker-image out of convenience (We only care
-    # that a version of python exists with a version of 3.7 or newer to run
-    # our scripts).
     executor:
       name: python
-      tag: 3.9.22
+      tag: 3.7.17  # we are explicitly using an older python version here, to
+                   # make sure that any python scripts used in compiling the
+                   # core-library maintain backwards compatability
       resource_class: medium  # <- 2 cores
 
     working_directory: ~/grackle
@@ -362,15 +361,15 @@ workflows:
    tests:
      jobs:
        - test-suite:
-           name: "Pygrackle test suite - Python 3.9"
-           tag: "3.9.22"
+           name: "Pygrackle test suite - Python 3.10"
+           tag: "3.10.3"
 
        - corelib-tests:
            name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.9.22"
+           tag: "3.10.3"
 
    weekly:
      triggers:
@@ -382,12 +381,12 @@ workflows:
                 - main
      jobs:
        - test-suite:
-           name: "Pygrackle test suite - Python 3.9"
-           tag: "3.9.22"
+           name: "Pygrackle test suite - Python 3.10"
+           tag: "3.10.3"
 
        - corelib-tests:
            name: "Core library test suite"
 
        - docs-build:
            name: "Docs build"
-           tag: "3.9.22"
+           tag: "3.10.3"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
   jobs:
     install:
       - pip install --group 'docs'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@ build:
     python: "3.13"
   jobs:
     install:
+      - pwd
+      - pip --version
       - pip install --group 'docs'
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,11 +3,10 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.11"
   jobs:
     install:
-      - pwd
-      - pip --version
+      - python -m pip install --upgrade pip
       - pip install --group 'docs'
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,13 +1,12 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
-
-python:
-   install:
-   - requirements: doc/source/requirements.txt
+  jobs:
+    install:
+      - pip install --group 'docs'
 
 sphinx:
   # Path to your Sphinx configuration file.

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -167,7 +167,7 @@ The above snippet, includes the optional ``-e`` flag to perform an editable-inst
 
 .. tip::
 
-   The high level interface of the ``uv python package manager <https://docs.astral.sh/uv/>``__ automatically installs the "dev" dependency-group when you install Pygrackle from source.
+   The high level interface of the `uv python package manager <https://docs.astral.sh/uv/>`__ automatically installs the "dev" dependency-group when you install Pygrackle from source.
 
 .. note::
 

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -169,12 +169,6 @@ The above snippet, includes the optional ``-e`` flag to perform an editable-inst
 
    The high level interface of the `uv python package manager <https://docs.astral.sh/uv/>`__ automatically installs the "dev" dependency-group when you install Pygrackle from source.
 
-.. note::
-
-   At one point, over the course of a few months, the documentation indicated that you should install development dependencies with commands like ``pip install -e '.[dev]``.
-   That will no longer work (those commands relied on separate machinery for "extrathat wasn't as well-suited to this task).
-
-
 Running the Example Scripts
 ---------------------------
 

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -4,30 +4,20 @@ Pygrackle: Running Grackle in Python
 ====================================
 
 Grackle comes with a Python interface, called Pygrackle, which provides
-access to all of Grackle's functionality.  Pygrackle requires the following
-Python packages:
+access to all of Grackle's functionality.
 
-- `Cython <https://cython.org/>`__
+To install Pygackle, you'll need to make sure that HDF5 and a fortran compiler are installed (for building the Grackle library itself).
 
-- flake8 (only required for the test suite)
+Pygrackle's runtime-dependencies are:
 
 - `h5py <https://www.h5py.org/>`__
-
 - `matplotlib <https://matplotlib.org/>`__
-
 - `NumPy <https://www.numpy.org/>`__
-
-- packaging (only required for the test suite)
-
-- py.test (only required for the test suite)
-
 - `yt <https://yt-project.org/>`__
 
-The easiest thing to do is follow the instructions for installing yt,
-which will provide you with Cython, matplotlib, and NumPy.  Flake8 and
-py.test can then be installed via pip.
+The above dependencies are automatically installed with pip (alternatively you can follow instructions for installing yt).
 
-You also need to have a fortran compiler installed (for building the Grackle library itself).
+If you want to run the pygrackle test-suite, you'll need the ``packaging`` and ``py.test`` packages. If pip is up to date (25.1 or newer), you can simply invoke ``pip install --group dev`` from the root of the repository.
 
 .. _install-pygrackle:
 
@@ -156,23 +146,33 @@ If this command executes without raising any errors, then you have successfully 
 Installing Pygrackle Development Requirements
 +++++++++++++++++++++++++++++++++++++++++++++
 
-There are a handful of additional packages required for developing
+There are a handful of additional packages required purely for developing
 Grackle. For example, these will enable :ref:`testing` and building
-the documentation locally. To install the development dependencies,
-repeat the last line of the :ref:`pygrackle installation instructions
-<install-pygrackle>` with ``[dev]`` appended.
+the documentation locally. These depdendencies are specified as dependency
+groups, which can be installed with pip (v25.1).
+To install all of these dependencies, you can invoke
 
 .. code-block:: shell-session
 
-   ~/grackle $ pip install -e .[dev]
+   ~/grackle $ pip install --group dev
 
-
-If you use ``zsh`` as your shell, you will need quotes around
-'.[dev]'.
+The above command will install the dependencies independently of Pygrackle.
+To install these dependencies at the same time as Pygrackle, you can replace last line of the :ref:`pygrackle installation instructions <install-pygrackle>` with:
 
 .. code-block:: shell-session
 
-   ~/grackle $ pip install -e '.[dev]'
+   ~/grackle $ pip install --group=dev -e .
+
+The above snippet, includes the optional ``-e`` flag to perform an editable-install, which is necessary to run most tests.
+
+.. tip::
+
+   The high level interface of the ``uv python package manager <https://docs.astral.sh/uv/>``__ automatically installs the "dev" dependency-group when you install Pygrackle from source.
+
+.. note::
+
+   At one point, over the course of a few months, the documentation indicated that you should install development dependencies with commands like ``pip install -e '.[dev]``.
+   That will no longer work (those commands relied on separate machinery for "extrathat wasn't as well-suited to this task).
 
 
 Running the Example Scripts

--- a/doc/source/Python.rst
+++ b/doc/source/Python.rst
@@ -148,7 +148,7 @@ Installing Pygrackle Development Requirements
 
 There are a handful of additional packages required purely for developing
 Grackle. For example, these will enable :ref:`testing` and building
-the documentation locally. These depdendencies are specified as dependency
+the documentation locally. These dependencies are specified as dependency
 groups, which can be installed with pip (v25.1).
 To install all of these dependencies, you can invoke
 

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,2 +1,0 @@
-sphinx-tabs
-furo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,16 +63,10 @@ Documentation = 'https://grackle.readthedocs.io/'
 Source = 'https://github.com/grackle-project/grackle'
 Tracker = 'https://github.com/grackle-project/grackle/issues'
 
-[project.optional-dependencies]
-dev = [
-  'flake8',
-  'packaging',
-  'pytest',
-  'sphinx',
-  'sphinx-tabs',
-  'furo',
-]
-
+[dependency-groups]
+docs = ['sphinx', 'sphinx-tabs', 'furo']
+test = ['pytest', 'packaging']
+dev = ['flake8', {include-group = 'test'}]
 
 [tool.pytest.ini_options]
 # settings inspired by: learn.scientific-python.org/development/guides/pytest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ Tracker = 'https://github.com/grackle-project/grackle/issues'
 [dependency-groups]
 docs = ['sphinx', 'sphinx-tabs', 'furo']
 test = ['pytest', 'packaging']
-dev = ['flake8', {include-group = 'test'}]
+dev = ['flake8', {include-group = "docs"}, {include-group = 'test'}]
 
 [tool.pytest.ini_options]
 # settings inspired by: learn.scientific-python.org/development/guides/pytest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ Documentation = 'https://grackle.readthedocs.io/'
 Source = 'https://github.com/grackle-project/grackle'
 Tracker = 'https://github.com/grackle-project/grackle/issues'
 
+[project.optional-dependencies]
+# currently the next line duplicates the dependency-groups purely for
+# historical reasons. We should delete the following entry in the near-future
+# (since they are actually dependencies of the pygrackle-wheel).
+dev = ['flake8', 'packaging', 'pytest', 'sphinx', 'sphinx-tabs', 'furo']
+
 [dependency-groups]
 docs = ['sphinx', 'sphinx-tabs', 'furo']
 test = ['pytest', 'packaging']


### PR DESCRIPTION
This adjusts the machinery for installing development dependencies. (it supersedes #301). This does **not** need a gold-standard update.

# Overview

Previously, we were specifying the development dependencies as optional-dependencies (commonly called "extras"). "Extras" are fundamentally intended to specify optional runtime dependencies of a python package (e.g. the way that installing `h5py` "unlocks" extra functionality in `yt`). While this has historically been a common way to do things, it had fundamental flaws:
1. You can't actually install these dependencies without installing the package itself. This is a minor inconvenience in 2 scenarios:
   - there are times, especially with documentation/linters/type-checking where you want dev dependencies without installing the package itself
   - if you've already installed the package without the dev-dependencies, you effectively need to reinstall the package to get the dev-dependencies.
2. These dependencies probably shouldn't be visible when people (can eventually) directly install precompiled wheels from PyPI (i.e. the dev-dependencies are fundamentally useless unless you have the source files).

Historically, people have used requirements.txt files to work around these flaws, but those aren't formally standardized and aren't composable)

This PR transitions us to using the relatively new dependency-group machinery which was officially designed for this purpose:
- they don't have either of the above flaws.
- because the dependencies can be installed without pygrackle, itself, we can eliminate the requirements.txt file used to specify our documentation requirements

Lots of tooling has built-in support for dependency groups, like [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) and the popular [uv python package manager](https://docs.astral.sh/uv/)[^1]

# Concrete Impacts
To install the dev dependencies without pygrackle, invoke the following from the root of the grackle directory (requires v25.1+ of pip)
```sh
pip install --group dev
```
To install the dev dependencies with pygrackle at the same time, you can use
```sh
pip install --group dev [OTHER-OPTIONS] .
```

# Other thoughts

Note: I had to bump the python version used in CI for building the answer-tests and installing pygrackle from 3.8 to 3.10.3, `yt`'s minimum supported version (we needed to update from 3.8 to at least 3.9 in order to install version 25.1 of pip)

I think that there's some value to transitioning from the "extras" approach to this new system sooner rather than later, since this new system is going to be the "right way" going forward. I've highlighted some of my conflicting thoughts about dropping support for the "extras" approach in a comment down below.

For this reason and to make `uv` work better (as well as a few other reasons), I would like to see this merged in the main branch.

[^1]: I've recently started using `uv` (which is **VERY COOL**) and it's how I learned about dependency-groups. The use of dependency groups makes `uv` work a lot more nicely "out-of-the-box"