### PR TITLE
Tweaking wheels.yml for release to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -120,7 +120,7 @@ jobs:
   upload_all:
     name: Publish to PyPI
     needs: [build_wheels, make_sdist]
-    environment: testpypi # CHANGEME to pypi (to start uploading to PyPI)
+    environment: pypi
     permissions:
       id-token: write
       attestations: write
@@ -143,5 +143,3 @@ jobs:
 
       - name: Publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:  # DELETEME (and the next line) to start uploading to PyPI
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
I had forgotten that we needed to do before closing PR #388

Once I realized it, I decided to do one final test-upload to testpypi (I temporarily pushed the `grackle-3.4.1-dev` tag) and while I was at it, I merged in #373 (which bumped the versions of software used in the workflow).

Once the test-upload succeeds, I'll merge in this branch and perform the actual release (and I'll delete the grackle-3.4.1-dev tag)