### PR TITLE
first attempt at codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@5.4.3
 
 commands:
   set-env:
@@ -305,6 +307,7 @@ jobs:
     steps:
       - checkout
       - install-cmake-dependencies
+      - run: sudo apt-get install lcov
       - run:
           name: "update CMake to newer version"
           command: |
@@ -316,11 +319,17 @@ jobs:
       - run:
           name: "Build libgrackle and all of the core library's tests"
           command: |
-            cmake --preset ci-linux
-            cmake --build build_ci-linux
+            cmake --preset ci-linux-coverage
+            cmake --build build_ci-linux-coverage
       - run:
           name: "Run the suite of tests that operate directly on the core-library."
-          command: ctest --test-dir build_ci-linux --output-on-failure
+          command: ctest --test-dir build_ci-linux-coverage --output-on-failure
+      - run:
+          name: "Generate a coverage report"
+          command: lcov --capture --directory build_ci-linux-coverage --output-file coverage.info
+      - codecov/upload:
+          disable_search: true
+          files: coverage.info
       - run:
           name: "Build libgrackle with OpenMP enabled"
           command: |

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,13 @@ if (GRACKLE_EXAMPLES)
   add_subdirectory(src/example)
 endif()
 
+if (_GRACKLE_CODE_COVERAGE)
+  # in the future, we may want to add CODE_COVERAGE or GRACKLE_CODE_COVERAGE
+  # as an option. For now, we don't want to do that
+  include(Coverage)
+  target_add_coverage_flags(Grackle_Grackle)
+endif()
+
 # Tests
 # -----
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,6 +61,15 @@
           "cacheVariables": { "CMAKE_BUILD_TYPE": "RELEASE" }
       },
       {
+          "name": "ci-linux-coverage",
+          "description": "an experimental preset for code-coverage",
+          "inherits": ["ci-flags-warnings-gcc-clang", "ci-common-config"],
+          "cacheVariables": {
+	    "CMAKE_BUILD_TYPE": "DEBUG",
+	    "_GRACKLE_CODE_COVERAGE": "ON"
+	  }
+      },
+      {
           "name": "ci-linux-omp",
           "description": "a preset for linux with OpenMP",
           "inherits": ["ci-flags-warnings-gcc-clang", "ci-omp-config"],

--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -1,0 +1,52 @@
+# this files includes some basic machinery for enabling code-coverage
+#
+# there is no standard way to do this. Examples include:
+# - CMake Scripts (https://git.stabletec.com/other/cmake-scripts) -- this is
+#   used by hdf5
+# - parthenon-hpc (https://github.com/parthenon-hpc-lab/parthenon/blob/develop/cmake/CodeCov.cmake)
+# - Professional CMake by Craig Scott (a CMake maintainer) suggests creating a
+#   custom build-type (alongside the standard choices Debug, Release, ...)
+
+function(target_add_coverage_flags targetName)
+  # it would probably be simpler to create a custom build-type, but I don't
+  # know how easy it will be disentangle CMake stuff
+
+  if ((NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID) OR
+      (NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILER_ID))
+    # it *might* be okay, but we'll need to confirm that
+    message(
+      WARNING "code-coverage instrumentation may not work properly if you're "
+      "using compilers from different vendors. CC: ${CMAKE_C_COMPILER_ID}, "
+      "CXX: ${CMAKE_CXX_COMPILER_ID}, FC: ${CMAKE_Fortran_COMPILER_ID"
+    )
+  endif()
+
+  get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if (${isMultiConfig} OR NOT CMAKE_BUILD_TYPE MATCHES "[Dd][Ee][Bb][Uu][Gg]")
+    message(
+      WARNING "code-coverage information may not be meaningful if not using a "
+              "\"Debug\" build-type"
+    )
+  endif()
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(${targetName} PRIVATE
+      "--coverage" "-fprofile-abs-path"
+    )
+  elseif (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang|IntelLLVM")
+    target_compile_options(${targetName} PRIVATE "--coverage" )
+  else()
+    message(
+      FATAL_ERROR "Don't know coverage flags for ${CMAKE_CXX_COMPILER_ID}"
+    )
+  endif()
+
+  get_target_property(targetType ${targetName} TYPE)
+  if (targetType MATCHES "STATIC_LIBRARY|OBJECT_LIBRARY|INTERFACE_LIBRARY")
+    set(linker_scope INTERFACE)
+  else()
+    set(linker_scope PRIVATE)
+  endif()
+  target_link_options(${targetName} ${linker_scope} "--coverage")
+
+endfunction()


### PR DESCRIPTION
This is a first attempt at using CodeCov.

Right now, we are only looking at code-coverage from running the core-lib test-suite. We could also potentially get code-coverage from the unit-tests in the pygrackle suite (I suspect that getting C/C++/Fortran coverage from the answer-tests will  slow things down quite a bit).

We can also collect pygrackle coverage (but haven't tried that yet).

I think we're ultimately going to want to use the "Component" functionality to differentiate between coverage of the core library and coverage of pygrackle. But that's something for the future