### PR TITLE
address a bug calc_temp_cloudy_g.F

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-v3"
+        default: "gold-standard-v4"
     steps:
       - run:
           name: "Build Pygrackle from Gold-Standard Commit (<< parameters.gold-standard-tag >>)"

--- a/src/clib/calc_temp_cloudy_g.F
+++ b/src/clib/calc_temp_cloudy_g.F
@@ -147,7 +147,12 @@
          do i = is+1, ie+1
             itmask(i) = .true.
 
-            rhoH(i) = fh * d(i,j,k)
+            if (imetal .eq. 1) then
+               rhoH(i) = fh * (d(i,j,k) - metal(i,j,k))
+            else
+               rhoH(i) = fh * d(i,j,k)
+            endif
+
          enddo
 
 !     Calculate temperature and mean molecular weight

--- a/src/python/tests/test_get_grackle_version.py
+++ b/src/python/tests/test_get_grackle_version.py
@@ -32,16 +32,13 @@ def query_grackle_version_props():
         return _rslt.stdout.decode().rstrip()
 
     # get the name of the most recent tag preceeding this commit:
-    most_recent_tag = _run(["git", "describe", "--abbrev=0", "--tags"])
-    if most_recent_tag.startswith("grackle-"):
-        latest_tagged_version = most_recent_tag[8:]
-    elif most_recent_tag.startswith("gold-standard-v"):
-        latest_tagged_version = most_recent_tag[15:]
-    else:
-        raise RuntimeError(
-            "expected the most recent git-tag to start with "
-            "'grackle-' or 'gold-standard-v'"
-        )
+    prefix = "grackle-"
+    descr_args = ["git", "describe", "--abbrev=0", "--tags", "--match", (prefix + "*")]
+    try:
+        most_recent_tag = _run(descr_args)
+    except subprocess.CalledProcessError:
+        pytest.skip("could not find git-tag that starts with {prefix!r}")
+    latest_tagged_version = most_recent_tag[len(prefix) :]
 
     # get the actual revision when most_recent tag was introduced
     revision_of_tag = _run(["git", "rev-parse", "-n", "1", most_recent_tag])


### PR DESCRIPTION
Fixes #366. This change requires a gold-standard bump.

EDIT: There was a minor bug with the way that **test_get_grackle_version.py** handled tags starting with `gold-standard-v*`. I back-ported a fix that I had previously applied to the `newchem-cpp` branch.

EDIT2: I had to reorder commits (and alter the commit associated with the "gold-standard-v4") so that the fix to **test_get_grackle_version.py** is actually present when we check out "gold-standard-v4"