### PR TITLE
test bugfix: use `shutil.move` in test_models.py

### DIFF
--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import shutil
 import sys
 import yt
 
@@ -57,7 +58,14 @@ def test_model(answertestspec, tmp_path, model_name, par_index, input_index):
         answer_path = os.path.join(answertestspec.answer_dir, output_basename)
 
         if answertestspec.generate_answers:
-            os.rename(output_file, answer_path)
+            # use shutil.move over os.rename in case output_file & answer_path
+            # specify locations on different file systems
+            # -> this is common since we using pytest's tmp_path machinery to
+            #    determine output_file. Unless overriden, this use's the
+            #    platform's standard directory for temporary files
+            # -> On some platforms, especially linux, this location is entirely
+            #    stored in RAM
+            shutil.move(output_file, answer_path)
         else:
             assert os.path.exists(answer_path)
 


### PR DESCRIPTION
## Overview

This patch replaces `os.rename` in **test_models.py** with the `shutil.move` function.

## What Changed

This patch addresses a bug that can arise when we run the answer-tests store-mode. Specifically, this bug arises when running the python example scripts (executed by **test_models.py**). These examples always write a temporary file with the result of the calculation. When run in store mode, the testing system moves the temporary file into the answer directory.

Prior to this patch, we used `os.rename` to move the temporary file. Unfortunately, this produces an error when the temporary file and the answer directory are located on separate filesystems. By replacing `os.rename` with `shutil.move` we can eliminate this issue.

## Significance

While the scenario we are addressing may sound somewhat pathological, it's actually fairly common (especially on linux operating systems). In more detail, we are relying upon pytest's `tmp_path` machinery to determine the location for writing the temporary output file. Unless explicitly overridden by the caller of pytest, this the platform's standard directory for temporary files.

On some platforms, especially Linux, this location is entirely stored in a temporary filesystem that is stored in RAM (sometimes it will get flushed to swap space). When that is the case, the gold-standard answer directory is almost always on a separate file system.

As a consequence of all this, I think it's probably important for us to bump the gold-standard version number after we merge this PR so that users don't run into problems if they try to run the answer tests locally. (Plus it would be helpful to merge main into newchem-cpp after we merge this PR)