### PR TITLE
[newchem-cpp] Minor tweaks to calc_temp1d_cloudy and basic_gas_props

### DIFF
--- a/src/clib/gas_props.hpp
+++ b/src/clib/gas_props.hpp
@@ -129,9 +129,9 @@ inline double self_consistent_Tgas(double tgas0, double nH2, double n_other,
 /// @param[in] idx_range Specifies the current index-range
 inline void basic_gas_props(double* tgas, double* mmw, double* rhoH, int imetal,
                             const gr_mask_type* itmask,
-                            chemistry_data* my_chemistry,
-                            cloudy_data* primordial_cloudy_data,
-                            grackle_field_data* my_fields,
+                            const chemistry_data* my_chemistry,
+                            const cloudy_data* primordial_cloudy_data,
+                            const grackle_field_data* my_fields,
                             InternalGrUnits internalu, IndexRange idx_range) {
   // construct 3d views
   View<const gr_float***> d(my_fields->density, my_fields->grid_dimension[0],

--- a/src/clib/tabulated/calc_temp1d_cloudy.cpp
+++ b/src/clib/tabulated/calc_temp1d_cloudy.cpp
@@ -34,13 +34,13 @@ void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
                         InternalGrUnits internalu, IndexRange idx_range) {
   // General Arguments
 
-  grackle::impl::View<gr_float***> d(
-      my_fields->density, my_fields->grid_dimension[0],
-      my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
-  grackle::impl::View<gr_float***> metal(
+  View<const gr_float***> d(my_fields->density, my_fields->grid_dimension[0],
+                            my_fields->grid_dimension[1],
+                            my_fields->grid_dimension[2]);
+  View<const gr_float***> metal(
       my_fields->metal_density, my_fields->grid_dimension[0],
       my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
-  grackle::impl::View<gr_float***> e(
+  View<const gr_float***> e(
       my_fields->internal_energy, my_fields->grid_dimension[0],
       my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
   std::vector<double> logtem(my_fields->grid_dimension[0]);

--- a/src/clib/tabulated/calc_temp1d_cloudy.cpp
+++ b/src/clib/tabulated/calc_temp1d_cloudy.cpp
@@ -28,8 +28,9 @@ namespace GRIMPL_NAMESPACE_DECL {
 void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
                         double dom, double zr, int imetal,
                         const gr_mask_type* itmask,
-                        chemistry_data* my_chemistry, cloudy_data cloudy_table,
-                        grackle_field_data* my_fields,
+                        const chemistry_data* my_chemistry,
+                        cloudy_data cloudy_table,
+                        const grackle_field_data* my_fields,
                         InternalGrUnits internalu, IndexRange idx_range) {
   // General Arguments
 

--- a/src/clib/tabulated/calc_temp1d_cloudy.hpp
+++ b/src/clib/tabulated/calc_temp1d_cloudy.hpp
@@ -42,8 +42,9 @@ namespace GRIMPL_NAMESPACE_DECL {
 void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
                         double dom, double zr, int imetal,
                         const gr_mask_type* itmask,
-                        chemistry_data* my_chemistry, cloudy_data cloudy_table,
-                        grackle_field_data* my_fields,
+                        const chemistry_data* my_chemistry,
+                        cloudy_data cloudy_table,
+                        const grackle_field_data* my_fields,
                         InternalGrUnits internalu, IndexRange idx_range);
 
 }  // namespace GRIMPL_NAMESPACE_DECL


### PR DESCRIPTION
To be reviewed after #533 has been merged

------

This is a simple PR that is a followup to #533. This PR labels certain arguments of `calc_temp1d_cloudy` as pointers to const values so that we can do the same thing in `basic_gas_props`.

While I was there, I added `const` labels to the Views constructed in `calc_temp1d_cloudy`