### PR TITLE
[newchem-cpp] Add support for const-casting

### DIFF
--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -46,6 +46,7 @@ OBJS_CONFIG_LIB = \
         rate_timestep_g.lo \
         make_consistent.lo \
         scale_fields.lo \
+        solve_cubic_equation.lo \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -49,9 +49,7 @@ OBJS_CONFIG_LIB = \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \
-        calc_tdust_1d_g.lo \
         dust/calc_tdust_3d.lo \
-        calc_grain_size_increment_1d.lo \
         rate_functions.lo \
         ratequery.lo \
         gaussj_g.lo \

--- a/src/clib/support/View.hpp
+++ b/src/clib/support/View.hpp
@@ -21,6 +21,32 @@
 namespace GRIMPL_NAMESPACE_DECL {
 
 namespace view_detail {
+
+// define template and some partial specializations to implement MkPtr_t
+template <typename value_type, int Rank>
+struct MkPtr_ {
+  static_assert(0 < Rank && Rank < 4, "rank isn't 1, 2 or 3");
+  using type = value_type*;
+};
+
+template <typename value_type>
+struct MkPtr_<value_type, 2> {
+  using type = value_type**;
+};
+
+template <typename value_type>
+struct MkPtr_<value_type, 3> {
+  using type = value_type***;
+};
+
+/// machinery that provides the appropriate pointer to ``value_type``
+///
+/// Examples: ``MkPtr_t<double, 3>::type`` is ``double***``
+///           ``MkPtr_t<const int, 2>::type`` is ``const int**``
+///           ``MkPtr_t<const int, 1>::type`` is ``const int*``
+template <typename value_type, int Rank>
+using MkPtr_t = typename MkPtr_<value_type, Rank>::type;
+
 /// this simply helps us implement the View class template
 template <typename T>
 struct MDPtrProps_ {
@@ -112,9 +138,8 @@ struct MDPtrProps_ {
 ///   as a 1D View (it depends on our thoughts about self-shielding)
 ///
 template <typename T>
-struct View {
+class View {
   // first, we define useful types used by instances of the class template
-private:
   using ptrprops_ = view_detail::MDPtrProps_<T>;
 
 public:
@@ -124,7 +149,15 @@ public:
   using size_type = int;  // maybe revisit this?
   static constexpr int rank = ptrprops_::rank;
 
-private:  // attributes
+private:
+  // these entries exist to help us support implicit casts of views of mutable
+  // data to the corresponding view of const data
+  using non_const_ptr_ =
+      view_detail::MkPtr_t<std::remove_const_t<element_type>, rank>;
+  using const_ptr_ = view_detail::MkPtr_t<std::add_const_t<element_type>, rank>;
+  friend class View<const_ptr_>;
+
+  // attributes:
   element_type* data_;
   size_type extent_[rank];
   size_type strides_[rank];
@@ -169,6 +202,25 @@ public:
     check_invariants_();
   }
   ///@}
+
+  /// conversion constructor that facilitates implicit casts from views of
+  /// non-constant values to views of constant values
+  ///
+  /// For example, this allows implicit creation of ``View<const double**>``
+  /// from ``View<double**>``
+  ///
+  /// @note
+  /// This is only defined for instances of View for which T is a pointer to a
+  /// a const (e.g. `const int*`, `const double**`). If it were defined when
+  /// T is not a pointer-to-const, then it would duplicate the copy-constructor.
+  template <class = std::enable_if<std::is_same<T, const_ptr_>::value>>
+  View(const View<non_const_ptr_>& other) {
+    data_ = other.data_;
+    for (int i = 0; i < rank; i++) {
+      extent_[i] = other.extent_[i];
+      strides_[i] = other.strides_[i];
+    }
+  }
 
   // explicitly use defaults for a handful of cases
   ~View() = default;

--- a/tests/unit/support/test_View.cpp
+++ b/tests/unit/support/test_View.cpp
@@ -45,6 +45,25 @@ TEST(View, Simple1D) {
   EXPECT_EQ(v(2), 6);
 }
 
+TEST(View, Simple1DConstCast) {
+  int arr[3] = {8, -3, 6};
+  GRIMPL_NS::View<int*> v(arr, 3);
+
+  GRIMPL_NS::View<const int*> v_const = v;
+
+  EXPECT_EQ(arr, v_const.data());
+  EXPECT_EQ(v_const.extent(0), 3);
+  EXPECT_EQ(v_const(0), 8);
+  EXPECT_EQ(v_const(1), -3);
+  EXPECT_EQ(v_const(2), 6);
+
+  arr[0] = 0;
+  v(2) = -6;
+  EXPECT_EQ(v_const(0), 0);
+  EXPECT_EQ(v_const(1), -3);
+  EXPECT_EQ(v_const(2), -6);
+}
+
 TEST(View, Simple2D) {
   // clang-format off:  formatter knows nothing about shape
   double arr[20] = {
@@ -63,6 +82,27 @@ TEST(View, Simple2D) {
   EXPECT_EQ(v(3, 0), 8);
   EXPECT_EQ(v(1, 2), 1);
   EXPECT_EQ(v(4, 3), 17);
+}
+
+TEST(View, Simple2DConstCast) {
+  // clang-format off:  formatter knows nothing about shape
+  double arr[20] = {
+    0, 0, 0, 8, 0,
+    0, 0, 0, 0, 0,
+    0, 1, 0, 0, 0,
+    0, 0, 0, 0, 17
+  };
+  // clang-format on
+
+  GRIMPL_NS::View<double**> v(arr, 5, 4);
+  GRIMPL_NS::View<const double**> v_const = v;
+
+  EXPECT_EQ(arr, v_const.data());
+  EXPECT_EQ(v_const.extent(0), 5);
+  EXPECT_EQ(v_const.extent(1), 4);
+  EXPECT_EQ(v_const(3, 0), 8);
+  EXPECT_EQ(v_const(1, 2), 1);
+  EXPECT_EQ(v_const(4, 3), 17);
 }
 
 TEST(View, Simple3D) {
@@ -94,6 +134,38 @@ TEST(View, Simple3D) {
   EXPECT_EQ(v(3, 1, 0), 9);
   EXPECT_EQ(v(0, 2, 1), -3);
   EXPECT_EQ(v(4, 3, 2), 1);
+}
+
+TEST(View, Simple3DConstCast) {
+  // clang-format off:  formatter knows nothing about shape
+  float arr[60] = {
+    0, 0, 0, 0, 0,
+    0, 0, 0, 9, 0,
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+    -3, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0, 1
+  };
+  // clang-format on
+
+  GRIMPL_NS::View<float***> v(arr, 5, 4, 3);
+  GRIMPL_NS::View<const float***> v_const = v;
+
+  EXPECT_EQ(arr, v_const.data());
+  EXPECT_EQ(v_const.extent(0), 5);
+  EXPECT_EQ(v_const.extent(1), 4);
+  EXPECT_EQ(v_const.extent(2), 3);
+  EXPECT_EQ(v_const(3, 1, 0), 9);
+  EXPECT_EQ(v_const(0, 2, 1), -3);
+  EXPECT_EQ(v_const(4, 3, 2), 1);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This PR should be reviewed after #559 is merged

-------

This PR adds support for implicitly casting views of mutable data to views of immutable data. Basically we are adding support for a regular pointer operation.

Let me elaborate. Consider a type `T` (like a `int`, `gr_float`, `double`).
- Recall that a view is essentially a "fat pointer" that tracks a 1D pointer address and some shape metadata in order to treat it like a multidimensional pointer.
- Essentially, a `View<T*>` acts like a `T*`, a `View<T**>` acts like a `T**`, and a `View<T***>` acts like a `T***`.

Just as you can implicitly cast a `T*` to `const T*`, `T**` to `const T**`, and `T***` to `const T***`, this PR seeks to make it possible to cast `View<T*>` to `View<const T*>`, `View<T**>` to `View<const T**>`, and `View<T***>` to `View<const T***>`.

----

Strictly speaking, this PR isn't essential, which is part of the reason for breaking this change off of PR #552. But, this is a nice property to have (and I've wanted this capability more than once) 