### PR TITLE
[newchem-cpp] Introduce internal `initialize_*.h` and `auto_general.h` headers

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -92,7 +92,7 @@ add_library(Grackle_Grackle
   index_helper.c
   initialize_chemistry_data.c
   initialize_cloudy_data.c
-  initialize_rates.c
+  initialize_rates.c initialize_rates.h
   initialize_UVbackground_data.c  initialize_UVbackground_data.h
   rate_functions.c
   set_default_chemistry_parameters.c

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(Grackle_Grackle
 
   # auto-generated C source files
   ${CMAKE_CURRENT_BINARY_DIR}/auto_general.c
+  # here is the companion header file (not generated)
+  auto_general.h
 
   # C++ Source (and Private Header Files)
   cool_multi_time_g-cpp.C cool_multi_time_g-cpp.h

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -91,7 +91,7 @@ add_library(Grackle_Grackle
   grackle_units.c
   index_helper.c
   initialize_chemistry_data.c
-  initialize_cloudy_data.c
+  initialize_cloudy_data.c initialize_cloudy_data.h
   initialize_rates.c initialize_rates.h
   initialize_UVbackground_data.c  initialize_UVbackground_data.h
   rate_functions.c

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -93,7 +93,7 @@ add_library(Grackle_Grackle
   initialize_chemistry_data.c
   initialize_cloudy_data.c
   initialize_rates.c
-  initialize_UVbackground_data.c
+  initialize_UVbackground_data.c  initialize_UVbackground_data.h
   rate_functions.c
   set_default_chemistry_parameters.c
   solve_chemistry.c

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -99,8 +99,8 @@ add_library(Grackle_Grackle
   solve_chemistry.c
   status_reporting.c status_reporting.h
   update_UVbackground_rates.c
-  initialize_dust_yields.c
-  initialize_metal_chemistry_rates.c
+  initialize_dust_yields.c initialize_dust_yields.h
+  initialize_metal_chemistry_rates.c initialize_metal_chemistry_rates.h
   rate_utils.c
   utils.c
 

--- a/src/clib/auto_general.c.in
+++ b/src/clib/auto_general.c.in
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "grackle.h"
+#include "auto_general.h"
 
 grackle_version get_grackle_version(void) {
   grackle_version out;

--- a/src/clib/auto_general.h
+++ b/src/clib/auto_general.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the general auto-generated functions
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef AUTO_GENERAL_H
+#define AUTO_GENERAL_H
+
+#include <stdio.h>    // <- declares FILE
+#include "grackle.h"  // <- declares get_grackle_version
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/// writes compilation flags to `fp`
+void auto_show_flags(FILE* fp);
+
+/// writes configuration information to `fp`
+void auto_show_config(FILE* fp);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
+
+#endif /* AUTO_GENERAL_H */

--- a/src/clib/initialize_UVbackground_data.c
+++ b/src/clib/initialize_UVbackground_data.c
@@ -14,11 +14,10 @@
 #include <stdlib.h>
 #include <math.h>
 #include "hdf5.h"
+#include "grackle.h"
 #include "grackle_macros.h"
-#include "grackle_types.h"
-#include "grackle_chemistry_data.h"
 
-extern int grackle_verbose;
+#include "initialize_UVbackground_data.h"
 
 // function prototypes
 int read_dataset(hid_t file_id, char *dset_name, double *buffer);

--- a/src/clib/initialize_UVbackground_data.h
+++ b/src/clib/initialize_UVbackground_data.h
@@ -15,11 +15,19 @@
 
 #include "grackle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /// Initializes an empty UVBtable struct with zeros and NULLs.
 void initialize_empty_UVBtable_struct(UVBtable* table);
 
 /// Initialize UV Background data
 int initialize_UVbackground_data(chemistry_data* my_chemistry,
                                  chemistry_data_storage* my_rates);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
 
 #endif /* INITIALIZE_UVBACKGROUND_DATA_H */

--- a/src/clib/initialize_UVbackground_data.h
+++ b/src/clib/initialize_UVbackground_data.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the function to initialize the UV background data
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef INITIALIZE_UVBACKGROUND_DATA_H
+#define INITIALIZE_UVBACKGROUND_DATA_H
+
+#include "grackle_chemistry_data.h"
+
+/// Initializes an empty UVBtable struct with zeros and NULLs.
+void initialize_empty_UVBtable_struct(UVBtable *table);
+
+/// Initialize UV Background data
+int initialize_UVbackground_data(chemistry_data *my_chemistry,
+                                 chemistry_data_storage *my_rates);
+
+#endif /* INITIALIZE_UVBACKGROUND_DATA_H */

--- a/src/clib/initialize_UVbackground_data.h
+++ b/src/clib/initialize_UVbackground_data.h
@@ -16,10 +16,10 @@
 #include "grackle.h"
 
 /// Initializes an empty UVBtable struct with zeros and NULLs.
-void initialize_empty_UVBtable_struct(UVBtable *table);
+void initialize_empty_UVBtable_struct(UVBtable* table);
 
 /// Initialize UV Background data
-int initialize_UVbackground_data(chemistry_data *my_chemistry,
-                                 chemistry_data_storage *my_rates);
+int initialize_UVbackground_data(chemistry_data* my_chemistry,
+                                 chemistry_data_storage* my_rates);
 
 #endif /* INITIALIZE_UVBACKGROUND_DATA_H */

--- a/src/clib/initialize_UVbackground_data.h
+++ b/src/clib/initialize_UVbackground_data.h
@@ -13,7 +13,7 @@
 #ifndef INITIALIZE_UVBACKGROUND_DATA_H
 #define INITIALIZE_UVBACKGROUND_DATA_H
 
-#include "grackle_chemistry_data.h"
+#include "grackle.h"
 
 /// Initializes an empty UVBtable struct with zeros and NULLs.
 void initialize_empty_UVBtable_struct(UVBtable *table);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -19,6 +19,7 @@
 #include "grackle.h"
 #include "grackle_macros.h"
 #include "interp_table_utils.h" // free_interp_grid_
+#include "initialize_rates.h"
 #include "initialize_UVbackground_data.h"
 #include "phys_constants.h"
 
@@ -44,9 +45,6 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 
 int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 int local_free_dust_yields(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
-
-int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units,
-                double co_length_units, double co_density_units);
 
 static void show_version(FILE *fp)
 {

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -19,7 +19,9 @@
 #include "grackle.h"
 #include "grackle_macros.h"
 #include "interp_table_utils.h" // free_interp_grid_
+#include "initialize_UVbackground_data.h"
 #include "phys_constants.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -40,16 +42,11 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
                            code_units *my_units,
                            int read_data);
 
-int initialize_UVbackground_data(chemistry_data *my_chemistry,
-                                 chemistry_data_storage *my_rates);
-
 int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 int local_free_dust_yields(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
 int initialize_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates, code_units *my_units,
                 double co_length_units, double co_density_units);
-
-void initialize_empty_UVBtable_struct(UVBtable *table);
 
 static void show_version(FILE *fp)
 {

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -19,6 +19,7 @@
 #include "grackle.h"
 #include "grackle_macros.h"
 #include "interp_table_utils.h" // free_interp_grid_
+#include "initialize_cloudy_data.h"
 #include "initialize_rates.h"
 #include "initialize_UVbackground_data.h"
 #include "phys_constants.h"
@@ -36,12 +37,6 @@ void auto_show_config(FILE *fp);
 void auto_show_flags(FILE *fp);
 grackle_version get_grackle_version(void);
 void show_parameters(FILE *fp, chemistry_data *my_chemistry);
-int _free_cloudy_data(cloudy_data *my_cloudy, chemistry_data *my_chemistry, int primordial);
-int initialize_cloudy_data(chemistry_data *my_chemistry,
-                           chemistry_data_storage *my_rates,
-                           cloudy_data *my_cloudy, char *group_name,
-                           code_units *my_units,
-                           int read_data);
 
 int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 int local_free_dust_yields(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -700,8 +700,8 @@ int local_free_chemistry_data(chemistry_data *my_chemistry,
     GRACKLE_FREE(my_rates->grain_growth_rate);
   }
 
-  _free_cloudy_data(&my_rates->cloudy_primordial, my_chemistry, /* primordial */ 1);
-  _free_cloudy_data(&my_rates->cloudy_metal, my_chemistry, /* primordial */ 0);
+  free_cloudy_data(&my_rates->cloudy_primordial, my_chemistry, /* primordial */ 1);
+  free_cloudy_data(&my_rates->cloudy_metal, my_chemistry, /* primordial */ 0);
 
   GRACKLE_FREE(my_rates->UVbackground_table.z);
   GRACKLE_FREE(my_rates->UVbackground_table.k24);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -21,6 +21,8 @@
 #include "auto_general.h"
 #include "interp_table_utils.h" // free_interp_grid_
 #include "initialize_cloudy_data.h"
+#include "initialize_dust_yields.h"
+#include "initialize_metal_chemistry_rates.h"
 #include "initialize_rates.h"
 #include "initialize_UVbackground_data.h"
 #include "phys_constants.h"
@@ -34,9 +36,6 @@
 #endif
 
 void show_parameters(FILE *fp, chemistry_data *my_chemistry);
-
-int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
-int local_free_dust_yields(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
 static void show_version(FILE *fp)
 {

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -18,6 +18,7 @@
 #include <math.h>
 #include "grackle.h"
 #include "grackle_macros.h"
+#include "auto_general.h"
 #include "interp_table_utils.h" // free_interp_grid_
 #include "initialize_cloudy_data.h"
 #include "initialize_rates.h"
@@ -32,10 +33,6 @@
 #error "Sanity check failure: GR_SUCCESS must be consistent with SUCCESS and GR_FAIL must be consistent with FAIL"
 #endif
 
-
-void auto_show_config(FILE *fp);
-void auto_show_flags(FILE *fp);
-grackle_version get_grackle_version(void);
 void show_parameters(FILE *fp, chemistry_data *my_chemistry);
 
 int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);

--- a/src/clib/initialize_chemistry_data.c
+++ b/src/clib/initialize_chemistry_data.c
@@ -18,8 +18,6 @@
 #include <math.h>
 #include "grackle.h"
 #include "grackle_macros.h"
-#include "grackle_types.h"
-#include "grackle_chemistry_data.h"
 #include "interp_table_utils.h" // free_interp_grid_
 #include "phys_constants.h"
 #ifdef _OPENMP
@@ -30,10 +28,6 @@
 #error "Sanity check failure: GR_SUCCESS must be consistent with SUCCESS and GR_FAIL must be consistent with FAIL"
 #endif
 
-extern int grackle_verbose;
-
-extern chemistry_data *grackle_data;
-extern chemistry_data_storage grackle_rates;
 
 void auto_show_config(FILE *fp);
 void auto_show_flags(FILE *fp);
@@ -48,8 +42,6 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
 
 int initialize_UVbackground_data(chemistry_data *my_chemistry,
                                  chemistry_data_storage *my_rates);
-
-int local_free_chemistry_data(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 
 int local_free_metal_chemistry_rates(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);
 int local_free_dust_yields(chemistry_data *my_chemistry, chemistry_data_storage *my_rates);

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -17,12 +17,9 @@
 #include "hdf5.h"
 #include "grackle.h"
 #include "grackle_macros.h"
-#include "grackle_types.h"
-#include "grackle_chemistry_data.h"
+#include "initialize_cloudy_data.h"
 
 #define SMALL_LOG_VALUE -99.0
-
-extern int grackle_verbose;
 
 
 /**
@@ -41,7 +38,7 @@ void initialize_empty_cloudy_data_struct(cloudy_data *my_cloudy)
   my_cloudy->data_size = 0LL;
 }
 
-// Initialize Cloudy cooling data
+// initialize cloudy cooling data
 int initialize_cloudy_data(chemistry_data *my_chemistry,
                            chemistry_data_storage *my_rates,
                            cloudy_data *my_cloudy, char *group_name,

--- a/src/clib/initialize_cloudy_data.c
+++ b/src/clib/initialize_cloudy_data.c
@@ -318,7 +318,7 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
   return SUCCESS;
 }
 
-int _free_cloudy_data(cloudy_data *my_cloudy, chemistry_data *my_chemistry, int primordial) {
+int free_cloudy_data(cloudy_data *my_cloudy, chemistry_data *my_chemistry, int primordial) {
   int i;
 
   for(i = 0; i < my_cloudy->grid_rank; i++) {

--- a/src/clib/initialize_cloudy_data.h
+++ b/src/clib/initialize_cloudy_data.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the function to initialize the cloudy data
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef INITIALIZE_CLOUDY_DATA_H
+#define INITIALIZE_CLOUDY_DATA_H
+
+#include "grackle.h"
+
+///Initializes an empty #cloudy_data struct with zeros and NULLs.
+void initialize_empty_cloudy_data_struct(cloudy_data *my_cloudy);
+
+// initialize cloudy cooling data
+int initialize_cloudy_data(chemistry_data *my_chemistry,
+                           chemistry_data_storage *my_rates,
+                           cloudy_data *my_cloudy, char *group_name,
+                           code_units *my_units, int read_data);
+
+int _free_cloudy_data(cloudy_data *my_cloudy,
+                      chemistry_data *my_chemistry,
+                      int primordial);
+
+#endif /* INITIALIZE_CLOUDY_DATA_H */

--- a/src/clib/initialize_cloudy_data.h
+++ b/src/clib/initialize_cloudy_data.h
@@ -24,8 +24,8 @@ int initialize_cloudy_data(chemistry_data *my_chemistry,
                            cloudy_data *my_cloudy, char *group_name,
                            code_units *my_units, int read_data);
 
-int _free_cloudy_data(cloudy_data *my_cloudy,
-                      chemistry_data *my_chemistry,
-                      int primordial);
+int free_cloudy_data(cloudy_data *my_cloudy,
+                     chemistry_data *my_chemistry,
+                     int primordial);
 
 #endif /* INITIALIZE_CLOUDY_DATA_H */

--- a/src/clib/initialize_cloudy_data.h
+++ b/src/clib/initialize_cloudy_data.h
@@ -15,6 +15,10 @@
 
 #include "grackle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /// Initializes an empty #cloudy_data struct with zeros and NULLs.
 void initialize_empty_cloudy_data_struct(cloudy_data* my_cloudy);
 
@@ -26,5 +30,9 @@ int initialize_cloudy_data(chemistry_data* my_chemistry,
 
 int free_cloudy_data(cloudy_data* my_cloudy, chemistry_data* my_chemistry,
                      int primordial);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
 
 #endif /* INITIALIZE_CLOUDY_DATA_H */

--- a/src/clib/initialize_cloudy_data.h
+++ b/src/clib/initialize_cloudy_data.h
@@ -15,17 +15,16 @@
 
 #include "grackle.h"
 
-///Initializes an empty #cloudy_data struct with zeros and NULLs.
-void initialize_empty_cloudy_data_struct(cloudy_data *my_cloudy);
+/// Initializes an empty #cloudy_data struct with zeros and NULLs.
+void initialize_empty_cloudy_data_struct(cloudy_data* my_cloudy);
 
 // initialize cloudy cooling data
-int initialize_cloudy_data(chemistry_data *my_chemistry,
-                           chemistry_data_storage *my_rates,
-                           cloudy_data *my_cloudy, char *group_name,
-                           code_units *my_units, int read_data);
+int initialize_cloudy_data(chemistry_data* my_chemistry,
+                           chemistry_data_storage* my_rates,
+                           cloudy_data* my_cloudy, char* group_name,
+                           code_units* my_units, int read_data);
 
-int free_cloudy_data(cloudy_data *my_cloudy,
-                     chemistry_data *my_chemistry,
+int free_cloudy_data(cloudy_data* my_cloudy, chemistry_data* my_chemistry,
                      int primordial);
 
 #endif /* INITIALIZE_CLOUDY_DATA_H */

--- a/src/clib/initialize_dust_yields.h
+++ b/src/clib/initialize_dust_yields.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the function to initialize the dust yields
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef INITIALIZE_DUST_YIELDS_H
+#define INITIALIZE_DUST_YIELDS_H
+
+#include "grackle.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+int initialize_dust_yields(chemistry_data* my_chemistry,
+                           chemistry_data_storage* my_rates,
+                           code_units* my_units);
+
+int local_free_dust_yields(chemistry_data* my_chemistry,
+                           chemistry_data_storage* my_rates);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
+
+#endif /* INITIALIZE_DUST_YIELDS_H */

--- a/src/clib/initialize_metal_chemistry_rates.h
+++ b/src/clib/initialize_metal_chemistry_rates.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the function to initialize the metal chemistry rates
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef INITIALIZE_METAL_CHEMISTRY_RATES_H
+#define INITIALIZE_METAL_CHEMISTRY_RATES_H
+
+#include "grackle.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+int initialize_metal_chemistry_rates(chemistry_data* my_chemistry,
+                                     chemistry_data_storage* my_rates,
+                                     code_units* my_units);
+
+int local_free_metal_chemistry_rates(chemistry_data* my_chemistry,
+                                     chemistry_data_storage* my_rates);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
+
+#endif /* INITIALIZE_METAL_CHEMISTRY_RATES_H */

--- a/src/clib/initialize_rates.c
+++ b/src/clib/initialize_rates.c
@@ -86,6 +86,7 @@
 #include "grackle.h"
 #include "grackle_macros.h"
 #include "grackle_rate_functions.h"
+#include "initialize_rates.h"
 #include "phys_constants.h"
 
 int initialize_metal_chemistry_rates(chemistry_data *my_chemistry,

--- a/src/clib/initialize_rates.c
+++ b/src/clib/initialize_rates.c
@@ -86,15 +86,11 @@
 #include "grackle.h"
 #include "grackle_macros.h"
 #include "grackle_rate_functions.h"
+#include "initialize_dust_yields.h"
+#include "initialize_metal_chemistry_rates.h"
 #include "initialize_rates.h"
 #include "phys_constants.h"
 
-int initialize_metal_chemistry_rates(chemistry_data *my_chemistry,
-                                     chemistry_data_storage *my_rates,
-                                     code_units *my_units);
-int initialize_dust_yields(chemistry_data *my_chemistry,
-                           chemistry_data_storage *my_rates,
-                           code_units *my_units);
 
 //Define the type of a scalar rate function.
 typedef double (*scalar_rate_function)(double, chemistry_data*);

--- a/src/clib/initialize_rates.h
+++ b/src/clib/initialize_rates.h
@@ -15,10 +15,8 @@
 
 #include "grackle.h"
 
-int initialize_rates(chemistry_data *my_chemistry,
-                     chemistry_data_storage *my_rates,
-                     code_units *my_units,
-                     double co_length_unit,
-                     double co_density_unit);
+int initialize_rates(chemistry_data* my_chemistry,
+                     chemistry_data_storage* my_rates, code_units* my_units,
+                     double co_length_unit, double co_density_unit);
 
 #endif /* INITIALIZE_RATES_H */

--- a/src/clib/initialize_rates.h
+++ b/src/clib/initialize_rates.h
@@ -15,8 +15,16 @@
 
 #include "grackle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 int initialize_rates(chemistry_data* my_chemistry,
                      chemistry_data_storage* my_rates, code_units* my_units,
                      double co_length_unit, double co_density_unit);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif /* __cplusplus */
 
 #endif /* INITIALIZE_RATES_H */

--- a/src/clib/initialize_rates.h
+++ b/src/clib/initialize_rates.h
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Declares the function to initialize the primordial rates
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef INITIALIZE_RATES_H
+#define INITIALIZE_RATES_H
+
+#include "grackle.h"
+
+int initialize_rates(chemistry_data *my_chemistry,
+                     chemistry_data_storage *my_rates,
+                     code_units *my_units,
+                     double co_length_unit,
+                     double co_density_unit);
+
+#endif /* INITIALIZE_RATES_H */


### PR DESCRIPTION
This can be reviewed at any time (there are no dependencies).

-------------

## Overview

This PR introduces internal header files that holds declarations of various initialization and cleanup routines.

## Motivation

The benefits of this PR are 2-fold:
1. This is considered a better practice than just copying and pasting the forward declarations around. By including the header where we declare the function in the file where we define the function, the compiler is able to ensure that the declaration and definition are compatible, which is especially useful if we need to introduce changes. (We have to manually ensure compatibility if we just copy and paste).
2. This is an important step to converting these files to C++, which is a crucial step on the path to transcribing `lookup_cool_rates1d_g` (strictly speaking, it isn't essential, but will reduce a bunch of work).

If you are not yet sold on the merits of this PR, you can wait to review it until after I have made further progress towards transcribing `lookup_cool_rates1d_g`

## Longer Term

In the longer term, it may be convenient to move the definitions of some functions in **some** of the `initialize_*.c` files into the header to reduce the number of files that we track. Even though the definitions of some of these functions are large, it would be reasonable to declare them as inline functions, since they **only** need to be including in a single source file. We need to defer on doing this until we convert enough of these files to C++ (that will be the next PR in the sequence)