### PR TITLE
[newchem-cpp] `calc_temp1d_cloudy`, `cool1d_cloudy`: fix redshift interpolation Bug

### DIFF
--- a/src/clib/tabulated/calc_temp1d_cloudy.cpp
+++ b/src/clib/tabulated/calc_temp1d_cloudy.cpp
@@ -56,7 +56,6 @@ void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
 
   int i, ti;
   double inv_log10, muold, munew;
-  long long end_int;
 
   // Slice locals
 
@@ -66,8 +65,6 @@ void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
   // \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////
   // =======================================================================
 
-  end_int = 0;
-
   inv_log10 = 1. / std::log(10.);
 
   // Calculate parameter value slopes
@@ -75,7 +72,8 @@ void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
       tabulated_detail::param_deltas(cloudy_table);
 
   // Calculate index for redshift dimension
-  const long long zindex = tabulated_detail::find_zindex(zr, cloudy_table);
+  const tabulated_detail::FindZIndexRslt zindex_pair =
+      tabulated_detail::find_zindex(zr, cloudy_table);
 
   for (i = my_fields->grid_start[0]; i <= my_fields->grid_end[0]; i++) {
     if (itmask[i] != MASK_FALSE) {
@@ -122,9 +120,10 @@ void calc_temp1d_cloudy(const double* rhoH, double* tgas, double* mmw,
               log_n_h[i], zr, log10tem[i],
               cloudy_table.grid_dimension,  // 3 elements
               cloudy_table.grid_parameters[0], dclPar[0],
-              cloudy_table.grid_parameters[1], zindex,
+              cloudy_table.grid_parameters[1], zindex_pair.zindex,
               cloudy_table.grid_parameters[2], dclPar[2],
-              cloudy_table.data_size, cloudy_table.mmw_data, end_int);
+              cloudy_table.data_size, cloudy_table.mmw_data,
+              zindex_pair.end_int);
         } else {
           printf("Maximum mmw data grid rank is 3!\n");
           return;

--- a/src/clib/tabulated/common.hpp
+++ b/src/clib/tabulated/common.hpp
@@ -36,6 +36,21 @@ inline std::array<double, MAX_RANK> param_deltas(const cloudy_data& table) {
   return out;
 }
 
+/// @brief Encodes the result of @ref find_zindex
+///
+/// @todo After PR #384 has been merged, we should try to adjust the redshift
+///       index so that it is now zero-indexed. I feel pretty strongly that we
+///       should also transition from using `long long` values to `int64_t`
+struct FindZIndexRslt {
+  /// The one-indexed redshift index
+  long long zindex;
+  /// Denotes whether the redshift is at the edge of the interpolation grid
+  ///
+  /// A value of 1 indicates that we should just interpolate from just the last
+  /// redshift slice in the datacube
+  long long end_int;
+};
+
 /// retrieve the index along the redshift dimension, most closely associated
 /// with @p z from a cloudy table, \p table (using bisection)
 ///
@@ -45,14 +60,10 @@ inline std::array<double, MAX_RANK> param_deltas(const cloudy_data& table) {
 /// @param table the cloudy table
 ///
 /// @returns The one-indexed redshift index
-///
-/// @todo After PR #394 has been merged, we should try to adjust the redshift
-///       index so that it is now zero-indexed. I fell pretty strongly that we
-///       should also transition from using `long long` values to `int64_t`
-[[gnu::always_inline]] inline long long find_zindex(double z,
-                                                    const cloudy_data& table) {
+[[gnu::always_inline]] inline FindZIndexRslt find_zindex(
+    double z, const cloudy_data& table) {
   if (table.grid_rank <= 2) {
-    return 1LL;
+    return {1LL, 0LL};
   }
 
   // reminder (since this looks wrong at a quick glance):
@@ -63,11 +74,11 @@ inline std::array<double, MAX_RANK> param_deltas(const cloudy_data& table) {
   const double* z_vals = table.grid_parameters[1];
   const long long n_vals = table.grid_dimension[1];
   if (z <= z_vals[0]) {
-    return 1LL;
+    return {1LL, 0LL};
   } else if (z >= z_vals[n_vals - 2]) {
-    return n_vals;
+    return {n_vals, 1LL};
   } else if (z >= z_vals[n_vals - 3]) {
-    return n_vals - 2;
+    return {n_vals - 2, 0LL};
   } else {
     long long zindex = 1;
     long long zhighpt = n_vals - 2;
@@ -79,7 +90,7 @@ inline std::array<double, MAX_RANK> param_deltas(const cloudy_data& table) {
         zhighpt = zmidpt;
       }
     }
-    return zindex;
+    return {zindex, 0LL};
   }
 }
 

--- a/src/clib/tabulated/cool1d_cloudy.cpp
+++ b/src/clib/tabulated/cool1d_cloudy.cpp
@@ -35,7 +35,6 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
 
   int i, get_heat;
   double inv_log10, log10_tCMB;
-  long long end_int;
 
   // Slice locals
 
@@ -49,7 +48,6 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
   // \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/////////////////////////////////
   // =======================================================================
 
-  end_int = 0;
   get_heat = iClHeat;
 
   inv_log10 = 1. / std::log(10.);
@@ -61,7 +59,8 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
       tabulated_detail::param_deltas(cloudy_table);
 
   // Calculate index for redshift dimension
-  const long long zindex = tabulated_detail::find_zindex(zr, cloudy_table);
+  const tabulated_detail::FindZIndexRslt zindex_pair =
+      tabulated_detail::find_zindex(zr, cloudy_table);
 
   for (i = idx_range.i_start; i <= idx_range.i_end; i++) {
     if (itmask[i] != MASK_FALSE) {
@@ -131,9 +130,9 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
         log_cool[i] = grackle::impl::fortran_wrapper::interpolate_3dz_g(
             log_n_h[i], zr, log10tem[i], cloudy_table.grid_dimension,
             cloudy_table.grid_parameters[0], dclPar[0],
-            cloudy_table.grid_parameters[1], zindex,
+            cloudy_table.grid_parameters[1], zindex_pair.zindex,
             cloudy_table.grid_parameters[2], dclPar[2], cloudy_table.data_size,
-            cloudy_table.cooling_data, end_int);
+            cloudy_table.cooling_data, zindex_pair.end_int);
         edot_met[i] = -std::pow(10., log_cool[i]);
 
         // Ignore CMB term if T >> T_CMB
@@ -141,9 +140,10 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
           log_cool_cmb[i] = grackle::impl::fortran_wrapper::interpolate_3dz_g(
               log_n_h[i], zr, log10_tCMB, cloudy_table.grid_dimension,
               cloudy_table.grid_parameters[0], dclPar[0],
-              cloudy_table.grid_parameters[1], zindex,
+              cloudy_table.grid_parameters[1], zindex_pair.zindex,
               cloudy_table.grid_parameters[2], dclPar[2],
-              cloudy_table.data_size, cloudy_table.cooling_data, end_int);
+              cloudy_table.data_size, cloudy_table.cooling_data,
+              zindex_pair.end_int);
           edot_met[i] = edot_met[i] + std::pow(10., log_cool_cmb[i]);
         }
 
@@ -151,9 +151,10 @@ void cool1d_cloudy(const double* rhoH, const double* metallicity,
           log_heat[i] = grackle::impl::fortran_wrapper::interpolate_3dz_g(
               log_n_h[i], zr, log10tem[i], cloudy_table.grid_dimension,
               cloudy_table.grid_parameters[0], dclPar[0],
-              cloudy_table.grid_parameters[1], zindex,
+              cloudy_table.grid_parameters[1], zindex_pair.zindex,
               cloudy_table.grid_parameters[2], dclPar[2],
-              cloudy_table.data_size, cloudy_table.heating_data, end_int);
+              cloudy_table.data_size, cloudy_table.heating_data,
+              zindex_pair.end_int);
           edot_met[i] = edot_met[i] + std::pow(10., log_heat[i]);
         }
 


### PR DESCRIPTION
This PR fixes a redshift interpolation bug that I had accidentally introduced when I previously factored `find z_index` out of the functions.

I had been intending to write some explicit unit tests to check the control flow so that this sort of case never happens again, but never quite got to it. (And I think it's extremely important for us to merge in these bugfixes -- before we forget about them)