### PR TITLE
[newchem-cpp] Shift CI dependency installation logic to `install_dependencies.py`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2.1
 
 commands:
-  set-env:
-    description: "Set environment variables."
+  setup-system-for-pytest:
+    description: "Set up the system for pytest."
     steps:
-      - run:
-          name: "Set environment variables."
-          command: |
+      - run: |
             echo "backend : Agg" > $HOME/matplotlibrc
             echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
             echo 'export YT_DATA_DIR=$HOME/yt_test' >> $BASH_ENV
@@ -17,12 +15,6 @@ commands:
               git fetch --tags https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME
             fi
 
-  install-dependencies:
-    description: "Install dependencies."
-    steps:
-      - run:
-          name: "Install dependencies."
-          command: |
             git submodule update --init --remote
             sudo apt update
             sudo apt install -y libhdf5-serial-dev gfortran ninja-build cmake
@@ -260,8 +252,7 @@ jobs:
 
     steps:
       - checkout
-      - set-env
-      - install-dependencies
+      - setup-system-for-pytest
       - download-test-data
       - store-gracklepy-suite-gold-standard-answers
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,14 +316,11 @@ jobs:
 
     steps:
       - checkout
-      - install-cmake-dependencies
-      - run:
-          name: "update CMake to newer version"
-          command: |
-            sudo apt remove cmake -y
-            sudo apt install python3-pip
-            # this is a hack to install a newer version of CMake (through PyPI)
-            pip3 install cmake
+      # we pin cmake to an arbitrarily new version
+      - run: |
+          sudo ./scripts/ci/install_dependencies.py --color \
+              --preset corelib-tests --preset static-analysis \
+              --software cmake=4.2 --software clang-tidy=20
 
       - run:
           name: "Build libgrackle and all of the core library's tests"
@@ -347,72 +344,6 @@ jobs:
       #    working_directory: build_ci-linux-omp/examples
       #    environment:
       #      OMP_NUM_THREADS: 4
-
-
-      # the following step currently uses the llvm hosted repositories
-      # (described at https://apt.llvm.org/)
-      # -> if the day ever comes where we need to install using a different
-      #    mechanism, we could always install it from the package on PyPI
-      # -> we could also leverage the current installation approach to make
-      #    test-builds with llvm
-      - run:
-          name: "Install clang-tidy"
-          command: |
-            # at the moment, we are trying to keep this synchronized with the
-            # version of clang-format used in pre-commit
-            LLVM_VERSION=20
-
-            # todo: maybe move this logic into a script
-
-            # in general we could replace a lot of the following with with the
-            # script downloaded via `wget https://apt.llvm.org/llvm.sh`
-            # -> it seems like the script may do a lot of extra unnecessary work
-
-            # Step 1: register LLVM's official apt registry
-            # =============================================
-
-            # Step 1a: add the llvm key for authenticating packages
-            GPG_DST=/etc/apt/trusted.gpg.d/apt.llvm.org.asc
-            GPG_SRC_URL="https://apt.llvm.org/llvm-snapshot.gpg.key"
-            wget -qO- "${GPG_SRC_URL}" | sudo tee "${GPG_DST}"
-
-            # Step 1b: lookup the codename of the distribution (e.g. jammy)
-            # -> Debian: only provides VERSION_CODENAME
-            # -> vanilla Ubuntu: UBUNTU_CODENAME & VERSION_CODENAME are same
-            # -> distinction is more important for (some) Ubuntu derivatives
-            source <(grep -F 'UBUNTU_CODENAME' /etc/os-release)
-            CODENAME="${UBUNTU_CODENAME}"
-
-            # step 1c: record the actual source of the package
-            # -> the formula for determining the uri and suite-name is fairly
-            #    consistent unless you are describing Debian Testing or the
-            #    LLVM version under active development
-            uri="http://apt.llvm.org/${CODENAME}/"
-            suite="llvm-toolchain-${CODENAME}-${LLVM_VERSION}"
-            sudo add-apt-repository \
-                --yes \
-                --sourceslist "deb ${uri} ${suite} main"
-
-            # Step 2: actually download clang-tidy
-            # ====================================
-            sudo apt-get update
-            sudo apt-get install -y clang-tidy-${LLVM_VERSION}
-
-            # Step 3: Santity Check and make a symlink
-            # ========================================
-            # The symlink is VERY hacky, but it lets us avoid carrying the
-            # LLVM_VERSION variable between job steps
-            bin_path="/usr/bin/clang-tidy-${LLVM_VERSION}"
-            if [ ! -f ${bin_path} ]; then
-              echo "Our assumptions about where the file is installed is wrong"
-              exit 1
-            elif [ -f /usr/bin/clang-tidy ]; then
-              echo "another version of clang-tidy seems to be installed"
-              exit 1
-            else
-              # this is pretty hacky!
-              sudo ln -s ${bin_path} /usr/bin/clang-tidy
-            fi
 
       - run:
           name: "Run clang-tidy"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,24 +17,15 @@ commands:
               git fetch --tags https://github.com/$CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME
             fi
 
-  install-cmake-dependencies:
-    description: "Install minimal dependencies needed for a CMake build"
+  install-dependencies:
+    description: "Install dependencies."
     steps:
       - run:
-          name: "Install minimal dependencies needed for a CMake build"
+          name: "Install dependencies."
           command: |
             git submodule update --init --remote
             sudo apt update
             sudo apt install -y libhdf5-serial-dev gfortran ninja-build cmake
-
-  install-dependencies:
-    description: "Install dependencies."
-    steps:
-      - install-cmake-dependencies
-      - run:
-          name: "Install all other dependencies."
-          command: |
-            source $BASH_ENV
             # libtool-bin is a requirement of the classic build-system
             # castxml is a requirement of the gracklepy test-suite
             sudo apt install -y libtool-bin castxml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,17 +316,20 @@ jobs:
 
     steps:
       - checkout
-      # we pin cmake to an arbitrarily new version
+      # we pinned cmake to an arbitrarily new version
       - run: |
-          sudo ./scripts/ci/install_dependencies.py --color \
+          git submodule update --init --remote
+          ./scripts/ci/install_dependencies.py --color \
               --preset corelib-tests --preset static-analysis \
-              --software cmake=4.2 --software clang-tidy=20
+              --software cmake=4.2 --software clang-tidy=20 \
+              --manual-install-dir ~/local_deps
 
       - run:
           name: "Build libgrackle and all of the core library's tests"
           command: |
             cmake --preset ci-linux
             cmake --build build_ci-linux
+
       - run:
           name: "Run the suite of tests that operate directly on the core-library."
           command: ctest --test-dir build_ci-linux --output-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ commands:
             sudo apt update
             sudo apt install -y libhdf5-serial-dev gfortran ninja-build cmake
             # libtool-bin is a requirement of the classic build-system
-            # castxml is a requirement of the gracklepy test-suite
-            sudo apt install -y libtool-bin castxml
+            sudo apt install -y libtool-bin
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,9 @@ commands:
             fi
 
             git submodule update --init --remote
-            sudo apt update
-            sudo apt install -y libhdf5-serial-dev gfortran ninja-build cmake
-            # libtool-bin is a requirement of the classic build-system
-            sudo apt install -y libtool-bin
+            ./scripts/ci/install_dependencies.py --color \
+              --preset classic-build --preset cmake-build
+
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ commands:
   setup-system-for-pytest:
     description: "Set up the system for pytest."
     steps:
-      - run: |
+      - run:
+          name: "Setup System"
+          command: |
             echo "backend : Agg" > $HOME/matplotlibrc
             echo 'export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
             echo 'export YT_DATA_DIR=$HOME/yt_test' >> $BASH_ENV

--- a/scripts/ci/common.py
+++ b/scripts/ci/common.py
@@ -100,6 +100,25 @@ class LinuxDistroInfo(NamedTuple):
         return cls(id=id, version_id=data.get("VERSION_ID"), codename=codename)
 
 
+def export_env_var_assignment(assignment_line: str):
+    # if assignment_line specifies VAR="FUN", then this function ensures that
+    # subsequent CI steps will define VAR="RUN"
+    if "CIRCLECI" in os.environ:
+        fname_env_variable = "BASH_ENV"
+    elif "GITHUB_ACTIONS" in os.environ:
+        fname_env_variable = "GITHUB_ENV"
+    else:
+        for name, value in os.environ.items():
+            print(f"{name}={value}")
+        raise RuntimeError("unexpected CI provider")
+
+    assert "\n" not in assignment_line, "sanity check"
+    logger.info(f"append to ${fname_env_variable}: `{assignment_line.rstrip()}`")
+    with open(os.environ[fname_env_variable], "a") as f:
+        f.write(assignment_line)
+        f.write("\n")
+
+
 def _fmt_env_args(
     include_outer_env: bool = True,
     env: Optional[Mapping[str, str]] = None,

--- a/scripts/ci/common.py
+++ b/scripts/ci/common.py
@@ -1,0 +1,248 @@
+"""
+Define some useful tools used by other scripts
+"""
+
+# for portability, we restrict ourselves to built-in modules provided with python 3.6
+import contextlib
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import Container, Dict, IO, Iterator, Mapping, NamedTuple, Optional, Union
+
+if sys.version_info < (3, 6, 1):  # 3.6.0 doesn't support all NamedTuple features
+    raise RuntimeError("python 3.6.1 or newer is required")
+
+logger = logging.getLogger("ci-setup")
+logger.setLevel(logging.DEBUG)
+
+
+def configure_logger(color: bool = False):
+    """
+    Configure the logger for pretty outputs.
+
+    A script should call this once, and only once.
+    """
+    global logger
+
+    color_start = ""
+    color_stop = ""
+    if color:
+        color_start = "\x1b[36;20m"
+        color_stop = "\x1b[0m"
+
+    fmt = f"{color_start}%(name)s{color_stop} > %(message)s"
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(console_handler)
+
+
+class ScriptError(RuntimeError):
+    """
+    Generic error type used for expected failure modes
+
+    Ideally, the error message should give a high-level description that
+    provides the user with enough context to understand the issue without
+    a traceback.
+    """
+
+    pass
+
+
+if sys.version_info < (3, 10):
+
+    def _os_release_lines() -> Iterator[str]:
+        for path in ("/etc/os-release", "/usr/lib/os-release"):
+            with contextlib.suppress(FileNotFoundError):
+                with open(path, "r") as f:
+                    yield from f
+                return  # <- exit immediately
+        raise OSError("unable to find '/etc/os-release' or '/usr/lib/os-release'")
+
+    def freedesktop_os_release() -> Dict[str, str]:
+        # crude backport of platform.freedesktop_os_release (which is based on
+        # https://www.freedesktop.org/software/systemd/man/latest/os-release.html)
+
+        escape_characters = [re.escape("\\"), "'", '"', "`", re.escape("$")]
+        escape_pattern = re.escape("\\") + "[" + "".join(escape_characters) + "]"
+
+        def sanitize_val_str(val):
+            if (val[0] == val[-1]) and val[0] in ("'", '"'):
+                val = val[1:-1]
+            return re.sub(escape_pattern, lambda m: m.group(0)[1], val)
+
+        out = {}
+        for line in _os_release_lines():
+            match = re.match(r"^([a-zA-Z0-9_]+)=(.*)$", line.rstrip())
+            if match is not None:
+                out[match.group(1)] = sanitize_val_str(match.group(2))
+        return out
+
+else:
+    from platform import freedesktop_os_release
+
+
+class LinuxDistroInfo(NamedTuple):
+    id: str
+    version_id: Optional[str]
+    codename: Optional[str]
+
+    @classmethod
+    def infer_from_system(cls):
+        # this will fail for non-linux systems or old/weird linux distributions
+        data = freedesktop_os_release()
+        id = data["ID"]  # <- standard guarantees its always defined (and lowercase)
+        codename = data.get("CODENAME")
+        if codename is None and id == "ubuntu":
+            codename = data.get("UBUNTU_CODENAME")
+        return cls(id=id, version_id=data.get("VERSION_ID"), codename=codename)
+
+
+def _fmt_env_args(
+    include_outer_env: bool = True,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """
+    Format a string representation conveying env variables as concisely as possible
+    """
+    # this assumes that the env-overwrites are short
+    kv_pairs = [] if env is None else (f"{k}={v}" for k, v in env.items())
+    if include_outer_env and env is None:
+        return "<inherit>"
+    elif include_outer_env:
+        return f"<inherit>.update({'; '.join(kv_pairs)})"
+    elif env is None:
+        return "<no-env-vars>"
+    else:
+        return f"{{{'; '.join(kv_pairs)}}}"
+
+
+def _get_subprocess_run_env_kwarg(
+    include_outer_env: bool = True,
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[Dict[str, str]]:
+    """Construct the env kwarg for subprocess.run"""
+    if include_outer_env and env is None:
+        return None  # subprocess simply inherits the environment variables
+    elif include_outer_env:
+        out = os.environ.copy()
+        out.update(env)
+        return out
+    elif env is None:
+        return {}  # subprocess is run with no environment variables
+    else:
+        return env
+
+
+class CmdRslt(NamedTuple):
+    returncode: int  # the exit code
+    stdout: Optional[str]  # the stdout stream (if captured)
+
+
+def exec_cmd(
+    *args: str,
+    log: bool = True,
+    silent: bool = False,
+    cwd: Optional[str] = None,
+    timeout: Optional[float] = None,
+    include_outer_env: bool = True,
+    env: Optional[Mapping[str, str]] = None,
+    stdout: Union[IO[str], int, None] = None,
+    stderr: Union[IO[str], int, None] = None,
+    success_codes: Optional[Container[int]] = (0,),
+    dry_run: bool = False,
+) -> CmdRslt:
+    """Invoke a command
+
+    The interface is loosely inspired by the nox API
+
+    Parameters
+    ----------
+    *args
+        The command and its arguments
+    log : bool, optional
+        When True (the default), log the command.
+    silent : bool
+        Default is ``False``. When ``True``, silences command output and
+        returns the output from this function. This is accomplished by
+        combining stdout & stderr into a single stream.
+    cwd : str, optional
+        Optionally specifies a directory to invoke the command from
+    timeout : float, optional
+        If the timeout expires, the subprocess will be killed and after it
+        is done terminating, an exception is raised
+    include_outer_env: bool
+        When True (the default), the subprocess inherits the environment of
+        the current process
+    env : dict, optional
+        When specified, it's used to specify the subprocess's env variables.
+        When include_outer_env is True, we overwrite variables.
+    stdout
+        Optionally specifies an open file object or a file descriptor where
+        the contents of stdout are written. Incompatible with silent=True
+    stderr
+        Optionally specifies an open file object or a file descriptor where
+        the contents of stderr are written. Incompatible with silent=True
+
+    Returns
+    -------
+    CmdRslt
+        Holds the return code and stdout (if it was captured)
+    """
+    # some argument checking:
+    if len(args) == 0:
+        raise ValueError("args was not specified")
+    elif not isinstance(args[0], str):
+        raise TypeError(f"args[0], {args[0]!r}, isn't a str")
+
+    if log:
+        _msg = " ".join(args)
+        _meta_list = []
+        if cwd is not None:
+            _meta_list.append(f"exec_dir: {cwd}")
+        _env_str = _fmt_env_args(include_outer_env=include_outer_env, env=env)
+        _meta_list.append(f"ENV: {_env_str}")
+        logger.info(f"$ {_msg}; ({'; '.join(_meta_list)})")
+
+    if dry_run:
+        return
+
+    # adjust stdout & stderr if necessary
+    if silent:
+        if stdout is not None:
+            raise ValueError("Can't specify stdout kwarg with silent==True")
+        elif stderr is not None:
+            raise ValueError("Can't specify stderr kwarg with silent==True")
+        # combine stdout and stder into a single stream
+        stdout = subprocess.PIPE
+        stderr = subprocess.STDOUT
+    elif stderr == subprocess.PIPE:
+        raise ValueError("currently no support for stderr=subprocess.PIPE")
+
+    tmp_rslt = subprocess.run(
+        args,
+        cwd=cwd,
+        stdout=stdout,
+        stderr=stderr,
+        env=_get_subprocess_run_env_kwarg(include_outer_env=include_outer_env, env=env),
+        timeout=timeout,
+    )
+    sys.stdout.flush()
+
+    # repackage the result
+    _stdout = tmp_rslt.stdout.decode("utf8") if tmp_rslt.stdout is not None else None
+    rslt = CmdRslt(returncode=tmp_rslt.returncode, stdout=_stdout)
+
+    if (success_codes is not None) and (rslt.returncode not in success_codes):
+        if silent and rslt.stdout:
+            print(rslt.stdout, file=sys.stderr, flush=True)
+        cwd = "./" if cwd is None else cwd
+        raise ScriptError(
+            "subprocess exited with nonzero code\n"
+            f"  command: {' '.join(args)}\n  exec_dir: {cwd!r}\n"
+            f"  env: {_fmt_env_args(include_outer_env=include_outer_env, env=env)}\n"
+            f"  code: {rslt.returncode}\n"
+        )
+    return rslt

--- a/scripts/ci/fetch_test_data.py
+++ b/scripts/ci/fetch_test_data.py
@@ -39,7 +39,7 @@ def _retrieve_url(url, dst, *, silent=False, chunksize=_CHUNKSIZE):
     """Download the datafile from url to dst."""
     req = urllib.request.Request(url)
     with contextlib.ExitStack() as stack:
-        out_file = stack.enter_context(open(dst, "wb"))
+        out_f = dst if hasattr(dst, "write") else stack.enter_context(open(dst, "wb"))
         response = stack.enter_context(urllib.request.urlopen(req))
         total_bytes = int(response.headers.get("Content-Length", -1))
         update_progress = _download_status_updater(total_bytes, silent=silent)
@@ -53,7 +53,7 @@ def _retrieve_url(url, dst, *, silent=False, chunksize=_CHUNKSIZE):
             if not block:
                 break
             downloaded_bytes += len(block)
-            out_file.write(block)
+            out_f.write(block)
 
 
 # duplicates logic in PR #235
@@ -78,7 +78,7 @@ def calc_checksum(fname, *, alg_name, chunksize=_CHUNKSIZE):
 def download_file(url, *, dst=None, dst_dir=None, silent=None, cksum=None):
     """download the file from url to dst"""
 
-    basename = os.path.basename(url if dst is None else dst)
+    basename = os.path.basename(url if dst is None or hasattr(dst, "write") else dst)
     if (dst is not None) and (dst_dir is not None):
         raise ValueError("dst and dst_dir can't both be specified")
     elif dst is None:

--- a/scripts/ci/install_dependencies.py
+++ b/scripts/ci/install_dependencies.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+This program seeks to install continuous integration dependencies.
+
+At the moment, this should work for ubuntu/debian images.
+
+Longer term, the goals are to:
+- unify this logic with the cibw scripts (that means we need to add support for macOS)
+- make it possible to install arbitrary versions of different compiler toolchains
+  and different versions of dependencies. For example, it would be good practice
+  for us to perform a test build with the oldest compatible versions of
+  hdf5/cmake/etc.
+"""
+
+# for portability, we restrict ourselves to built-in modules provided with python 3.6
+
+import argparse
+import functools
+import itertools
+import json
+import os
+import platform
+import re
+import tempfile
+from typing import (
+    Dict,
+    Callable,
+    Collection,
+    IO,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+from fetch_test_data import download_file
+from common import LinuxDistroInfo, ScriptError, configure_logger, exec_cmd, logger
+
+
+class Conf(NamedTuple):
+    manual_install_dir: str
+    dry_run: bool
+    os_str: str
+    distro_info: Optional[LinuxDistroInfo]
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace):
+        os_str = platform.system().lower()
+        distro_info = LinuxDistroInfo.infer_from_system() if os_str == "linux" else None
+        return Conf(
+            manual_install_dir=args.manual_install_dir,
+            dry_run=args.dry_run,
+            os_str=os_str,
+            distro_info=distro_info,
+        )
+
+    def sys_info_str(self) -> str:
+        tmp = f"os={self.os_str}"
+        distro_info = self.distro_info._asdict() if self.distro_info else {}
+        return tmp + "".join(f", {k}={v}" for k, v in distro_info.items())
+
+
+class SymlinkSpec(NamedTuple):
+    src: str
+    dst: str
+
+
+class CodeSourceAPT(NamedTuple):
+    """Encapsulates information for installing a package via APT"""
+
+    pkg_name: str
+    # the following attributes are usually just used with non-default APT repositories
+    setup_fn: Optional[Callable[[Conf], None]] = None
+    symlinks: Optional[List[SymlinkSpec]] = None
+
+
+# The source of each piece of software is associated with either
+#   1. an APT package OR
+#   2. a simple callable function that manually performs the installation itself
+# Given a version string (or `None`) a source factory returns one of the above 2 choices
+SimpleCallable = Callable[[Conf], Optional[List[SymlinkSpec]]]
+SoftwareSource = Union[CodeSourceAPT, SimpleCallable]
+SourceFactory = Callable[[Optional[str]], SoftwareSource]
+
+
+def _search_cksum_file(fp: IO[str], target_fname: str) -> Optional[str]:
+    """
+    Extracts the checksum from a file using the standard format (or returns
+    None if the target_filename can't be found
+    """
+    # for context, each line of such a file holds `<cksum>  <filename>`
+    for line in fp:
+        cksum, fname = line.rstrip().decode("utf-8").split()
+        if fname == target_fname:
+            return cksum
+
+
+def install_cmake(target_version: str, conf: Conf) -> List[SymlinkSpec]:
+    """Download an install a target cmake version"""
+    # It's also easy to build from source, but this is faster
+
+    # extract the prefix of target_version that holds major and minor version numbers
+    m = re.match(r"^(\d+\.\d+).*", target_version)
+    if m is None:
+        raise ScriptError(f"{target_version} is an invalid CMake version")
+    major_minor_version = m.group(1)
+    major, minor = [int(e) for e in major_minor_version.split(".")]
+    if (major, minor) < (3, 20):
+        raise RuntimeError(f"the url pattern isn't handled for {major_minor_version}")
+
+    # set up some basic properties
+    prefix = "https://cmake.org/files"
+    url_dir = f"{prefix}/v{major_minor_version}"
+    outdir = os.path.join(conf.manual_install_dir, f"cmake-{major_minor_version}")
+
+    # if the caller specified "major.minor", let's infer "major.minor.patch"
+    if major_minor_version == target_version:
+        # we are missing a patch version, infer the latest version
+        logger.info(f"inferring newest CMake patch associated with {target_version}")
+        with tempfile.TemporaryFile() as fp:
+            download_file(url=f"{url_dir}/cmake-latest-files-v1.json", dst=fp)
+            fp.seek(0)
+            target_version = json.load(fp)["version"]["string"]
+
+    logger.info(f"prepare to download CMake version: {target_version}")
+
+    # determine the name of the file that will be downloaded
+    if conf.os_str == "darwin":
+        desired = f"cmake-{target_version}-macos-universal.dmg"
+    else:
+        arch = platform.machine()
+        arch = "x86_64"
+        desired = f"cmake-{target_version}-{conf.os_str}-{arch}.tar.gz"
+
+    # determine the sha256 checksum
+    # -> this lets us check for errors in the download
+    # -> this doesn't really add much security (if someone compromises the
+    #    precompiled binary, they probably also compromised the cksum file)
+    logger.info(f"fetching the checksum for {desired}")
+    with tempfile.TemporaryFile() as fp:
+        download_file(url=f"{url_dir}/cmake-{target_version}-SHA-256.txt", dst=fp)
+        fp.seek(0)
+        cksum = _search_cksum_file(fp, target_fname=desired)
+    if cksum is None:
+        raise RuntimeError(f"could not find the checksum for {desired}")
+    elif ":" not in cksum:
+        cksum = "sha256:" + cksum
+
+    # download the full file
+    logger.info(f"downloading {desired}")
+    with tempfile.NamedTemporaryFile() as fp:
+        tmp_path = fp.name
+        download_file(url=f"{url_dir}/{desired}", dst=tmp_path, cksum=cksum)
+        logger.info("unpacking the contents")
+        if not conf.dry_run:
+            if not os.path.isdir(outdir):
+                os.mkdir(outdir)
+            exec_cmd("tar", "-x", "-C", outdir, "-f", tmp_path)
+
+    installed_bin = os.path.join(outdir, "cmake")
+
+    return [
+        SymlinkSpec(installed_bin, f"/usr/bin/cmake-{target_version}"),
+        SymlinkSpec(installed_bin, f"/usr/bin/cmake-{major_minor_version}"),
+        # this last choice is VERY hacky
+        # -> we probably want to something clever with paths instead
+        SymlinkSpec(installed_bin, "/usr/bin/cmake"),
+    ]
+
+
+def get_cmake_source(version: Optional[str]) -> Union[CodeSourceAPT, SimpleCallable]:
+    if version is None:
+        return CodeSourceAPT("cmake")
+    return functools.partial(install_cmake, version)
+
+
+def setup_llvm_repository(conf: Conf, llvm_version: int):
+    """This function registers LLVM's official apt repository"""
+    # this logic is loosely based on the from https://apt.llvm.org/llvm.sh
+
+    _descr = "to register LLVM's official apt repository"
+    if conf.distro_info is None:
+        raise ScriptError("linux distribution info must be known")
+    elif conf.distro_info.id not in ["ubuntu", "debian"]:
+        raise ScriptError(f"{_descr}: only possible on debian/ubuntu")
+    elif conf.distro_info.codename is None:
+        raise ScriptError(f"{_descr}: requires knowledge of the codename")
+
+    logger.info("Fetch and register key for authenticating LLVM's APT repository")
+    gpg_dst = "/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
+    gpg_src_url = "https://apt.llvm.org/llvm-snapshot.gpg.key"
+    if not conf.dry_run:
+        download_file(gpg_src_url, dst=gpg_dst)
+
+    # Part 2: record the actual source of the package
+    # -> the formula for determining the uri and suite-name is fairly
+    #    consistent unless you are describing Debian Testing or the
+    #    LLVM version under active development
+
+    logger.info("Register the appropriate LLVM repository with APT")
+    uri = f"http://apt.llvm.org/{conf.distro_info.codename}/"
+    suite = f"llvm-toolchain-{conf.distro_info.codename}-{llvm_version}"
+    cmd = (  # the last arg is intentionally a single string
+        "add-apt-repository",
+        "--yes",
+        "--sourceslist",
+        f"deb {uri} {suite} main",
+    )
+    exec_cmd("sudo", *cmd, dry_run=conf.dry_run)
+
+
+def get_clang_tidy_source(version: Optional[str]) -> CodeSourceAPT:
+    if version is None:
+        raise ScriptError("you must associate clang-tidy with a version")
+    # the choice to make this symlink is VERY hacky
+    tmp = SymlinkSpec(src=f"/usr/bin/clang-tidy-{version}", dst="/usr/bin/clang-tidy")
+    return CodeSourceAPT(
+        pkg_name=f"clang-tidy-{version}",
+        setup_fn=functools.partial(setup_llvm_repository, llvm_version=version),
+        symlinks=[tmp],
+    )
+
+
+class SimpleSourceFactory(NamedTuple):
+    """Used when APT (with the default repository) is the only way install software"""
+
+    name: str
+    apt_pkg_name: str
+
+    def __call__(self, version: Optional[str]) -> CodeSourceAPT:
+        if version is not None:
+            raise ScriptError(f"{self.name!s} cannot be specified with a version")
+        return CodeSourceAPT(pkg_name=self.apt_pkg_name)
+
+
+_SOFTWARE: Dict[str, SourceFactory] = {
+    "castxml": SimpleSourceFactory(name="castxml", apt_pkg_name="castxml"),
+    "clang-tidy": get_clang_tidy_source,
+    "cmake": get_cmake_source,
+    "hdf5": SimpleSourceFactory(name="hdf5", apt_pkg_name="libhdf5-serial-dev"),
+    "gfortran": SimpleSourceFactory(name="gfortran", apt_pkg_name="gfortran"),
+    "gcc": SimpleSourceFactory(name="gcc", apt_pkg_name="gcc"),
+    "g++": SimpleSourceFactory(name="g++", apt_pkg_name="g++"),
+    "gmake": SimpleSourceFactory(name="gmake", apt_pkg_name="make"),  # <- GNU Make
+    "libtool": SimpleSourceFactory(name="libtool", apt_pkg_name="libtool-bin"),
+    "ninja": SimpleSourceFactory(name="ninja", apt_pkg_name="ninja-build"),
+}
+
+
+# the values are a tuple([<dependent_presets>], [<software>])
+_PRESETS = {
+    "common": ([], ["hdf5", "gfortran", "gcc", "g++"]),
+    "cmake-build": (["common"], ["cmake", "ninja"]),
+    "classic-build": (["common"], ["gmake", "libtool"]),
+    "corelib-tests": (["cmake-build"], ["castxml"]),
+    "static-analysis": (["cmake-build"], ["clang-tidy=20"]),
+}
+_PRESETS["all-presets"] = (list(_PRESETS), [])
+
+
+def software_from_presets(presets: Iterable[str]) -> Iterable[str]:
+    preset_set = set(presets)  # <- avoid mutating args.preset
+    while preset_set:
+        preset_l, software_l = _PRESETS[preset_set.pop()]
+        preset_set.update(preset_l)
+        yield from software_l
+
+
+def _get_name_version(software_str: str) -> Tuple[str, Optional[str]]:
+    count = software_str.count("=")
+    if count == 0:
+        return software_str, None
+    elif count == 1:
+        return software_str.split("=")
+    raise ScriptError(f"{software_str!r} is an invalid string for specifying software")
+
+
+def apt_install(conf: Conf, names: Collection[str]):
+    assert len(names) > 0, "sanity check failed"
+    exec_cmd("sudo", "apt-get", "update", dry_run=conf.dry_run)
+    exec_cmd("sudo", "apt-get", "install", "-y", *sorted(names), dry_run=conf.dry_run)
+
+
+def install_software(software_str_itr: Iterable[str], conf: Conf):
+    """Does all of the heavy-lifting"""
+    # software strings may occur more than once in software_str_itr
+
+    logger.info(f"Sys Info: {conf.sys_info_str()}")
+
+    # fill all_software with name : (version, software_name) entries
+    all_software = {}
+    for software_str in software_str_itr:
+        name, new_v = _get_name_version(software_str)
+        if name not in _SOFTWARE:
+            raise ScriptError(f"{software_str} doesn't specify known software")
+        old_v, _ = all_software.get(name, (None, None))
+        if old_v is not None:
+            logger.warning(f"override {name!r} version: use {new_v} instead of {old_v}")
+        all_software[name] = (new_v, software_str)
+
+    # infer the required steps
+    cmd_list: List[Tuple[str, str, SimpleCallable]] = []
+    apt_packages: Set[str] = set()
+    symlink_sets: List[Tuple[str, List[SymlinkSpec]]] = []
+
+    for name, (version, software_str) in all_software.items():
+        src = _SOFTWARE[name](version=version)
+        if callable(src):
+            cmd_list.append(("manual step", software_str, src))
+        else:
+            assert isinstance(src, CodeSourceAPT)
+            apt_packages.add(src.pkg_name)
+            if src.setup_fn is not None:
+                cmd_list.append(("setup step", software_str, src.setup_fn))
+            if src.symlinks is not None:
+                symlink_sets.append((software_str, src.symlinks))
+
+    if len(apt_packages) > 0:
+        fn = functools.partial(apt_install, names=apt_packages)
+        cmd_list.append(("apt invocations", None, fn))
+
+    n_steps = len(cmd_list) + 1  # add 1 for symlinks
+
+    # actually do the installation
+    for i, (descr, target, cmd) in enumerate(cmd_list, start=1):
+        msg = f"{descr} for {target}" if target is not None else descr
+        logger.info(f"Dependency Install {i}/{n_steps}: {msg}")
+        extra_symlinks = cmd(conf)
+        if extra_symlinks:
+            assert target is not None, "sanity check"
+            symlink_sets.append((target, extra_symlinks))
+
+    logger.info(f"Dependency Install {n_steps}/{n_steps}: Make Symlinks (if needed)")
+    for descr, symlink_set in symlink_sets:
+        for symlink_spec in symlink_set:
+            msg = f"  for {descr}: SRC={symlink_spec.src}, DST={symlink_spec.dst}"
+            logger.info(msg)
+            if not conf.dry_run:
+                os.symlink(symlink_spec.src, symlink_spec.dst)
+
+
+def main(args: argparse.Namespace):
+    configure_logger(color=args.color)
+
+    try:
+        itr_a = [] if args.preset is None else software_from_presets(args.preset)
+        itr_b = [] if args.software is None else args.software
+        install_software(itertools.chain(itr_a, itr_b), Conf.from_args(args))
+
+    except ScriptError as err:
+        # in this case, we handle "expected errors"
+        logger.error(f"ERROR: {err.args[0]}")
+        return 70  # https://www.man7.org/linux/man-pages/man3/sysexits.h.3head.html
+    except BaseException:
+        # here we handle all other exceptions (e.g. programming errors,
+        # KeyboardInterrupt). Generally we want a standard traceback in these cases
+        logger.error("Unexpected error:")
+        raise
+    else:
+        return 0
+
+
+_SHORT_DESCR = "Install dependencies for use in continuous integration."
+parser = argparse.ArgumentParser(description=_SHORT_DESCR, allow_abbrev=False)
+parser.add_argument("--color", action="store_true", help="use color")
+parser.add_argument("--dry-run", action="store_true")
+parser.add_argument(
+    "--software",
+    action="append",
+    help="""
+        Each occurrence adds to the list of software that this tool installs. To specify
+        a particular version, write the value as `<name>=<version>`
+    """,
+)
+parser.add_argument(
+    "--preset",
+    action="append",
+    choices=list(_PRESETS),
+    help="""
+        Each occurrence of this flag appends the associated value to the list of
+        software presets that this tool will install
+    """,
+)
+parser.add_argument(
+    "--manual-install-dir",
+    action="store",
+    default="/opt",
+    help="specifies destination for manually installed dependencies",
+)
+
+if __name__ == "__main__":
+    main(parser.parse_args())

--- a/scripts/ci/install_dependencies.py
+++ b/scripts/ci/install_dependencies.py
@@ -13,7 +13,6 @@ Longer term, the goals are to:
 """
 
 # for portability, we restrict ourselves to built-in modules provided with python 3.6
-
 import argparse
 import functools
 import itertools
@@ -21,6 +20,7 @@ import json
 import os
 import platform
 import re
+import sys
 import tempfile
 from typing import (
     Dict,
@@ -37,7 +37,14 @@ from typing import (
 )
 
 from fetch_test_data import download_file
-from common import LinuxDistroInfo, ScriptError, configure_logger, exec_cmd, logger
+from common import (
+    LinuxDistroInfo,
+    ScriptError,
+    configure_logger,
+    exec_cmd,
+    logger,
+    export_env_var_assignment,
+)
 
 
 class Conf(NamedTuple):
@@ -45,13 +52,14 @@ class Conf(NamedTuple):
     dry_run: bool
     os_str: str
     distro_info: Optional[LinuxDistroInfo]
+    mutate_path: bool = True
 
     @classmethod
     def from_args(cls, args: argparse.Namespace):
         os_str = platform.system().lower()
         distro_info = LinuxDistroInfo.infer_from_system() if os_str == "linux" else None
         return Conf(
-            manual_install_dir=args.manual_install_dir,
+            manual_install_dir=os.path.expanduser(args.manual_install_dir),
             dry_run=args.dry_run,
             os_str=os_str,
             distro_info=distro_info,
@@ -65,25 +73,19 @@ class Conf(NamedTuple):
 
 class SymlinkSpec(NamedTuple):
     src: str
-    dst: str
+    dst_basename: str
 
 
-class CodeSourceAPT(NamedTuple):
-    """Encapsulates information for installing a package via APT"""
+class APTPackage(NamedTuple):
+    name: str
 
-    pkg_name: str
-    # the following attributes are usually just used with non-default APT repositories
+
+class CodeSource(NamedTuple):
+    """Represents the source for a piece of software"""
+
+    source: Union[APTPackage, Callable[[], None]]
     setup_fn: Optional[Callable[[Conf], None]] = None
     symlinks: Optional[List[SymlinkSpec]] = None
-
-
-# The source of each piece of software is associated with either
-#   1. an APT package OR
-#   2. a simple callable function that manually performs the installation itself
-# Given a version string (or `None`) a source factory returns one of the above 2 choices
-SimpleCallable = Callable[[Conf], Optional[List[SymlinkSpec]]]
-SoftwareSource = Union[CodeSourceAPT, SimpleCallable]
-SourceFactory = Callable[[Optional[str]], SoftwareSource]
 
 
 def _search_cksum_file(fp: IO[str], target_fname: str) -> Optional[str]:
@@ -98,83 +100,82 @@ def _search_cksum_file(fp: IO[str], target_fname: str) -> Optional[str]:
             return cksum
 
 
-def install_cmake(target_version: str, conf: Conf) -> List[SymlinkSpec]:
-    """Download an install a target cmake version"""
-    # It's also easy to build from source, but this is faster
-
-    # extract the prefix of target_version that holds major and minor version numbers
-    m = re.match(r"^(\d+\.\d+).*", target_version)
+def _extract_major_minor(version: str) -> Tuple[int, int]:
+    m = re.match(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[^0-9].*)?$", version)
     if m is None:
-        raise ScriptError(f"{target_version} is an invalid CMake version")
-    major_minor_version = m.group(1)
-    major, minor = [int(e) for e in major_minor_version.split(".")]
-    if (major, minor) < (3, 20):
-        raise RuntimeError(f"the url pattern isn't handled for {major_minor_version}")
+        raise ScriptError(f"{version} doesn't have a major and minor version")
+    return tuple(int(e) for e in m.groups())
 
-    # set up some basic properties
-    prefix = "https://cmake.org/files"
-    url_dir = f"{prefix}/v{major_minor_version}"
-    outdir = os.path.join(conf.manual_install_dir, f"cmake-{major_minor_version}")
 
-    # if the caller specified "major.minor", let's infer "major.minor.patch"
-    if major_minor_version == target_version:
-        # we are missing a patch version, infer the latest version
-        logger.info(f"inferring newest CMake patch associated with {target_version}")
-        with tempfile.TemporaryFile() as fp:
-            download_file(url=f"{url_dir}/cmake-latest-files-v1.json", dst=fp)
-            fp.seek(0)
-            target_version = json.load(fp)["version"]["string"]
-
-    logger.info(f"prepare to download CMake version: {target_version}")
-
-    # determine the name of the file that will be downloaded
-    if conf.os_str == "darwin":
-        desired = f"cmake-{target_version}-macos-universal.dmg"
-    else:
-        arch = platform.machine()
-        arch = "x86_64"
-        desired = f"cmake-{target_version}-{conf.os_str}-{arch}.tar.gz"
-
-    # determine the sha256 checksum
-    # -> this lets us check for errors in the download
+def _download_and_install_precompiled(
+    url_prefix: str, cksum_fname: str, desired_fname: str, outdir: str, cksum_kind: str
+):
+    # determine the checksum (to let us check for errors in the download)
     # -> this doesn't really add much security (if someone compromises the
     #    precompiled binary, they probably also compromised the cksum file)
-    logger.info(f"fetching the checksum for {desired}")
+    logger.info(f"fetching the checksum for {desired_fname}")
     with tempfile.TemporaryFile() as fp:
-        download_file(url=f"{url_dir}/cmake-{target_version}-SHA-256.txt", dst=fp)
+        download_file(url=f"{url_prefix}/{cksum_fname}", dst=fp)
         fp.seek(0)
-        cksum = _search_cksum_file(fp, target_fname=desired)
+        cksum = _search_cksum_file(fp, target_fname=desired_fname)
     if cksum is None:
-        raise RuntimeError(f"could not find the checksum for {desired}")
+        raise RuntimeError(f"could not find the checksum for {desired_fname}")
     elif ":" not in cksum:
-        cksum = "sha256:" + cksum
+        cksum = f"{cksum_kind}:{cksum}"
 
     # download the full file
-    logger.info(f"downloading {desired}")
+    logger.info(f"downloading {desired_fname}")
     with tempfile.NamedTemporaryFile() as fp:
         tmp_path = fp.name
-        download_file(url=f"{url_dir}/{desired}", dst=tmp_path, cksum=cksum)
+        download_file(url=f"{url_prefix}/{desired_fname}", dst=tmp_path, cksum=cksum)
         logger.info("unpacking the contents")
-        if not conf.dry_run:
-            if not os.path.isdir(outdir):
-                os.mkdir(outdir)
-            exec_cmd("tar", "-x", "-C", outdir, "-f", tmp_path)
-
-    installed_bin = os.path.join(outdir, "cmake")
-
-    return [
-        SymlinkSpec(installed_bin, f"/usr/bin/cmake-{target_version}"),
-        SymlinkSpec(installed_bin, f"/usr/bin/cmake-{major_minor_version}"),
-        # this last choice is VERY hacky
-        # -> we probably want to something clever with paths instead
-        SymlinkSpec(installed_bin, "/usr/bin/cmake"),
-    ]
+        exec_cmd("tar", "-x", "--strip-components", "1", "-C", outdir, "-f", tmp_path)
 
 
-def get_cmake_source(version: Optional[str]) -> Union[CodeSourceAPT, SimpleCallable]:
+def get_cmake_source(conf: Conf, version: Optional[str]) -> CodeSource:
     if version is None:
-        return CodeSourceAPT("cmake")
-    return functools.partial(install_cmake, version)
+        return CodeSource(source=APTPackage("cmake"))
+    else:
+        # in this case, we try to download a precompiled binary
+        # (building from source is also very easy, but will be slower)
+        try:
+            major, minor = _extract_major_minor(version)
+        except ScriptError:
+            raise ScriptError(f"{version} isn't a valid version for CMake") from None
+        url_prefix = f"https://cmake.org/files/v{major}.{minor}"
+
+        if (major, minor) < (3, 20):
+            raise RuntimeError(f"CMake url pattern isn't handled for {major}.{minor}")
+        elif f"{major}.{minor}" == version:
+            logger.info(f"inferring full CMake version from {version}")
+            with tempfile.TemporaryFile() as fp:
+                download_file(url=f"{url_prefix}/cmake-latest-files-v1.json", dst=fp)
+                fp.seek(0)
+                version = json.load(fp)["version"]["string"]
+
+        outdir = os.path.join(conf.manual_install_dir, f"cmake-{version}")
+
+        def install_cmake():
+            cksum_fname = f"cmake-{version}-SHA-256.txt"
+            if conf.os_str == "darwin":
+                desired = f"cmake-{version}-macos-universal.dmg"
+            else:
+                desired = f"cmake-{version}-{conf.os_str}-{platform.machine()}.tar.gz"
+            if not conf.dry_run:
+                if not os.path.isdir(outdir):
+                    os.mkdir(outdir)
+                _download_and_install_precompiled(
+                    url_prefix, cksum_fname, desired, outdir, cksum_kind="sha256"
+                )
+
+        installed_bin = os.path.join(outdir, "bin", "cmake")
+        return CodeSource(
+            source=install_cmake,
+            symlinks=[
+                SymlinkSpec(src=installed_bin, dst_basename=f"cmake-{version}"),
+                SymlinkSpec(src=installed_bin, dst_basename="cmake"),
+            ],
+        )
 
 
 def setup_llvm_repository(conf: Conf, llvm_version: int):
@@ -183,7 +184,7 @@ def setup_llvm_repository(conf: Conf, llvm_version: int):
 
     _descr = "to register LLVM's official apt repository"
     if conf.distro_info is None:
-        raise ScriptError("linux distribution info must be known")
+        raise ScriptError(f"{_descr}: linux distribution info must be known")
     elif conf.distro_info.id not in ["ubuntu", "debian"]:
         raise ScriptError(f"{_descr}: only possible on debian/ubuntu")
     elif conf.distro_info.codename is None:
@@ -192,8 +193,11 @@ def setup_llvm_repository(conf: Conf, llvm_version: int):
     logger.info("Fetch and register key for authenticating LLVM's APT repository")
     gpg_dst = "/etc/apt/trusted.gpg.d/apt.llvm.org.asc"
     gpg_src_url = "https://apt.llvm.org/llvm-snapshot.gpg.key"
-    if not conf.dry_run:
-        download_file(gpg_src_url, dst=gpg_dst)
+    with tempfile.NamedTemporaryFile() as fp:
+        tmp_path = fp.name
+        download_file(gpg_src_url, dst=tmp_path)
+        exec_cmd("sudo", "cp", tmp_path, gpg_dst, dry_run=conf.dry_run)
+        exec_cmd("sudo", "chmod", "a+r", gpg_dst, dry_run=conf.dry_run)
 
     # Part 2: record the actual source of the package
     # -> the formula for determining the uri and suite-name is fairly
@@ -212,15 +216,17 @@ def setup_llvm_repository(conf: Conf, llvm_version: int):
     exec_cmd("sudo", *cmd, dry_run=conf.dry_run)
 
 
-def get_clang_tidy_source(version: Optional[str]) -> CodeSourceAPT:
+def get_clang_tidy_source(conf: Conf, version: Optional[str]) -> CodeSource:
     if version is None:
         raise ScriptError("you must associate clang-tidy with a version")
-    # the choice to make this symlink is VERY hacky
-    tmp = SymlinkSpec(src=f"/usr/bin/clang-tidy-{version}", dst="/usr/bin/clang-tidy")
-    return CodeSourceAPT(
-        pkg_name=f"clang-tidy-{version}",
-        setup_fn=functools.partial(setup_llvm_repository, llvm_version=version),
-        symlinks=[tmp],
+    return CodeSource(
+        source=APTPackage(f"clang-tidy-{version}"),
+        setup_fn=functools.partial(
+            setup_llvm_repository, llvm_version=version, conf=conf
+        ),
+        symlinks=[
+            SymlinkSpec(src=f"/usr/bin/clang-tidy-{version}", dst_basename="clang-tidy")
+        ],
     )
 
 
@@ -230,13 +236,13 @@ class SimpleSourceFactory(NamedTuple):
     name: str
     apt_pkg_name: str
 
-    def __call__(self, version: Optional[str]) -> CodeSourceAPT:
+    def __call__(self, conf: Conf, version: Optional[str]) -> CodeSource:
         if version is not None:
             raise ScriptError(f"{self.name!s} cannot be specified with a version")
-        return CodeSourceAPT(pkg_name=self.apt_pkg_name)
+        return CodeSource(source=APTPackage(name=self.apt_pkg_name))
 
 
-_SOFTWARE: Dict[str, SourceFactory] = {
+_SOFTWARE: Dict[str, Callable[[Conf, str], CodeSource]] = {
     "castxml": SimpleSourceFactory(name="castxml", apt_pkg_name="castxml"),
     "clang-tidy": get_clang_tidy_source,
     "cmake": get_cmake_source,
@@ -262,7 +268,7 @@ _PRESETS["all-presets"] = (list(_PRESETS), [])
 
 
 def software_from_presets(presets: Iterable[str]) -> Iterable[str]:
-    preset_set = set(presets)  # <- avoid mutating args.preset
+    preset_set = set(presets)  # <- avoid mutating presets
     while preset_set:
         preset_l, software_l = _PRESETS[preset_set.pop()]
         preset_set.update(preset_l)
@@ -278,10 +284,30 @@ def _get_name_version(software_str: str) -> Tuple[str, Optional[str]]:
     raise ScriptError(f"{software_str!r} is an invalid string for specifying software")
 
 
-def apt_install(conf: Conf, names: Collection[str]):
+def _apt_install(conf: Conf, names: Collection[str]):
     assert len(names) > 0, "sanity check failed"
     exec_cmd("sudo", "apt-get", "update", dry_run=conf.dry_run)
     exec_cmd("sudo", "apt-get", "install", "-y", *sorted(names), dry_run=conf.dry_run)
+
+
+def _handle_symlinks(conf: Conf, symlink_sets: List[Tuple[str, List[SymlinkSpec]]]):
+    bin_dir = os.path.abspath(os.path.join(conf.manual_install_dir, "bin"))
+    logger.info(f"  ensure BINDIR={bin_dir} exists")
+    if not conf.dry_run:
+        os.makedirs(bin_dir, exist_ok=True)
+        export_env_var_assignment(f"export PATH={bin_dir}:$PATH")
+    for descr, symlink_spec_set in symlink_sets:
+        for spec in symlink_spec_set:
+            msg = f"  for {descr}: SRC={spec.src}, DST=$BINDIR/{spec.dst_basename}"
+            logger.info(msg)
+            if conf.dry_run:
+                continue
+            elif not os.path.isfile(spec.src):
+                raise RuntimeError(
+                    f"can't make a symlink to {spec.src}, (it doesn't seem to exist)"
+                )
+            else:
+                os.symlink(spec.src, os.path.join(bin_dir, spec.dst_basename))
 
 
 def install_software(software_str_itr: Iterable[str], conf: Conf):
@@ -290,6 +316,16 @@ def install_software(software_str_itr: Iterable[str], conf: Conf):
 
     logger.info(f"Sys Info: {conf.sys_info_str()}")
 
+    if not conf.dry_run:
+        try:
+            os.mkdir(conf.manual_install_dir)
+        except FileExistsError:
+            pass  # <- this case is ok!
+        except OSError:
+            raise ScriptError(
+                f"{conf.manual_install_dir} doesn't exist & can't easily be created"
+            ) from None
+
     # fill all_software with name : (version, software_name) entries
     all_software = {}
     for software_str in software_str_itr:
@@ -297,49 +333,43 @@ def install_software(software_str_itr: Iterable[str], conf: Conf):
         if name not in _SOFTWARE:
             raise ScriptError(f"{software_str} doesn't specify known software")
         old_v, _ = all_software.get(name, (None, None))
-        if old_v is not None:
+        if (old_v is not None) and (new_v is None):
+            continue
+        elif (old_v is not None) and (old_v != new_v):
             logger.warning(f"override {name!r} version: use {new_v} instead of {old_v}")
         all_software[name] = (new_v, software_str)
 
     # infer the required steps
-    cmd_list: List[Tuple[str, str, SimpleCallable]] = []
+    cmd_list: List[Tuple[str, str, Callable[[], None]]] = []
     apt_packages: Set[str] = set()
     symlink_sets: List[Tuple[str, List[SymlinkSpec]]] = []
 
     for name, (version, software_str) in all_software.items():
-        src = _SOFTWARE[name](version=version)
-        if callable(src):
-            cmd_list.append(("manual step", software_str, src))
+        src = _SOFTWARE[name](conf=conf, version=version)
+        if src.setup_fn is not None:
+            cmd_list.append(("setup step", software_str, src.setup_fn))
+        if callable(src.source):
+            cmd_list.append(("manual step", software_str, src.source))
         else:
-            assert isinstance(src, CodeSourceAPT)
-            apt_packages.add(src.pkg_name)
-            if src.setup_fn is not None:
-                cmd_list.append(("setup step", software_str, src.setup_fn))
-            if src.symlinks is not None:
-                symlink_sets.append((software_str, src.symlinks))
+            assert isinstance(src.source, APTPackage), "sanity check"
+            apt_packages.add(src.source.name)
+        if src.symlinks is not None:
+            symlink_sets.append((software_str, src.symlinks))
 
     if len(apt_packages) > 0:
-        fn = functools.partial(apt_install, names=apt_packages)
-        cmd_list.append(("apt invocations", None, fn))
+        fn = functools.partial(_apt_install, conf=conf, names=apt_packages)
+        cmd_list.append(("invoke APT", None, fn))
 
-    n_steps = len(cmd_list) + 1  # add 1 for symlinks
+    if len(symlink_sets) > 0:
+        fn = functools.partial(_handle_symlinks, conf=conf, symlink_sets=symlink_sets)
+        cmd_list.append(("Handle Symlinks (And Paths)", None, fn))
 
-    # actually do the installation
+    # execute the commands
+    n_steps = len(cmd_list)
     for i, (descr, target, cmd) in enumerate(cmd_list, start=1):
         msg = f"{descr} for {target}" if target is not None else descr
         logger.info(f"Dependency Install {i}/{n_steps}: {msg}")
-        extra_symlinks = cmd(conf)
-        if extra_symlinks:
-            assert target is not None, "sanity check"
-            symlink_sets.append((target, extra_symlinks))
-
-    logger.info(f"Dependency Install {n_steps}/{n_steps}: Make Symlinks (if needed)")
-    for descr, symlink_set in symlink_sets:
-        for symlink_spec in symlink_set:
-            msg = f"  for {descr}: SRC={symlink_spec.src}, DST={symlink_spec.dst}"
-            logger.info(msg)
-            if not conf.dry_run:
-                os.symlink(symlink_spec.src, symlink_spec.dst)
+        cmd()
 
 
 def main(args: argparse.Namespace):
@@ -392,4 +422,4 @@ parser.add_argument(
 )
 
 if __name__ == "__main__":
-    main(parser.parse_args())
+    sys.exit(main(parser.parse_args()))

--- a/scripts/ci/install_dependencies.py
+++ b/scripts/ci/install_dependencies.py
@@ -287,7 +287,9 @@ def _get_name_version(software_str: str) -> Tuple[str, Optional[str]]:
 def _apt_install(conf: Conf, names: Collection[str]):
     assert len(names) > 0, "sanity check failed"
     exec_cmd("sudo", "apt-get", "update", dry_run=conf.dry_run)
-    exec_cmd("sudo", "apt-get", "install", "-y", *sorted(names), dry_run=conf.dry_run)
+    _cmd = ["sudo", "apt-get", "install", "-y", "--no-install-recommends"]
+    _cmd.extend(sorted(names))
+    exec_cmd(*_cmd, dry_run=conf.dry_run)
 
 
 def _handle_symlinks(conf: Conf, symlink_sets: List[Tuple[str, List[SymlinkSpec]]]):


### PR DESCRIPTION
I've thought about doing this for quite a while.

### Motivation:

- in general, it's good practice to move away from putting critical logic into CI-specific YAML formats and using scripts instead (this affords us more flexibility if we ever wanted/needed to change CI providers)
- it would be nice to unify the logic for downloading dependencies that are used for building wheels of gracklepy (that's a topic for the future)
- I have some ideas that I've thought about from time-to-time for adding a few tests of Grackle-linking that involve docker containers. It would be useful to be able to reuse the same logic for installing dependencies in those scripts
- In the future, we would ideally run some quick smoke tests validating different versions of dependencies (e.g. CMake or compiler versions).

### Discussion

This got a little bigger than I expected.

In install_dependencies.py:
- there is a bunch of logic to install an arbitrary CMake version. We definitely want to be able to run a build with the newest CMake version (we have been burned by this before). In the future, we may also want to explicitly try to run a build with the oldest version of CMake that we claim to support
- There's a bunch of logic to install an arbitrary version of clang-tidy (the C++ linting tool we use). As I previously ighlighted in the docs, It's **REALLY** important that we pin clang-tidy to a particular major version (which is not necessarily the version supported by APT out of the box)
- I introduced this concept of software presets to reduice the number of command line args (rather than explicitly listing everything). By removing this, we could probably cut ~30 lines.

In common.py:
- there is a bunch of logic that basically backports `platform.freedesktop_os_release` (this is needed to install arbitrary versions of clang-tidy)
- `exec_cmd` is a nice wrapper around `subprocess.run`. I've tinkered with this quite a bit and I'm quite happy with it (but we can definitely remove it if you think it's unnecessary)