### PR TITLE
[newchem-cpp] Link OpenMP::OpenMP_CXX to the core library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,19 +334,17 @@ jobs:
           name: "Run the suite of tests that operate directly on the core-library."
           command: ctest --test-dir build_ci-linux --output-on-failure
 
-      # we are temporarily disabling OpenMP tests in the newchem-cpp branch
-      # since OpenMP-support is currently "broken" (it is fixed in the C++ port)
-      #- run:
-      #    name: "Build libgrackle with OpenMP enabled"
-      #    command: |
-      #      cmake --preset ci-linux-omp
-      #      cmake --build build_ci-linux-omp
-      #- run:
-      #    name: "run the OpenMP example"
-      #    command: ./cxx_omp_example
-      #    working_directory: build_ci-linux-omp/examples
-      #    environment:
-      #      OMP_NUM_THREADS: 4
+      - run:
+          name: "Build libgrackle with OpenMP enabled"
+          command: |
+            cmake --preset ci-linux-omp
+            cmake --build build_ci-linux-omp
+      - run:
+          name: "run the OpenMP example"
+          command: ./cxx_omp_example
+          working_directory: build_ci-linux-omp/examples
+          environment:
+            OMP_NUM_THREADS: 4
 
       - run:
           name: "Run clang-tidy"

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -100,13 +100,7 @@ if (GRACKLE_USE_OPENMP)
       "CMake. The quick fix is use Makefiles. See the docs for more info"
     )
   endif()
-
-  if(GRACKLE_EXAMPLES)
-    set(_GRACKLE_OMP_COMPONENTS C Fortran CXX)
-  else()
-    set(_GRACKLE_OMP_COMPONENTS C Fortran)
-  endif()
-  find_package(OpenMP REQUIRED COMPONENTS ${_GRACKLE_OMP_COMPONENTS})
+  find_package(OpenMP REQUIRED COMPONENTS C Fortran CXX)
 endif()
 
 # define target to link the math functions of the C standard library

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -283,6 +283,7 @@ target_link_libraries(Grackle_Grackle
           GRACKLE_HDF5_C
           $<$<BOOL:${GRACKLE_USE_OPENMP}>:OpenMP::OpenMP_Fortran>
           $<$<BOOL:${GRACKLE_USE_OPENMP}>:OpenMP::OpenMP_C>
+          $<$<BOOL:${GRACKLE_USE_OPENMP}>:OpenMP::OpenMP_CXX>
 )
 
 # add the necessary compiler-specific Fortran flags to ensure proper handling

--- a/src/clib/support/config.hpp
+++ b/src/clib/support/config.hpp
@@ -29,7 +29,7 @@
 /// [here](https://en.cppreference.com/w/cpp/preprocessor/impl). More details
 /// can be found [here](https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html).
 #ifdef _OPENMP
-#define OMP_PRAGMA(x) _Pragma(#x)
+#define OMP_PRAGMA(x) _Pragma(x)
 #else
 #define OMP_PRAGMA(x) /* ... */
 #endif


### PR DESCRIPTION
@mabruzzo I noticed these issues while trying to run cxx_omp_example to do some profiling.