### PR TITLE
Introduce an extremely simplistic `.pre-commit-config.yaml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# This is a placeholder file. The plan is to introduce pre-commit and
+# pre-commit.ci into the newchem-cpp development branch. This file exists to
+# prevent the pre-commit.ci service from reporting errors on the main branch
+# (or for PRs into the main branch) because pre-commit.ci is unable to find
+# a .pre-commit-config.yaml file.
+#
+# Right now, this enables some extremely simplistic checks.
+
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+
+# there are some other useful hooks we could enable from here in the future
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-executables-have-shebangs
+  - id: check-case-conflict # make sure no filenames would conflict on
+                            # case-insensitive filesystems
+  # these hooks check that .json, .toml, .yaml files have valid syntax
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml


### PR DESCRIPTION
This commit merges an extremely simplistic `.pre-commit-config.yaml` file that applies some extremely simplistic checks. The intention to merge this commit into the main branch while we configure pre-commit to run code formatting/linting in the newchem-cpp branch. PR #287 (where we start configuring pre-commit to run formatting/linting) is configured so all changes build off this commit (in other words, there won't be any merge conflicts when we ultimately merge newchem-cpp into main).

If we don't merge a .pre-commit-config.yaml file into the main branch, then pre-commit.ci will report a failure (since it can't find a .pre-commit-config.yaml file)

In slightly more detail, the file configures pre-commit to check that
- executable files have shebangs
- filenames won't cause issues on case-insensitive file systems (e.g. some file systems can't differentiate myfile.c and MyFile.c)
- our .toml, .json, .yaml files all use valid syntax