### PR TITLE
Backport cmake tweaks

### DIFF
--- a/cmake/GrackleConfig.cmake.in
+++ b/cmake/GrackleConfig.cmake.in
@@ -251,30 +251,46 @@ if (${_GRACKLE_LIBKIND} STREQUAL "static")
 
   unset(_FIND_H5_ARGS)
 
-  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
-    list(APPEND _EXTRA_ARGS QUIET)
-  endif()
-
-  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
-    list(APPEND _EXTRA_ARGS REQUIRED)
-  endif()
+  # the order in which we build up _FIND_H5_ARGS matters!
 
   # if we know the HDF5 version used to build to build Grackle as a static
-  # library, we really need to make sure the version number of the hdf5 library
-  # match the version number of the hdf5-headers (the documentation for the
-  # H5check_version function makes it clear a mismatch is bad!)
+  # library, we really should try to request it
   set(_DESIRED_HDF5_VERSION "@HDF5_VERSION@")
   if(NOT "${_DESIRED_HDF5_VERSION}" STREQUAL "")
-    list(APPEND _EXTRA_ARGS "${_DESIRED_HDF5_VERSION}" EXACT)
+    list(APPEND _FIND_H5_ARGS "${_DESIRED_HDF5_VERSION}")
+    if ("${_DESIRED_HDF5_VERSION}" VERSION_LESS "2.0.0")
+      # prior to version 2.0, HDF5 did not adhere to semver
+      # -> in this case, we REALLY need to make sure the version number of the
+      #    hdf5 library matches the version number of the hdf5-headers (the
+      #    documentation for the H5check_version function makes it clear a
+      #    mismatch is bad!)
+      list(APPEND _FIND_H5_ARGS EXACT)
+    else()
+      # do NOT append EXACT
+      # -> starting with HDF5 2.0, HDF5 is only ever built with CMake and we
+      #    can rely upon the version compatability checks provided in HDF5's
+      #    Config Package File
+    endif()
   endif()
   unset(_DESIRED_HDF5_VERSION)
 
+  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+    list(APPEND _FIND_H5_ARGS QUIET)
+  endif()
+
+  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
+    list(APPEND _FIND_H5_ARGS REQUIRED)
+  endif()
+
+  set(_FIND_H5_ARGS "${_FIND_H5_ARGS};COMPONENTS;C")
+
   # now we actually find the dependencies
-  find_package(HDF5 COMPONENTS C ${_EXTRA_ARGS})
+  find_package(HDF5 ${_FIND_H5_ARGS})
   if(NOT HDF5_FOUND)
     _FIND_GRACKLE_FAIL(
       "Grackle couldn't be found because dependency HDF5 couldn't be found")
   endif()
+  unset(_FIND_H5_ARGS)
   # declare HDF5 target (details are omitted that aren't needed for linking)
   add_library(GRACKLE_HDF5_C INTERFACE IMPORTED)
   set_target_properties(GRACKLE_HDF5_C PROPERTIES

--- a/cmake/installation_rules.cmake
+++ b/cmake/installation_rules.cmake
@@ -147,7 +147,7 @@ if (BUILD_SHARED_LIBS)
   # install-rule to make a symlink called libgrackle.so to support compilation
   # with `-lgrackle`. (This is consistent with the classic build-system)
   install(CODE "
-    set(_prefix \"${CMAKE_INSTALL_PREFIX}\")
+    set(_prefix \"\${CMAKE_INSTALL_PREFIX}\")
     if(DEFINED ENV{DESTDIR})
       message(WARNING
         \"linking to libgrackle.so (during install) is untested with DESTDIR\")
@@ -298,7 +298,7 @@ else()
   # if shared library was previously installed, install grackle-conventional.pc
   # as grackle.pc. Otherwise, install grackle-static.pc as grackle.pc
   install(CODE "
-    set(_prefix \"${CMAKE_INSTALL_PREFIX}\")
+    set(_prefix \"\${CMAKE_INSTALL_PREFIX}\")
     if(DEFINED ENV{DESTDIR})
       message(WARNING
         \"linking to libgrackle.so (during install) is untested with DESTDIR\")

--- a/cmake/installation_rules.cmake
+++ b/cmake/installation_rules.cmake
@@ -192,8 +192,11 @@ set(_TOOLCHAIN_LINK_LIBS ${Fortran_implicit_libs})
 # to the standard library's math functions
 # -> here we determine based on whether our custom toolchain::m target
 #    is a dummy placeholder or not whether to add this target
-get_target_property(toolchain_m_prop toolchain::m IMPORTED_LIBNAME)
-if(${toolchain_m_prop})
+#
+# NOTE: when we start using C++ in the core grackle library, we can drop this logic
+# and just rely upon `get_implicit_link_reqs(CXX ...)`, since the C++ runtime
+# library is ALWAYS linked to the math functions
+if (UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   list(APPEND _TOOLCHAIN_LINK_LIBS m) # explicit c requirement (but may
                                       # be a duplicate)
 endif()

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -75,18 +75,3 @@ if (GRACKLE_USE_OPENMP)
   endif()
   find_package(OpenMP REQUIRED COMPONENTS ${_GRACKLE_OMP_COMPONENTS})
 endif()
-
-# define target to link the math functions of the C standard library
-# (i.e. the -lm flag). This is commonly needed on unix-like platforms
-# -> For platforms that don't need libm, this target acts as a dummy
-#    placeholder (that does nothing)
-# -> The -lm flag should NOT be used on MacOS (while CMake is smart enough to
-#    not pass it to the linker, it will mess with exporting linker flags)
-#
-# NOTE: when we start using C++ in the core grackle library, we can remove
-# everything related to the toolchain::m variable (since the C++ runtime
-# library is ALWAYS linked to the math functions)
-add_library(toolchain::m INTERFACE IMPORTED)
-if (UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set_target_properties(toolchain::m PROPERTIES IMPORTED_LIBNAME "m")
-endif()

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -168,7 +168,7 @@ The following snippet shows a sample Makefile for compiling a sample application
 
    c_example:
    	$(CC) $(CFLAGS) -c c_example.c -o c_example.o
-   	$(CC) $(LDFLAGS) $(OTHER_LDFLAGS) c_example.o -o c_example
+   	$(CC) c_example.o $(LDFLAGS) $(OTHER_LDFLAGS) -o c_example
 
 pkg-config also provides additional functionality, like querying version numbers, enforcing version requirements, etc.
 Most of that functionality is described in `this guide <https://people.freedesktop.org/~dbn/pkg-config-guide.html>`__.

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -225,11 +225,27 @@ target_include_directories(Grackle_Grackle
 )
 
 target_link_libraries(Grackle_Grackle
-  PRIVATE toolchain::m
-          GRACKLE_HDF5_C
+  PRIVATE GRACKLE_HDF5_C
           $<$<BOOL:${GRACKLE_USE_OPENMP}>:OpenMP::OpenMP_Fortran>
           $<$<BOOL:${GRACKLE_USE_OPENMP}>:OpenMP::OpenMP_C>
 )
+
+# explicitly link against the math functions of the C standard library
+# (i.e. the -lm flag). This is commonly needed on unix-like platforms
+# -> The -lm flag does not get used on MacOS. CMake is smart enough to
+#    to intercept and remove the flag when invoking the linker on MacOS
+# -> Historically, passing the flag on MacOS caused issues with exporting
+#    the linker flags. I'm 99% sure, that this isn't a problem after we
+#    tweaked our implementation, but I don't want to test it.
+#
+# NOTE: when we start using C++ in the core grackle library, we can remove
+# everything related to the toolchain::m variable (since the C++ runtime
+# library is ALWAYS linked to the math functions)
+add_library(toolchain::m INTERFACE IMPORTED)
+if (UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  target_link_libraries(Grackle_Grackle PRIVATE m)
+endif()
+
 
 # add the necessary compiler-specific Fortran flags to ensure proper handling
 # of our specific Fortran-dialect and that name mangling is performed as


### PR DESCRIPTION
This PR backports some issues with the meta files created/installed by CMake in order to make integration easier with external applications.

The fundamental problem is that we don't regularly test these approaches. I'm ~95% done with implementing some automated tests for these approaches. Those tests will be introduced in a PR to newchem-cpp (this PR simply backports some of those bugfixes)