### PR TITLE
Revert "Remove dust_sublimation parameter and functionality."

### DIFF
--- a/src/clib/ceiling_species.hpp
+++ b/src/clib/ceiling_species.hpp
@@ -287,7 +287,8 @@ inline void ceiling_species(int imetal, chemistry_data* my_chemistry,
             H2OII(i, j, k) = std::fmax(H2OII(i, j, k), tiny_fortran_val);
             H3OII(i, j, k) = std::fmax(H3OII(i, j, k), tiny_fortran_val);
             O2II(i, j, k) = std::fmax(O2II(i, j, k), tiny_fortran_val);
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 Mg(i, j, k) = std::fmax(Mg(i, j, k), tiny_fortran_val);
               }
@@ -308,7 +309,8 @@ inline void ceiling_species(int imetal, chemistry_data* my_chemistry,
       for (j = my_fields->grid_start[1]; j <= my_fields->grid_end[1]; j++) {
         for (i = my_fields->grid_start[0]; i <= my_fields->grid_end[0]; i++) {
           dust(i, j, k) = std::fmax(dust(i, j, k), tiny_fortran_val);
-          if (my_chemistry->grain_growth == 1) {
+          if ((my_chemistry->grain_growth == 1) ||
+              (my_chemistry->dust_sublimation == 1)) {
             // !                if (metal(i,j,k) .gt. 1.d-9 * d(i,j,k)) then
             if (my_chemistry->dust_species > 0) {
               MgSiO3(i, j, k) = std::fmax(MgSiO3(i, j, k), tiny_fortran_val);

--- a/src/clib/chemistry_solver_funcs.hpp
+++ b/src/clib/chemistry_solver_funcs.hpp
@@ -640,7 +640,7 @@ inline void species_density_updates_gauss_seidel(
               + kcol_buf[CollisionalRxnLUT::kz41][i] *  OHII(i,j,k) / 17.
               + kcol_buf[CollisionalRxnLUT::kz42][i] * H2OII(i,j,k) / 18.
               + kcol_buf[CollisionalRxnLUT::kz51][i] *    CI(i,j,k) / 12.;
-          if (my_chemistry->grain_growth == 1)  {
+          if ((my_chemistry->grain_growth == 1)  ||  (my_chemistry->dust_sublimation == 1))  {
             if (my_chemistry->dust_species > 0)  {
               scoef = scoef + 2. *
                     grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust]  [i] * 2.;
@@ -866,7 +866,7 @@ inline void species_density_updates_gauss_seidel(
             + kcol_buf[CollisionalRxnLUT::kz28][i] *    OH(i,j,k) / 17.
             + kcol_buf[CollisionalRxnLUT::kz29][i] *    O2(i,j,k) / 32.
             + kcol_buf[CollisionalRxnLUT::kz51][i] *   H2I(i,j,k) /  2.;
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::AC_dust]      [i] / CI(i,j,k) * 12.;
@@ -915,7 +915,7 @@ inline void species_density_updates_gauss_seidel(
            );
         acoef = 0.
             + kcol_buf[CollisionalRxnLUT::kz26][i] *    OH(i,j,k) / 17.;
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 2)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::ref_org_dust]  [i] / CO(i,j,k) * 17. * 0.5
@@ -1020,7 +1020,7 @@ inline void species_density_updates_gauss_seidel(
         acoef = 0.
             + kcol_buf[CollisionalRxnLUT::kz18][i] *    HI(i,j,k)
             + kcol_buf[CollisionalRxnLUT::kz35][i] *   HII(i,j,k);
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust]  [i] / H2O(i,j,k) * 18. * 2.;
@@ -1070,7 +1070,7 @@ inline void species_density_updates_gauss_seidel(
         acoef = 0.
             + kcol_buf[CollisionalRxnLUT::kz52][i] *    OH(i,j,k) / 17.
             + kcol_buf[CollisionalRxnLUT::kz53][i] *    O2(i,j,k) / 32.;
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 1)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::SiM_dust]     [i] / SiI(i,j,k) * 28.;
@@ -1088,7 +1088,7 @@ inline void species_density_updates_gauss_seidel(
            );
         acoef = 0.
             + kcol_buf[CollisionalRxnLUT::kz54][i] *    OH(i,j,k) / 17.;
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust]  [i] / SiOI(i,j,k) * 44.;
@@ -1108,7 +1108,7 @@ inline void species_density_updates_gauss_seidel(
             + kcol_buf[CollisionalRxnLUT::kz54][i] *  SiOI(i,j,k) *    OH(i,j,k) / 748.
            );
         acoef = 0.;
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 1)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::SiO2_dust]   [i] / SiO2I(i,j,k) * 60.;
@@ -1141,7 +1141,7 @@ inline void species_density_updates_gauss_seidel(
            );
         acoef = 0.
             + kcol_buf[CollisionalRxnLUT::kz16][i] *    HI(i,j,k);
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 2)  {
             acoef = acoef
             + grain_growth_rates[OnlyGrainSpLUT::ref_org_dust]  [i] / CH2(i,j,k) * 14. * 0.5;
@@ -1232,7 +1232,7 @@ inline void species_density_updates_gauss_seidel(
                    / ( 1. + acoef*dtit[i] );
 
 
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0)  {
             // ***** Mg **********
             scoef = 0.;
@@ -1290,7 +1290,7 @@ inline void species_density_updates_gauss_seidel(
   }
 
   // --- (D4) Now do dust species ---
-  if (my_chemistry->grain_growth == 1)  {
+  if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
     for (i = idx_range.i_start; i < idx_range.i_stop; i++) {
       if (itmask_metal[i] != MASK_FALSE)  {
 
@@ -1992,7 +1992,7 @@ inline void species_density_derivatives_0d(
           + kcol_buf[CollisionalRxnLUT::kz41][0]    *  OHII        / 17.
           + kcol_buf[CollisionalRxnLUT::kz42][0]    * H2OII        / 18.
           + kcol_buf[CollisionalRxnLUT::kz51][0]    *    CI        / 12.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           scoef = scoef + 2. *
                 grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust][0]      * 2.;
@@ -2221,7 +2221,7 @@ inline void species_density_derivatives_0d(
           + kcol_buf[CollisionalRxnLUT::kz28][0]    *    OH        / 17.
           + kcol_buf[CollisionalRxnLUT::kz29][0]    *    O2        / 32.
           + kcol_buf[CollisionalRxnLUT::kz51][0]    *   H2I        /  2.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::AC_dust][0]          / CI        * 12.;
@@ -2270,7 +2270,7 @@ inline void species_density_derivatives_0d(
          );
       acoef = 0.
           + kcol_buf[CollisionalRxnLUT::kz26][0]    *    OH        / 17.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 2)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::ref_org_dust][0]      / CO        * 17. * 0.5
@@ -2375,7 +2375,7 @@ inline void species_density_derivatives_0d(
       acoef = 0.
           + kcol_buf[CollisionalRxnLUT::kz18][0]    *    HI
           + kcol_buf[CollisionalRxnLUT::kz35][0]    *   HII;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust][0]      / H2O        * 18. * 2.;
@@ -2425,7 +2425,7 @@ inline void species_density_derivatives_0d(
       acoef = 0.
           + kcol_buf[CollisionalRxnLUT::kz52][0]    *    OH        / 17.
           + kcol_buf[CollisionalRxnLUT::kz53][0]    *    O2        / 32.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 1)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::SiM_dust][0]         / SiI        * 28.;
@@ -2443,7 +2443,7 @@ inline void species_density_derivatives_0d(
          );
       acoef = 0.
           + kcol_buf[CollisionalRxnLUT::kz54][0]    *    OH        / 17.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::MgSiO3_dust][0]      / SiOI        * 44.;
@@ -2463,7 +2463,7 @@ inline void species_density_derivatives_0d(
           + kcol_buf[CollisionalRxnLUT::kz54][0]    *  SiOI        *    OH        / 748.
          );
       acoef = 0.;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 1)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::SiO2_dust][0]       / SiO2I        * 60.;
@@ -2496,7 +2496,7 @@ inline void species_density_derivatives_0d(
          );
       acoef = 0.
           + kcol_buf[CollisionalRxnLUT::kz16][0]    *    HI;
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 2)  {
           acoef = acoef
           + grain_growth_rates[OnlyGrainSpLUT::ref_org_dust][0]      / CH2        * 14. * 0.5;
@@ -2587,7 +2587,7 @@ inline void species_density_derivatives_0d(
 
 
 
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           // ***** Mg **********
           scoef = 0.;
@@ -2645,7 +2645,7 @@ inline void species_density_derivatives_0d(
   }
 
   // --- (D4) Now do dust species ---
-  if (my_chemistry->grain_growth == 1)  {
+  if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
 
     if (itmask_metal[0] != MASK_FALSE   )  {
 

--- a/src/clib/dust/lookup_dust_rates1d.hpp
+++ b/src/clib/dust/lookup_dust_rates1d.hpp
@@ -382,6 +382,48 @@ inline void lookup_dust_rates1d(
         }  // idx_range loop
       }  // n_grain_species loop
     }
+
+    // todo: determine better behavior when my_chemistry->dust_sublimation
+    //       and my_chemistry->grain_growth are both equal to 1. When the
+    //       former option is enabled, the latter option has no impact. Thus
+    //       it makes no sense to let users enable both options!
+
+    if (my_chemistry->dust_sublimation == 1) {
+      for (int gsp_idx = 0; gsp_idx < n_grain_species; gsp_idx++) {
+        // load the sublimation temperature for the current grain species
+        double temdust_sublimation =
+            gsp_info->species_info[gsp_idx].sublimation_temperature;
+
+        // get pointer to the dust temperatures for the current grain species
+        const double* temdust_arr =
+            (my_chemistry->use_multiple_dust_temperatures == 0)
+                ? tdust
+                : grain_temperatures.data[gsp_idx];
+
+        // get the view of the grain species's current mass density
+        const gr_float* rho_gsp_ptr = field_data_adaptor.get_ptr_dynamic(
+            gsp_info->species_info[gsp_idx].species_idx);
+        grackle::impl::View<const gr_float***> rho_gsp(
+            rho_gsp_ptr, my_fields->grid_dimension[0],
+            my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
+
+        // iterate over the current index range
+        for (int i = idx_range.i_start; i < idx_range.i_stop; i++) {
+          if (itmask_metal[i] != MASK_FALSE) {
+            // zero-out the grain growth rate
+            grain_growth_rates[gsp_idx][i] = 0.0;
+
+            // set the growth rate to a negative value that will destroy the
+            // grain over the interval `dt` if the dust temperature exceeds
+            // the grain species's sublimation temperature
+            if (temdust_arr[i] > temdust_sublimation) {
+              grain_growth_rates[gsp_idx][i] =
+                  (tiny8 - rho_gsp(i, idx_range.j, idx_range.k)) / dt;
+            }
+          }
+        }
+      }
+    }  // (my_chemistry->dust_sublimation == 1)
   }
 }
 

--- a/src/clib/grackle_chemistry_data_fields.def
+++ b/src/clib/grackle_chemistry_data_fields.def
@@ -94,6 +94,9 @@ ENTRY(dust_species, INT, 0)
 /* Flag to solve temperatures of multiple grain species */
 ENTRY(use_multiple_dust_temperatures, INT, FALSE)
 
+/* Flag to supply dust sublimation */
+ENTRY(dust_sublimation, INT, FALSE)
+
 /* add heating from UV background model
    0) off, 1) on */
 ENTRY(UVbackground, INT, 0)

--- a/src/clib/make_consistent.cpp
+++ b/src/clib/make_consistent.cpp
@@ -473,7 +473,8 @@ void make_consistent(
           H2OII(i, j, k) = std::fabs(H2OII(i, j, k));
           H3OII(i, j, k) = std::fabs(H3OII(i, j, k));
           O2II(i, j, k) = std::fabs(O2II(i, j, k));
-          if (my_chemistry->grain_growth == 1) {
+          if ((my_chemistry->grain_growth == 1) ||
+              (my_chemistry->dust_sublimation == 1)) {
             if (my_chemistry->dust_species > 0) {
               Mg(i, j, k) = std::fabs(Mg(i, j, k));
             }
@@ -487,7 +488,8 @@ void make_consistent(
         }
       }
 
-      if (my_chemistry->grain_growth == 1) {
+      if ((my_chemistry->grain_growth == 1) ||
+          (my_chemistry->dust_sublimation == 1)) {
         for (i = my_fields->grid_start[0]; i <= my_fields->grid_end[0]; i++) {
           // if (itmask_metal(i)) then
           if (my_chemistry->dust_species > 0) {
@@ -547,7 +549,8 @@ void make_consistent(
             H2OII(i, j, k) = H2OII(i, j, k) * correctOg;
             H3OII(i, j, k) = H3OII(i, j, k) * correctOg;
             O2II(i, j, k) = O2II(i, j, k) * correctOg;
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalOd = 48. / 100. * MgSiO3(i, j, k);
               }
@@ -591,7 +594,8 @@ void make_consistent(
             CH(i, j, k) = CH(i, j, k) * correctCg;
             CH2(i, j, k) = CH2(i, j, k) * correctCg;
             COII(i, j, k) = COII(i, j, k) * correctCg;
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalCd = AC(i, j, k);
               }
@@ -615,7 +619,8 @@ void make_consistent(
             SiI(i, j, k) = SiI(i, j, k) * correctSig;
             SiOI(i, j, k) = SiOI(i, j, k) * correctSig;
             SiO2I(i, j, k) = SiO2I(i, j, k) * correctSig;
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalSid = 28. / 100. * MgSiO3(i, j, k);
               }
@@ -635,7 +640,8 @@ void make_consistent(
               }
             }
 
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 1) {
                 totalFeg = Fe(i, j, k);
                 correctFeg = (gr_float)(Feg[i] / totalFeg);
@@ -683,7 +689,8 @@ void make_consistent(
                      16. / 28. * COII(i, j, k) + OII(i, j, k) +
                      16. / 17. * OHII(i, j, k) + 16. / 18. * H2OII(i, j, k) +
                      16. / 19. * H3OII(i, j, k) + O2II(i, j, k);
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalO = totalO + 48. / 100. * MgSiO3(i, j, k);
               }
@@ -699,7 +706,8 @@ void make_consistent(
                          16. / 18. * H2Oice(i, j, k);
               }
             }
-            if (my_chemistry->grain_growth == 0) {
+            if ((my_chemistry->grain_growth == 0) &&
+                (my_chemistry->dust_sublimation == 0)) {
               correctO = (gr_float)(Og[i] / totalO);
               CO(i, j, k) = CO(i, j, k) * correctO;
               CO2(i, j, k) = CO2(i, j, k) * correctO;
@@ -751,7 +759,8 @@ void make_consistent(
             totalC = CI(i, j, k) + CII(i, j, k) + 12. / 28. * CO(i, j, k) +
                      12. / 44. * CO2(i, j, k) + 12. / 13. * CH(i, j, k) +
                      12. / 14. * CH2(i, j, k) + 12. / 28. * COII(i, j, k);
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalC = totalC + AC(i, j, k);
               }
@@ -760,7 +769,8 @@ void make_consistent(
                          12. / 32. * volorg(i, j, k);
               }
             }
-            if (my_chemistry->grain_growth == 0) {
+            if ((my_chemistry->grain_growth == 0) &&
+                (my_chemistry->dust_sublimation == 0)) {
               correctC = (gr_float)(Cg[i] / totalC);
               CI(i, j, k) = CI(i, j, k) * correctC;
               CII(i, j, k) = CII(i, j, k) * correctC;
@@ -789,7 +799,8 @@ void make_consistent(
 
             totalSi = SiI(i, j, k) + 28. / 44. * SiOI(i, j, k) +
                       28. / 60. * SiO2I(i, j, k);
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 0) {
                 totalSi = totalSi + 28. / 100. * MgSiO3(i, j, k);
               }
@@ -799,7 +810,8 @@ void make_consistent(
                           28. / 60. * SiO2D(i, j, k);
               }
             }
-            if (my_chemistry->grain_growth == 0) {
+            if ((my_chemistry->grain_growth == 0) &&
+                (my_chemistry->dust_sublimation == 0)) {
               correctSi = (gr_float)(Sig[i] / totalSi);
               SiI(i, j, k) = SiI(i, j, k) * correctSi;
               SiOI(i, j, k) = SiOI(i, j, k) * correctSi;
@@ -819,7 +831,8 @@ void make_consistent(
               }
             }
 
-            if (my_chemistry->grain_growth == 1) {
+            if ((my_chemistry->grain_growth == 1) ||
+                (my_chemistry->dust_sublimation == 1)) {
               if (my_chemistry->dust_species > 1) {
                 totalFe = Fe(i, j, k) + FeM(i, j, k) +
                           168. / 232. * Fe3O4(i, j, k) +

--- a/src/clib/scale_fields.cpp
+++ b/src/clib/scale_fields.cpp
@@ -297,7 +297,8 @@ void scale_fields(int imetal, gr_float factor, chemistry_data* my_chemistry,
           }
         }
 
-        if (my_chemistry->grain_growth == 1) {
+        if ((my_chemistry->grain_growth == 1) ||
+            (my_chemistry->dust_sublimation == 1)) {
           if (my_chemistry->dust_species > 0) {
             for (i = my_fields->grid_start[0]; i <= my_fields->grid_end[0];
                  i++) {
@@ -319,7 +320,8 @@ void scale_fields(int imetal, gr_float factor, chemistry_data* my_chemistry,
             dust(i, j, k) = dust(i, j, k) * factor;
           }
 
-          if (my_chemistry->grain_growth == 1) {
+          if ((my_chemistry->grain_growth == 1) ||
+              (my_chemistry->dust_sublimation == 1)) {
             if (my_chemistry->dust_species > 0) {
               for (i = my_fields->grid_start[0]; i <= my_fields->grid_end[0];
                    i++) {

--- a/src/clib/scale_fields.hpp
+++ b/src/clib/scale_fields.hpp
@@ -138,7 +138,8 @@ inline void scale_fields_dust(chemistry_data* my_chemistry,
     if (my_chemistry->use_dust_density_field == 1) {
       for (int i = idx_range.i_start; i < idx_range.i_stop; i++) {
         dust(i, j, k) = dust(i, j, k) * factor;
-        if (my_chemistry->grain_growth == 1) {
+        if ((my_chemistry->grain_growth == 1) ||
+            (my_chemistry->dust_sublimation == 1)) {
           // !            if (metal(i,j,k) .gt. 1.d-9 * d(i,j,k)) then
           if (my_chemistry->dust_species > 0) {
             MgSiO3(i, j, k) = MgSiO3(i, j, k) * factor;

--- a/src/clib/step_rate_gauss_seidel.hpp
+++ b/src/clib/step_rate_gauss_seidel.hpp
@@ -180,7 +180,7 @@ inline void update_fields_from_tmpdens_gauss_seidel(
         H2OII(i,j,k)   = std::fmax((gr_float)(species_tmpdens.data[SpLUT::H2OII][i]   ), tiny_fortran_val);
         H3OII(i,j,k)   = std::fmax((gr_float)(species_tmpdens.data[SpLUT::H3OII][i]   ), tiny_fortran_val);
         O2II(i,j,k)    = std::fmax((gr_float)(species_tmpdens.data[SpLUT::O2II][i]    ), tiny_fortran_val);
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0)  {
             Mg(i,j,k)      = std::fmax((gr_float)(species_tmpdens.data[SpLUT::Mg][i]      ), tiny_fortran_val);
           }
@@ -192,7 +192,7 @@ inline void update_fields_from_tmpdens_gauss_seidel(
         }
       }
 
-      if (my_chemistry->grain_growth == 1)  {
+      if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
         if (my_chemistry->dust_species > 0)  {
           MgSiO3(i,j,k)  = std::fmax((gr_float)(species_tmpdens.data[SpLUT::MgSiO3_dust][i]  ), tiny_fortran_val);
           AC(i,j,k)      = std::fmax((gr_float)(species_tmpdens.data[SpLUT::AC_dust][i]      ), tiny_fortran_val);

--- a/src/clib/step_rate_newton_raphson.hpp
+++ b/src/clib/step_rate_newton_raphson.hpp
@@ -279,12 +279,12 @@ inline void step_rate_newton_raphson(
       if (itmask_metal[i] != MASK_FALSE)  {
         if (my_chemistry->metal_chemistry == 1)  {
           nsp = nsp + 19;
-          if (my_chemistry->grain_growth == 1)  {
+          if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
             if (my_chemistry->dust_species > 0) { nsp = nsp + 1; }
             if (my_chemistry->dust_species > 1) { nsp = nsp + 3; }
           }
         }
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1) )  {
           if (my_chemistry->dust_species > 0) { nsp = nsp + 2; }
           if (my_chemistry->dust_species > 1) { nsp = nsp + 8; }
           if (my_chemistry->dust_species > 2) { nsp = nsp + 3; }
@@ -345,7 +345,7 @@ inline void step_rate_newton_raphson(
           dsp[SpLUT::H2OII] = my_fields->H2OII_density[field_idx1d];
           dsp[SpLUT::H3OII] = my_fields->H3OII_density[field_idx1d];
           dsp[SpLUT::O2II] = my_fields->O2II_density[field_idx1d];
-          if (my_chemistry->grain_growth == 1) {
+          if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) ) {
             if (my_chemistry->dust_species > 0)  {
               dsp[SpLUT::Mg] = my_fields->Mg_density[field_idx1d];
             }
@@ -356,7 +356,7 @@ inline void step_rate_newton_raphson(
             }
           }
         }
-        if (my_chemistry->grain_growth == 1) {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) ) {
           if (my_chemistry->dust_species > 0)  {
             dsp[SpLUT::MgSiO3_dust] = my_fields->MgSiO3_dust_density[field_idx1d];
             dsp[SpLUT::AC_dust] = my_fields->AC_dust_density[field_idx1d];
@@ -435,7 +435,7 @@ inline void step_rate_newton_raphson(
           idsp[id++] = SpLUT::H2OII;
           idsp[id++] = SpLUT::H3OII;
           idsp[id++] = SpLUT::O2II;
-          if (my_chemistry->grain_growth == 1)  {
+          if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) )  {
             if (my_chemistry->dust_species > 0)  {
               idsp[id++] = SpLUT::Mg;
             }
@@ -446,7 +446,7 @@ inline void step_rate_newton_raphson(
             }
           }
         }
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) )  {
           if (my_chemistry->dust_species > 0)  {
             idsp[id++] = SpLUT::MgSiO3_dust;
             idsp[id++] = SpLUT::AC_dust;
@@ -726,7 +726,7 @@ label_9996:
           my_fields->H2OII_density[field_idx1d]   = dsp[SpLUT::H2OII];
           my_fields->H3OII_density[field_idx1d]   = dsp[SpLUT::H3OII];
           my_fields->O2II_density[field_idx1d]    = dsp[SpLUT::O2II];
-          if (my_chemistry->grain_growth == 1)  {
+          if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) )  {
             if (my_chemistry->dust_species > 0)  {
               my_fields->Mg_density[field_idx1d]      = dsp[SpLUT::Mg];
             }
@@ -737,7 +737,7 @@ label_9996:
             }
           }
         }
-        if (my_chemistry->grain_growth == 1)  {
+        if ( ( my_chemistry->grain_growth == 1 )  ||  ( my_chemistry->dust_sublimation == 1 ) )  {
           if (my_chemistry->dust_species > 0)  {
             my_fields->MgSiO3_dust_density[field_idx1d]  = dsp[SpLUT::MgSiO3_dust];
             my_fields->AC_dust_density[field_idx1d]      = dsp[SpLUT::AC_dust];

--- a/src/include/grackle_chemistry_data.h
+++ b/src/include/grackle_chemistry_data.h
@@ -134,6 +134,9 @@ typedef struct
   /* Flag to solve temperatures of multiple grain species */
   int use_multiple_dust_temperatures;
 
+  /* Flag to supply dust sublimation */
+  int dust_sublimation;
+
   /* photo-electric heating from irradiated dust */
   int photoelectric_heating;
   double photoelectric_heating_rate;

--- a/src/include/grackle_fortran_interface.def
+++ b/src/include/grackle_fortran_interface.def
@@ -157,6 +157,7 @@ c     This is the fortran definition of grackle_chemistry_data
          INTEGER(C_INT) :: metal_abundances
          INTEGER(C_INT) :: dust_species
          INTEGER(C_INT) :: use_multiple_dust_temperatures
+         INTEGER(C_INT) :: dust_sublimation
          INTEGER(C_INT) :: photoelectric_heating
          REAL(C_DOUBLE) :: photoelectric_heating_rate
          INTEGER(C_INT) :: use_isrf_field

--- a/src/python/gracklepy/utilities/model_tests.py
+++ b/src/python/gracklepy/utilities/model_tests.py
@@ -314,6 +314,7 @@ _model_test_grids = \
                     "use_dust_density_field": 1,
                     "photoelectric_heating": 0,
                     "dust_recombination_cooling": 1,
+                    "dust_sublimation": 1,
                     "grain_growth": 1,
                     "dust_species": 3,
                     "multi_metals": 0,


### PR DESCRIPTION
Reverts grackle-project/grackle#566

The removal of sublimation is making some of the free-fall tests behave badly. I wonder if sublimation of low melting point dust species was subtly keeping things stable.