### PR TITLE
[newchem-cpp] Introduce destructor to `gr_opaque_storage`

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -130,7 +130,7 @@ add_library(Grackle_Grackle
   lnT_prep.cpp lnT_prep.hpp
   lookup_cool_rates1d.hpp
   make_consistent.cpp make_consistent.hpp
-  opaque_storage.hpp
+  opaque_storage.cpp opaque_storage.hpp
   ratequery.cpp ratequery.hpp
   rate_functions.cpp
   rate_timestep_g.cpp rate_timestep_g.hpp

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -45,6 +45,7 @@ OBJS_CONFIG_LIB = \
         lnT_prep.lo \
         rate_timestep_g.lo \
         make_consistent.lo \
+        opaque_storage.lo \
         scale_fields.lo \
         solve_cubic_equation.lo \
         solve_rate_cool.lo \

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -46,6 +46,7 @@ OBJS_CONFIG_LIB = \
         rate_timestep_g.lo \
         make_consistent.lo \
         scale_fields.lo \
+        solve_cubic_equation.lo \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \

--- a/src/clib/Make.config.objects
+++ b/src/clib/Make.config.objects
@@ -49,9 +49,7 @@ OBJS_CONFIG_LIB = \
         solve_rate_cool.lo \
         support/status_reporting.lo \
         update_UVbackground_rates.lo \
-        calc_tdust_1d_g.lo \
         dust/calc_tdust_3d.lo \
-        calc_grain_size_increment_1d.lo \
         rate_functions.lo \
         ratequery.lo \
         gaussj_g.lo \

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -335,14 +335,9 @@ static int local_initialize_chemistry_data_(
 
   // perform some basic allocations
   my_rates->opaque_storage = new gr_opaque_storage;
-  my_rates->opaque_storage->kcol_rate_tables = nullptr;
-  my_rates->opaque_storage->used_kcol_rate_indices = nullptr;
-  my_rates->opaque_storage->n_kcol_rate_indices = 0;
+  // the following line will be made unnecessary after PR #564 is merged
   grackle::impl::init_empty_interp_grid_props_(
     &my_rates->opaque_storage->h2dust_grain_interp_props);
-  my_rates->opaque_storage->grain_species_info = nullptr;
-  my_rates->opaque_storage->inject_pathway_props = nullptr;
-  my_rates->opaque_storage->registry = nullptr;
 
   double co_length_units, co_density_units;
   if (my_units->comoving_coordinates == TRUE) {

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -586,54 +586,6 @@ extern "C" int local_free_chemistry_data(chemistry_data *my_chemistry,
     return GR_FAIL;
   }
 
-  // start freeing memory associated with opaque storage
-  // ---------------------------------------------------
-  if (my_rates->opaque_storage->kcol_rate_tables != nullptr) {
-    // delete contents of kcol_rate_tables
-    drop_CollisionalRxnRateCollection(my_rates->opaque_storage->kcol_rate_tables);
-    // delete kcol_rate_tables, itself
-    delete my_rates->opaque_storage->kcol_rate_tables;
-  }
-
-  if (my_rates->opaque_storage->used_kcol_rate_indices !=nullptr) {
-    // since used_kcol_rate_indices are just integers, we can directly
-    // deallocate them
-    delete[] my_rates->opaque_storage->used_kcol_rate_indices;
-  }
-
-  // delete contents of h2dust_grain_interp_props (automatically handles the
-  // case where we didn't allocate anything)
-  grackle::impl::free_interp_grid_props_(
-      &my_rates->opaque_storage->h2dust_grain_interp_props,
-      /* use_delete = */ false);
-  // since h2dust_grain_interp_props isn't a pointer, there is nothing more to
-  // allocate right here
-
-  if (my_rates->opaque_storage->grain_species_info != nullptr) {
-    // delete contents of grain_species_info
-    grackle::impl::drop_GrainSpeciesInfo(
-      my_rates->opaque_storage->grain_species_info);
-    // delete grain_species_info, itself
-    delete my_rates->opaque_storage->grain_species_info;
-  }
-
-  if (my_rates->opaque_storage->inject_pathway_props != nullptr) {
-    // delete contents of inject_pathway_props
-    grackle::impl::drop_GrainMetalInjectPathways(
-      my_rates->opaque_storage->inject_pathway_props);
-    // delete inject_pathway_props, itself
-    delete my_rates->opaque_storage->inject_pathway_props;
-  }
-
-  if (my_rates->opaque_storage->registry != nullptr) {
-    // delete contents of registry
-    grackle::impl::ratequery::drop_Registry(
-      my_rates->opaque_storage->registry
-    );
-    // delete registry, itself
-    delete my_rates->opaque_storage->registry;
-  }
-
   delete my_rates->opaque_storage;
   my_rates->opaque_storage = nullptr;
 

--- a/src/clib/opaque_storage.cpp
+++ b/src/clib/opaque_storage.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// See the LICENSE file for license and copyright information
+// SPDX-License-Identifier: NCSA AND BSD-3-Clause
+//
+//===----------------------------------------------------------------------===//
+///
+/// @file
+/// Define the methods associated with gr_opaque_storage
+///
+//===----------------------------------------------------------------------===//
+
+#include "opaque_storage.hpp"
+
+gr_opaque_storage::~gr_opaque_storage() {
+  if (kcol_rate_tables != nullptr) {
+    // delete contents of kcol_rate_tables
+    drop_CollisionalRxnRateCollection(kcol_rate_tables);
+    // delete kcol_rate_tables, itself
+    delete kcol_rate_tables;
+  }
+
+  if (used_kcol_rate_indices != nullptr) {
+    // since used_kcol_rate_indices are just integers, we can directly
+    // deallocate them
+    delete[] used_kcol_rate_indices;
+  }
+
+  // delete contents of h2dust_grain_interp_props (automatically handles the
+  // case where we didn't allocate anything)
+  grackle::impl::free_interp_grid_props_(&h2dust_grain_interp_props,
+                                         /* use_delete = */ false);
+  // since h2dust_grain_interp_props isn't a pointer, there is nothing more to
+  // allocate right here
+
+  if (grain_species_info != nullptr) {
+    // delete contents of grain_species_info
+    grackle::impl::drop_GrainSpeciesInfo(grain_species_info);
+    // delete grain_species_info, itself
+    delete grain_species_info;
+  }
+
+  if (inject_pathway_props != nullptr) {
+    // delete contents of inject_pathway_props
+    grackle::impl::drop_GrainMetalInjectPathways(inject_pathway_props);
+    // delete inject_pathway_props, itself
+    delete inject_pathway_props;
+  }
+
+  if (registry != nullptr) {
+    // delete contents of registry
+    grackle::impl::ratequery::drop_Registry(registry);
+    // delete registry, itself
+    delete registry;
+  }
+}

--- a/src/clib/opaque_storage.hpp
+++ b/src/clib/opaque_storage.hpp
@@ -13,13 +13,15 @@
 #ifndef OPAQUE_STORAGE_HPP
 #define OPAQUE_STORAGE_HPP
 
+#include <cstddef>
 #include "grackle.h"
 #include "dust/grain_species_info.hpp"
 #include "inject_model/grain_metal_inject_pathways.hpp"
 #include "internal_types.hpp"
 #include "ratequery.hpp"
+#include "support/config.hpp"
 
-/// a struct that used to wrap some private storage details
+/// @brief a struct-like class that is used to wrap some private storage details
 ///
 /// The short-term goal is to have @ref chemistry_data_storage struct hold an
 /// opaque pointer to an instance of this struct. In more detail:
@@ -57,12 +59,12 @@ struct gr_opaque_storage {
   /// by the input parameters (here "ln" stands for natural log)
   ///@{
   /// holds the collision rate tables
-  grackle::impl::CollisionalRxnRateCollection* kcol_rate_tables;
+  GRIMPL_NS::CollisionalRxnRateCollection* kcol_rate_tables = nullptr;
   /// a list of the indices that are actualy used from kcol_rate_tables in the
   /// current calculation
-  int* used_kcol_rate_indices;
+  int* used_kcol_rate_indices = nullptr;
   /// length of used_kcol_rate_indices
-  int n_kcol_rate_indices;
+  int n_kcol_rate_indices = 0;
   ///@}
 
   /// tracks the grid of values used for interpolating grain-species specific
@@ -96,14 +98,29 @@ struct gr_opaque_storage {
   /// > contains some extra information that is unnecessary during the
   /// > calculations). An alternative would be to briefly initialize an
   /// > instance during setup and then repack the data.
-  grackle::impl::GrainSpeciesInfo* grain_species_info;
+  GRIMPL_NS::GrainSpeciesInfo* grain_species_info = nullptr;
 
   /// Tracks metal and grain yields for each modeled injection pathway as well
   /// as other grain properties
-  grackle::impl::GrainMetalInjectPathways* inject_pathway_props;
+  GRIMPL_NS::GrainMetalInjectPathways* inject_pathway_props = nullptr;
 
   /// used to implement the experimental ratequery machinery
-  grackle::impl::ratequery::Registry* registry;
+  GRIMPL_NS::ratequery::Registry* registry = nullptr;
+
+  // define basic constructor/assignement/destructor methods
+  // -------------------------------------------------------
+
+  gr_opaque_storage() = default;
+
+  // we delete the copy/move constructor and assignment the default
+  // implementations introduce dangling pointers
+  gr_opaque_storage(const gr_opaque_storage&) = delete;
+  gr_opaque_storage& operator=(const gr_opaque_storage&) = delete;
+  gr_opaque_storage(gr_opaque_storage&&) = delete;
+  gr_opaque_storage& operator=(gr_opaque_storage&&) = delete;
+
+  /// destroy an instance
+  ~gr_opaque_storage();
 };
 
 #endif /* OPAQUE_STORAGE_HPP */


### PR DESCRIPTION
This should not be reviewed until after #559 has been merged

--------

This is a simple PR that makes `gr_opaque_storage` responsible for deleting its own data. This has been a LONG time coming (I always put it off because I was concerned about merge-conflicts). 