### PR TITLE
[newchem-cpp] Update to gold standard v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-nccv5"
+        default: "gold-standard-nccv6"
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string


### PR DESCRIPTION
This updates the newchem-cpp gold standard to version 6 after merging PR #405.