### PR TITLE
[newchem-cpp] turn sublimation off in testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ commands:
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string
-        default: "6"
+        default: "7"
     steps:
       - run:
           name: "Build Pygrackle from Gold-Standard Commit (<< parameters.gold-standard-tag >>)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ commands:
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string
-        default: "5"
+        default: "6"
     steps:
       - run:
           name: "Build Pygrackle from Gold-Standard Commit (<< parameters.gold-standard-tag >>)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-nccv12"
+        default: "gold-standard-nccv13"
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string
-        default: "2"
+        default: "5"
     steps:
       - run:
           name: "Build Pygrackle from Gold-Standard Commit (<< parameters.gold-standard-tag >>)"

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -58,7 +58,8 @@ def main(args=None):
     if len(args) != 0:  # we are using the testing framework
         my_vars = get_test_variables(_MODEL_NAME, args)
 
-        metallicity = my_vars["metallicity"]
+        metallicity = my_vars.get("metallicity", 0.)
+        final_density = my_vars.get("final_density", 1e12 * mass_hydrogen_cgs)
         extra_attrs = my_vars["extra_attrs"]
         my_chemistry = my_vars["my_chemistry"]
         output_name = my_vars["output_name"]
@@ -67,6 +68,8 @@ def main(args=None):
 
     else:  # Just run the script as is.
         metallicity = 0.
+        final_density = 1e12 * mass_hydrogen_cgs
+
         # dictionary to store extra information in output dataset
         extra_attrs = {}
 
@@ -104,7 +107,6 @@ def main(args=None):
     # set initial density and temperature
     initial_temperature = 50000.
     initial_density     = 1e-1 * mass_hydrogen_cgs # g / cm^3
-    final_density       = 1e12 * mass_hydrogen_cgs
 
     metal_mass_fraction = metallicity * my_chemistry.SolarMetalFractionByMass
     dust_to_gas_ratio = metallicity * my_chemistry.local_dust_to_gas_ratio

--- a/src/python/gracklepy/utilities/model_tests.py
+++ b/src/python/gracklepy/utilities/model_tests.py
@@ -319,14 +319,13 @@ _model_test_grids = \
                     "grain_growth": 1,
                     "dust_species": 3,
                     "multi_metals": 0,
-                    "metal_abundances": 0,
+                    "metal_abundances": 11,
                 },
                 "variants": \
                 {
                     "dust_species": (0, 1, 2),
                     "use_multiple_dust_temperatures": (0, 1),
                     "multi_metals": (1,),
-                    "metal_abundances": (11,),
                 }
             },
             "inputs": \
@@ -366,11 +365,11 @@ _model_test_grids = \
                     "grain_growth": 1,
                     "dust_species": 3,
                     "multi_metals": 0,
-                    "metal_abundances": 1,
+                    "metal_abundances": 0,
                 },
                 "variants": \
                 {
-                    "metal_abundances": (2, 3, 4, 5, 6, 7, 8, 9, 10),
+                    "metal_abundances": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
                 }
             },
             "inputs": \

--- a/src/python/gracklepy/utilities/model_tests.py
+++ b/src/python/gracklepy/utilities/model_tests.py
@@ -17,6 +17,7 @@ import os
 import sys
 
 from gracklepy import chemistry_data
+from gracklepy.utilities.physical_constants import mass_hydrogen_cgs
 
 if sys.version_info < (3, 9):
     from functools import lru_cache as cache
@@ -314,7 +315,7 @@ _model_test_grids = \
                     "use_dust_density_field": 1,
                     "photoelectric_heating": 0,
                     "dust_recombination_cooling": 1,
-                    "dust_sublimation": 1,
+                    "dust_sublimation": 0,
                     "grain_growth": 1,
                     "dust_species": 3,
                     "multi_metals": 0,
@@ -325,7 +326,7 @@ _model_test_grids = \
                     "dust_species": (0, 1, 2),
                     "use_multiple_dust_temperatures": (0, 1),
                     "multi_metals": (1,),
-                    "metal_abundances": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+                    "metal_abundances": (11,),
                 }
             },
             "inputs": \
@@ -333,6 +334,51 @@ _model_test_grids = \
                 "defaults": \
                 {
                     "metallicity": 1e-3,
+                }
+            }
+        },
+
+        "metal_dust_chemistry_low_density": \
+        {
+            "parameters": \
+            {
+                "defaults": \
+                {
+                    "use_grackle": 1,
+                    "primordial_chemistry": 4,
+                    "CaseBRecombination": 1,
+                    "cie_cooling": 2,
+                    "h2_optical_depth_approximation": 1,
+                    "use_primordial_continuum_opacity": 1,
+                    "h2_charge_exchange_rate": 1,
+                    "h2_h_cooling_rate": 1,
+                    "h2_cooling_rate": 3,
+                    "hd_reaction_rates": 1,
+                    "grackle_data_file": "cloudy_metals_2008_3D.h5",
+                    "metal_cooling": 1,
+                    "metal_chemistry": 1,
+                    "three_body_rate": 4,
+                    "dust_chemistry": 1,
+                    "use_dust_density_field": 1,
+                    "photoelectric_heating": 0,
+                    "dust_recombination_cooling": 1,
+                    "dust_sublimation": 0,
+                    "grain_growth": 1,
+                    "dust_species": 3,
+                    "multi_metals": 0,
+                    "metal_abundances": 1,
+                },
+                "variants": \
+                {
+                    "metal_abundances": (2, 3, 4, 5, 6, 7, 8, 9, 10),
+                }
+            },
+            "inputs": \
+            {
+                "defaults": \
+                {
+                    "metallicity": 1e-3,
+                    "final_density": 1e10 * mass_hydrogen_cgs,
                 }
             }
         }

--- a/src/python/gracklepy/utilities/model_tests.py
+++ b/src/python/gracklepy/utilities/model_tests.py
@@ -317,13 +317,13 @@ _model_test_grids = \
                     "dust_recombination_cooling": 1,
                     "dust_sublimation": 0,
                     "grain_growth": 1,
-                    "dust_species": 3,
+                    "dust_species": 2,
                     "multi_metals": 0,
-                    "metal_abundances": 11,
+                    "metal_abundances": 0,
                 },
                 "variants": \
                 {
-                    "dust_species": (0, 1, 2),
+                    "dust_species": (0, 1),
                     "use_multiple_dust_temperatures": (0, 1),
                     "multi_metals": (1,),
                 }
@@ -369,7 +369,7 @@ _model_test_grids = \
                 },
                 "variants": \
                 {
-                    "metal_abundances": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+                    "metal_abundances": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
                 }
             },
             "inputs": \


### PR DESCRIPTION
This disables dust_sublimation in the testing in advance of removing this feature entirely. To enable this, I created a new testing variant for all the freefall tests that get unstable with sublimation off. These simply run to a lower density and stop before this occurs.