### PR TITLE
fixing a bug in pyproject.toml that arose because PRs #320 and #350 introduced conflicting changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,6 @@ dependencies = [
   'yt>=4.0.2'
 ]
 
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
 [project.license]
 text = "BSD 3-Clause"
 


### PR DESCRIPTION
This is really minor... Basically both PRs added a field to pyproject.toml that mentioning the README, but they did it in entirely different ways. As a result, we were effectively defining the location of the README twice (which pip does **NOT** like)