### PR TITLE
[newchem-cpp] Make separate step to generate gold standard.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,24 @@ executors:
     resource_class: << parameters.resource_class >>
 
 jobs:
+  generate-gold-standard:
+    parameters:
+      tag:
+        type: string
+        default: latest
+    executor:
+      name: python
+      tag: << parameters.tag >>
+      resource_class: small  # <- 1 core
+
+    working_directory: ~/grackle
+
+    steps:
+      - checkout
+      - setup-system-for-pytest
+      - download-test-data
+      - store-gracklepy-suite-gold-standard-answers
+
   test-suite:
     parameters:
       tag:
@@ -363,7 +381,13 @@ workflows:
 
    tests:
      jobs:
+       - generate-gold-standard:
+           name: "Generate the gold standard."
+           tag: "3.10.14"
+
        - test-suite:
+           requires:
+             - "Generate the gold standard.": success
            name: "Pygrackle test suite - Python 3.10"
            tag: "3.10.14"
 
@@ -383,7 +407,13 @@ workflows:
               only:
                 - main
      jobs:
+       - generate-gold-standard:
+           name: "Generate the gold standard."
+           tag: "3.10.14"
+
        - test-suite:
+           requires:
+             - "Generate the gold standard.": success
            name: "Pygrackle test suite - Python 3.10"
            tag: "3.10.14"
 


### PR DESCRIPTION
This creates a separate job for generating the gold standard and adds this as a requirement for the test-suite job. This essentially buys us extra time to run the tests twice (to generate and then compare) without reaching our 60 minute limit per job. It's arguable this is a bandaid, but it saves me from restarting timed-out jobs once they have cached the gold standard. We could go back to trying to cut down on tests, but I think this also has the benefit of making it clearer when the tests fail because of issues relating to generating the gold standard.