### PR TITLE
[newchem-cpp] Calculate gas temperature within `calc_tdust_3d`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-nccv13"
+        default: "gold-standard-nccv14"
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string
-        default: "7"
+        default: "1"
     steps:
       - run:
           name: "Build Pygrackle from Gold-Standard Commit (<< parameters.gold-standard-tag >>)"

--- a/src/clib/api/calculate_dust_temperature.cpp
+++ b/src/clib/api/calculate_dust_temperature.cpp
@@ -36,25 +36,10 @@ extern "C" int local_calculate_dust_temperature(
   if (my_fields->metal_density == NULL)
     metal_field_present = FALSE;
 
-  /* Compute the size of the fields. */
- 
-  int size = 1;
-  for (int dim = 0; dim < my_fields->grid_rank; dim++) {
-    size *= my_fields->grid_dimension[dim];
-  }
-
-  gr_float *temperature = new gr_float[size];
-  if (local_calculate_temperature(my_chemistry, my_rates, my_units,
-                                  my_fields, temperature) != GR_SUCCESS) {
-    std::fprintf(stderr, "Error in local_calculate_temperature.\n");
-    return GR_FAIL;
-  }
-
   GRIMPL_NS::calc_tdust_3d(
-    temperature, dust_temperature, metal_field_present, my_chemistry, my_rates,
+    dust_temperature, metal_field_present, my_chemistry, my_rates,
     my_fields, internalu
   );
-  delete[] temperature;
 
   return GR_SUCCESS;
 }

--- a/src/clib/api/calculate_dust_temperature.cpp
+++ b/src/clib/api/calculate_dust_temperature.cpp
@@ -30,14 +30,9 @@ extern "C" int local_calculate_dust_temperature(
 
   GRIMPL_NS::InternalGrUnits internalu = GRIMPL_NS::new_internalu_(my_units);
 
-  /* Check for a metal field. */
-
-  int metal_field_present = TRUE;
-  if (my_fields->metal_density == NULL)
-    metal_field_present = FALSE;
-
+  int has_metal_field = (my_fields->metal_density == nullptr) ? FALSE : TRUE;
   GRIMPL_NS::calc_tdust_3d(
-    dust_temperature, metal_field_present, my_chemistry, my_rates,
+    dust_temperature, has_metal_field, my_chemistry, my_rates,
     my_fields, internalu
   );
 

--- a/src/clib/dust/calc_tdust_3d.cpp
+++ b/src/clib/dust/calc_tdust_3d.cpp
@@ -197,12 +197,6 @@ void calc_tdust_3d(
 
       for (int i = idx_range.i_start; i < idx_range.i_stop; i++) {
         if(itmask_metal[i] != MASK_FALSE)  {
-          // Calculate metallicity
-
-          if (imetal == 1)  {
-            metallicity[i] = metal(i,j,k) / d(i,j,k) / my_chemistry->SolarMetalFractionByMass;
-          }
-
           // Calculate dust to gas ratio
 
           //       if ( (idustfield .gt. 0) .and. (idspecies .gt. 0) ) then

--- a/src/clib/dust/calc_tdust_3d.cpp
+++ b/src/clib/dust/calc_tdust_3d.cpp
@@ -257,12 +257,6 @@ void calc_tdust_3d(
         }
       }
 
-      // Compute log temperature and precompute standard interpolation props
-      LnTPreparer::prep_undamped_lnT_lininterp_bufs(logTlininterp_buf,
-                                                    idx_range, *my_chemistry,
-                                                    itmask_metal.data(),
-                                                    tgas.data());
-
       // Compute dust temperature(s) in the index-range
       calc_all_tdust_gasgr_1d_g(
         trad, tgas.data(), tdust.data(), metallicity.data(),

--- a/src/clib/dust/calc_tdust_3d.cpp
+++ b/src/clib/dust/calc_tdust_3d.cpp
@@ -19,6 +19,7 @@
 #include "calc_tdust_3d.hpp"
 #include "dust_props.hpp"
 #include "dust/multi_grain_species/calc_grain_size_increment_1d.hpp"
+#include "gas_props.hpp"
 #include "grackle.h"
 #include "support/index_helper.hpp"
 #include "inject_model/grain_metal_inject_pathways.hpp"
@@ -31,7 +32,7 @@
 namespace GRIMPL_NAMESPACE_DECL {
 
 void calc_tdust_3d(
-  gr_float* gas_temp_data_, gr_float* dust_temp_data_, int imetal,
+  gr_float* dust_temp_data_, int imetal,
   chemistry_data* my_chemistry, chemistry_data_storage* my_rates,
   grackle_field_data* my_fields, InternalGrUnits internalu
 )
@@ -67,7 +68,6 @@ void calc_tdust_3d(
     View<gr_float***> HII(my_fields->HII_density, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
     View<gr_float***> H2I(my_fields->H2I_density, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
     View<gr_float***> H2II(my_fields->H2II_density, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
-    View<gr_float***> gas_temp(gas_temp_data_, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
     View<gr_float***> dust_temp(dust_temp_data_, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
     View<gr_float***> isrf_habing(my_fields->isrf_habing, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
     View<gr_float***> metal(my_fields->metal_density, my_fields->grid_dimension[0], my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
@@ -139,8 +139,36 @@ void calc_tdust_3d(
       const int k = idx_range.k;
       const int j = idx_range.j;
 
+      // compute gas properties (tgas and metallicity) & fill up logTlinterp_buf
+      // - compared to earlier iterations of this code path:
+      //   - this computes/records a few unneeded quantities
+      //   - it saves an allocation of a temporary temperature buffer the size
+      //     of a field (this is potentially significant)
+      //   - the temperature calculation is FAR more consistent with the
+      //     calculation during the normal chemistry/cooling solve
+      // - we can always introduce more optimized logic later that bypasses the
+      //   unnecessary work (i.e. calculating nelec_times_mH)
+      {
+        gr_mask_type* itmask = itmask_metal.data();
+        for (int i = idx_range.i_start; i < idx_range.i_stop; i++) {
+          itmask[i] = MASK_TRUE;
+        }
 
-      // Set itmask to true for entire idx_range
+        // these buffers need to be filled (otherwise, we introduce lots of
+        // branching). We will overwrite all of these
+        double* dummy_mmw = myisrf.data();
+        double* dummy_rhoH = dust2gas.data();
+        double* dummy_nelec_times_mH = nh.data();
+
+        extended_gas_props(tgas.data(), dummy_mmw, dummy_rhoH,
+                           metallicity.data(), dummy_nelec_times_mH,
+                           logTlininterp_buf, imetal, itmask,
+                           my_chemistry, &my_rates->cloudy_primordial,
+                           my_fields, internalu, idx_range, nullptr);
+      }
+
+
+      // Set itmask_metal to true for entire idx_range
       for (int i = idx_range.i_start; i < idx_range.i_stop; i++) {
         itmask_metal[i] = MASK_TRUE;
       }
@@ -226,9 +254,6 @@ void calc_tdust_3d(
           // We have not converted to proper, so use urho and not dom
 
           nh[i] = nh[i] * internalu.urho / mh_local_var;
-
-          // copy temperature into 1D buffer
-          tgas[i]   = gas_temp(i,j,k);
         }
       }
 

--- a/src/clib/dust/calc_tdust_3d.hpp
+++ b/src/clib/dust/calc_tdust_3d.hpp
@@ -26,8 +26,8 @@ namespace GRIMPL_NAMESPACE_DECL {
 ///
 /// @par History
 /// written by: Britton Smith July 2011
-void calc_tdust_3d(gr_float* gas_temp_data_, gr_float* dust_temp_data_,
-                   int imetal, chemistry_data* my_chemistry,
+void calc_tdust_3d(gr_float* dust_temp_data_, int imetal,
+                   chemistry_data* my_chemistry,
                    chemistry_data_storage* my_rates,
                    grackle_field_data* my_fields, InternalGrUnits internalu);
 


### PR DESCRIPTION
This PR moves has `calc_tdust_3d` directly compute the gas temperature. The current implementation does marginally more work (i.e. it computes the number density of electrons), it uses quite a bit less memory in grid-based simulation codes.

The gas temperature calculation is more consistent with the internals of the full chemistry solve. It's on my todo list to do something similar with the calculate_temperature api function, but that's beyond the scope of this PR.[^1]

> [!note]
> Because the precise temperature calculation logic changes and this will affect the exact dust temperatures computed by `local_calculate_dust_temperature`, the gold standard probably needs to be updated (but we **may** get lucky).

The main impetus for this PR is to start computing a row of `metallicity` values in the same way as the other parts of the codebase. This will help me wrap up PR #546.

[^1]: For some context, when `primordial_chemistry>0` the precise algorithm for computing T and gamma are different from the internal logic. For `primordial_chemistry=1`, I suspect that this will just be a rounding difference (from reordering floating point operations). For `primordial_chemistry>1`, I think the difference may be slightly more significant.