### PR TITLE
Address linter warnings in __init__.py

### DIFF
--- a/src/python/pygrackle/__init__.py
+++ b/src/python/pygrackle/__init__.py
@@ -11,24 +11,31 @@
 # software.
 ########################################################################
 
-from .__config__ import \
-    __version__
+from .__config__ import (
+    __version__ as __version__
+)
 
-from .fluid_container import \
-    FluidContainer
+from .fluid_container import (
+    FluidContainer as FluidContainer
+)
 
-from .grackle_wrapper import \
-    chemistry_data
+from .grackle_wrapper import (
+    chemistry_data as chemistry_data
+)
 
-from .utilities.convenience import \
-    setup_fluid_container
+from .utilities.convenience import (
+    setup_fluid_container as setup_fluid_container
+)
 
-from .utilities.evolve import \
-    evolve_constant_density, \
-    evolve_freefall
+from .utilities.evolve import (
+    evolve_constant_density as evolve_constant_density,
+    evolve_freefall as evolve_freefall
+)
 
-from .utilities.units import \
-    set_cosmology_units
+from .utilities.units import (
+    set_cosmology_units as set_cosmology_units
+)
 
-from .yt_fields import \
-    add_grackle_fields
+from .yt_fields import (
+    add_grackle_fields as add_grackle_fields
+)

--- a/src/python/setup.cfg
+++ b/src/python/setup.cfg
@@ -1,4 +1,8 @@
 [flake8]
 max-line-length = 999
-exclude = pygrackle/__init__.py,pygrackle/utilities/testing.py
+exclude = pygrackle/utilities/testing.py
 ignore = E111,E121,E122,E123,E124,E125,E127,E129,E131,E201,E202,E211,E221,E222,E227,E228,E241,E301,E203,E225,E226,E231,E251,E261,E262,E265,E266,E302,E303,E402,E502,E701,E731,W292,W293,W391,W503,W504
+# when we switch to ruff-format (in the newchem-cpp branch) we won't need to
+# ignore F401 (ruff-format provides a nice workaround)
+per-file-ignores =
+    */__init__.py: F401


### PR DESCRIPTION
I slightly tweaked the format of __init__.py so that the F401 linter warning won't be an issue when we shift to using ruff-format (we start using ruff-format in newchem-cpp). I had thought this would also work with the flake8 linter, but I didn't have any luck.

Consequently, I tweaked setup.cfg to have flake8 process **__init__.py** while ignoring F401, rather than ignoring the rule entirely.

@brittonsmith, lmk if you would prefer that I apply this commit to the newchem-cpp branch, directly