### PR TITLE
[newchem-cpp] Remove last references to `Flake8`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,18 +42,7 @@ commands:
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --group test
-            pip install flake8
 
-  lint:
-    description: "Lint."
-    steps:
-      - run:
-          name: "Lint."
-          command: |
-            source $BASH_ENV
-            source $HOME/venv/bin/activate
-            cd src/python
-            flake8 gracklepy examples tests
 
   install-grackle:
     description: "Install the core Grackle Library & Pygrackle."
@@ -281,7 +270,6 @@ jobs:
       - checkout
       - set-env
       - install-dependencies
-      - lint
       - download-test-data
       - store-gracklepy-suite-gold-standard-answers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,12 @@ Tracker = 'https://github.com/grackle-project/grackle/issues'
 # currently the next line duplicates the dependency-groups purely for
 # historical reasons. We should delete the following entry in the near-future
 # (since they are actually dependencies of the gracklepy-wheel).
-dev = ['flake8', 'packaging', 'pytest', 'sphinx', 'sphinx-tabs', 'furo']
+dev = ['packaging', 'pytest', 'sphinx', 'sphinx-tabs', 'furo']
 
 [dependency-groups]
 docs = ['sphinx', 'sphinx-tabs', 'furo']
 test = ['pytest', 'packaging']
-dev = ['flake8', {include-group = "docs"}, {include-group = 'test'}]
+dev = [{include-group = "docs"}, {include-group = 'test'}]
 
 [tool.pytest.ini_options]
 # settings inspired by: learn.scientific-python.org/development/guides/pytest/
@@ -203,12 +203,6 @@ For more context:
 select = ["E4", "E7", "E9", "F"]
 # our ignore-list is based on our old flake8 ignore-list
 ignore = ["E402", "E502", "E701", "E731"]
-
-exclude = [
-    # these are based on flake8's exclude-list
-    "src/python/gracklepy/__init__.py",
-    "src/python/gracklepy/utilities/testing.py",
-]
 
 [tool.ruff.format]
 # This following option adds files to the standard set of ruff-format's

--- a/src/python/setup.cfg
+++ b/src/python/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 999
-ignore = E111,E121,E122,E123,E124,E125,E127,E129,E131,E201,E202,E211,E221,E222,E227,E228,E241,E301,E203,E225,E226,E231,E251,E261,E262,E265,E266,E302,E303,E402,E502,E701,E731,W292,W293,W391,W503,W504
-# when we switch to ruff-format (in the newchem-cpp branch) we won't need to
-# ignore F401 (ruff-format provides a nice workaround)
-per-file-ignores =
-    */__init__.py: F401


### PR DESCRIPTION
There are **NO** prerequisites for reviewing/merging this PR

------------

Background
----------

Previously we had replaced 99% uses of the Flake8 linter with the Ruff linter (not to be confused with the Ruff formatter). We had continued to use the Flake8 linter to deal with the following 2 files:

1. **gracklepy/utilities/testing.py**
2. **gracklepy/__init__.py**

In more detail, we were suppressing certain warnings in these 2 files from Flake8, and transistioning to using the Ruff formatter for these files would involve making a few changes.

More recently PRs #368 and #369 introduced the required changes into the main branch. Now that those changes have been ported to the newchem-cpp branch, we are able to make this change.

What Changed
------------

I essentially changed 3 things:

1. We no longer install and use flake8 in the continuous integration
2. I removed the **setup.cfg** file (it was **only** being used to track flake8 configuration information
3. I needed to tweak **pyproject.toml** to both:
   - stop excluding the **gracklepy/utilities/testing.py** and **gracklepy/__init__.py** files from the linter
   - stop listing flake8 as a development dependency