### PR TITLE
[newchem-cpp] Makefile hotfix: remove old-filenames from Makefile

### DIFF
--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -46,6 +46,7 @@ OBJS_CONFIG_LIB = \
         rate_timestep_g.lo \
         make_consistent.lo \
         scale_fields.lo \
+        solve_cubic_equation.lo \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -49,9 +49,7 @@ OBJS_CONFIG_LIB = \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \
-        calc_tdust_1d_g.lo \
         dust/calc_tdust_3d.lo \
-        calc_grain_size_increment_1d.lo \
         rate_functions.lo \
         ratequery.lo \
         gaussj_g.lo \


### PR DESCRIPTION
This fixes a small bug that probably crept in during a recent merge. Essentially 2 files got renamed and the old names weren't removed from the Makefile (thus, the python CI tests would fail when we tried to build grackle using the classic build-system)