### PR TITLE
[newchem-cpp] ratequery rate-fetching-recipes now report the array shapes of fetched recipes

### DIFF
--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -141,16 +141,16 @@ static void initialize_empty_chemistry_data_storage_struct(chemistry_data_storag
   my_rates->opaque_storage = NULL;
 }
 
-/// core logic of local_initialize_chemistry_data_
-///
-/// @note
-/// This has been separated from local_initialize_chemistry_data to ensure that
-/// any memory allocations tracked by reg_builder can be appropriately freed
-/// (this is somewhat unavoidable in C++ without destructors)
-static int local_initialize_chemistry_data_(
+extern "C" int local_initialize_chemistry_data(
     chemistry_data *my_chemistry, chemistry_data_storage *my_rates,
-    code_units *my_units, grackle::impl::ratequery::RegBuilder* reg_builder)
+    code_units *my_units)
 {
+  // Here we will default construct an empty RegBuilder
+  // -> as we move through this function, we will register various
+  //    kinds of rate-related quantities
+  // -> if all goes well with initialization, we'll use it to construct
+  //    a ratequery::Registry object
+  GRIMPL_NS::ratequery::RegBuilder reg_builder;
 
   /* Better safe than sorry: Initialize everything to NULL/0 */
   initialize_empty_chemistry_data_storage_struct(my_rates);
@@ -346,7 +346,7 @@ static int local_initialize_chemistry_data_(
   // Compute rate tables.
   if (grackle::impl::initialize_rates(my_chemistry, my_rates, my_units,
                                       co_length_units, co_density_units,
-                                      reg_builder)
+                                      &reg_builder)
       != GR_SUCCESS) {
     fprintf(stderr, "Error in initialize_rates.\n");
     return GR_FAIL;
@@ -385,15 +385,15 @@ static int local_initialize_chemistry_data_(
   my_rates->initial_units = *my_units;
 
   // add some miscellaneous recipes for looking up rates to reg_builder
-  if (GRIMPL_NS::ratequery::add_misc_recipies_to_RegBuilder(reg_builder,
+  if (GRIMPL_NS::ratequery::add_misc_recipies_to_RegBuilder(&reg_builder,
                                                             my_chemistry)
       != GR_SUCCESS){
     return GrPrintAndReturnErr("error in add_misc_recipies_to_RegBuilder");
   }
 
   // initialize the registry
-  my_rates->opaque_storage->registry = new grackle::impl::ratequery::Registry(
-    grackle::impl::ratequery::RegBuilder_consume_and_build(reg_builder)
+  my_rates->opaque_storage->registry = new GRIMPL_NS::ratequery::Registry(
+    GRIMPL_NS::ratequery::RegBuilder_consume_and_build(&reg_builder)
   );
 
   if (grackle_verbose) {
@@ -459,20 +459,6 @@ static int local_initialize_chemistry_data_(
   }
 
   return GR_SUCCESS;
-}
-
-
-extern "C" int local_initialize_chemistry_data(chemistry_data *my_chemistry,
-                                               chemistry_data_storage *my_rates,
-                                               code_units *my_units)
-{
-  namespace rate_q = grackle::impl::ratequery;
-  rate_q::RegBuilder reg_builder = rate_q::new_RegBuilder();
-
-  int out = local_initialize_chemistry_data_(my_chemistry, my_rates, my_units,
-                                             &reg_builder);
-  rate_q::drop_RegBuilder(&reg_builder);
-  return out;
 }
 
 extern "C" int initialize_chemistry_data(code_units *my_units)

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -393,7 +393,7 @@ extern "C" int local_initialize_chemistry_data(
 
   // initialize the registry
   my_rates->opaque_storage->registry = new GRIMPL_NS::ratequery::Registry(
-    GRIMPL_NS::ratequery::RegBuilder_consume_and_build(&reg_builder)
+    reg_builder.consume_and_build()
   );
 
   if (grackle_verbose) {

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -384,12 +384,14 @@ static int local_initialize_chemistry_data_(
   /* store a copy of the initial units */
   my_rates->initial_units = *my_units;
 
-  // initialize the registry
-  if (grackle::impl::ratequery::RegBuilder_misc_recipies(reg_builder,
-                                                         my_chemistry)
+  // add some miscellaneous recipes for looking up rates to reg_builder
+  if (GRIMPL_NS::ratequery::add_misc_recipies_to_RegBuilder(reg_builder,
+                                                            my_chemistry)
       != GR_SUCCESS){
-    return GrPrintAndReturnErr("error in RegBuilder_misc_recipies");
+    return GrPrintAndReturnErr("error in add_misc_recipies_to_RegBuilder");
   }
+
+  // initialize the registry
   my_rates->opaque_storage->registry = new grackle::impl::ratequery::Registry(
     grackle::impl::ratequery::RegBuilder_consume_and_build(reg_builder)
   );

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -516,6 +516,11 @@ int grackle::impl::initialize_rates(
       }
     }
 
+    // store NumberOfTemperatureBins inside of opaque_storage. This is a crude
+    // hack so ratequery machinery can infer shapes without my_chemistry
+    my_rates->opaque_storage->NumberOfTemperatureBins =
+        my_chemistry->NumberOfTemperatureBins;
+
     int anyDust;
     if ( my_chemistry->h2_on_dust > 0 || my_chemistry->dust_chemistry > 0 || my_chemistry->dust_recombination_cooling > 0) {
         anyDust = TRUE;

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -630,10 +630,8 @@ int grackle::impl::initialize_rates(
       }
 
       // register the recipe for looking up the "standard" collisional rates
-      if (reg_builder->recipe_1d(CollisionalRxnLUT::NUM_ENTRIES,
-                                 &get_CollisionalRxn_Entry,
-                                 my_chemistry->NumberOfTemperatureBins
-          ) != GR_SUCCESS) {
+      if (reg_builder->recipe(CollisionalRxnLUT::NUM_ENTRIES,
+                              &get_CollisionalRxn_Entry) != GR_SUCCESS) {
         return GrPrintAndReturnErr("error registering standard collisional "
                                    "reaction rates");
       }
@@ -654,9 +652,7 @@ int grackle::impl::initialize_rates(
         add_k13dd_reaction_rate(&my_rates->k13dd, kUnit, my_chemistry);
 
         // maybe k13dd should be considered multi-dimensional?
-        if (reg_builder->recipe_1d(1, &get_k13dd_Entry,
-                                   my_chemistry->NumberOfTemperatureBins * 14
-             ) != GR_SUCCESS) {
+        if (reg_builder->recipe(1, &get_k13dd_Entry) != GR_SUCCESS) {
           return GrPrintAndReturnErr("error registering k13dd rate");
         }
 

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -56,6 +56,7 @@
 #include "interp_grid.hpp"
 #include "opaque_storage.hpp" // gr_opaque_storage
 #include "phys_constants.h"
+#include "ratequery.hpp"
 #include "support/config.hpp"
 #include "support/status_reporting.hpp"
 
@@ -391,16 +392,19 @@ int init_kcol_rate_tables(
 ///
 /// @param my_rates The object from which the rate Entry is loaded
 /// @param i the index of the queried rate
-grackle::impl::ratequery::Entry get_CollisionalRxn_Entry
+GRIMPL_NS::ratequery::Entry get_CollisionalRxn_Entry
     (chemistry_data_storage* my_rates, int i) {
+  namespace rateq = GRIMPL_NS::ratequery;
+
   // sanity check! (this shouldn't actually happen)
   if ((my_rates == nullptr) || (my_rates->opaque_storage == nullptr) ||
       (my_rates->opaque_storage->kcol_rate_tables == nullptr)) {
-    return grackle::impl::ratequery::mk_invalid_Entry();
+    return rateq::mk_invalid_Entry();
   }
 
-  // import new_Entry into the current scope (so we don't need the full name)
-  using ::grackle::impl::ratequery::new_Entry;
+  // all entries share a common shape
+  int len = my_rates->opaque_storage->NumberOfTemperatureBins;
+  rateq::EntryShape shape = rateq::EntryShape::create_1d(len);
 
   double** data = my_rates->opaque_storage->kcol_rate_tables->data;
 
@@ -417,7 +421,9 @@ grackle::impl::ratequery::Entry get_CollisionalRxn_Entry
   switch (i) {
 #define TO_STR(s) #s
 #define ENTRY(NAME)                                                            \
-  case CollisionalRxnLUT::NAME: { return new_Entry(data[i], TO_STR(NAME)); }
+  case CollisionalRxnLUT::NAME: {                                              \
+    return new_Entry(data[i], TO_STR(NAME), shape);                            \
+  }
 #include "collisional_rxn_rate_members.def"
 
 #undef ENTRY
@@ -437,13 +443,15 @@ grackle::impl::ratequery::Entry get_CollisionalRxn_Entry
 ///
 /// @param my_rates The object from which the rate Entry is loaded
 /// @param i the index of the queried rate
-grackle::impl::ratequery::Entry get_k13dd_Entry(
-    chemistry_data_storage* my_rates, int i) {
-  if (i == 0) {
-    double* ptr = (my_rates == nullptr) ? nullptr : my_rates->k13dd;
-    return grackle::impl::ratequery::new_Entry(ptr, "k13dd");
+GRIMPL_NS::ratequery::Entry get_k13dd_Entry(chemistry_data_storage* my_rates,
+                                            int i) {
+  namespace rateq = GRIMPL_NS::ratequery;
+  if (i == 0 && my_rates != nullptr) {
+    int len = my_rates->opaque_storage->NumberOfTemperatureBins * 14;
+    return rateq::new_Entry(my_rates->k13dd, "k13dd",
+                            rateq::EntryShape::create_1d(len));
   } else {
-    return grackle::impl::ratequery::mk_invalid_Entry();
+    return rateq::mk_invalid_Entry();
   }
 }
 

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -617,9 +617,9 @@ int grackle::impl::initialize_rates(
       }
 
       // register the recipe for looking up the "standard" collisional rates
-      if (grackle::impl::ratequery::RegBuilder_recipe_1d(
-              reg_builder, CollisionalRxnLUT::NUM_ENTRIES,
-              &get_CollisionalRxn_Entry, my_chemistry->NumberOfTemperatureBins
+      if (reg_builder->recipe_1d(CollisionalRxnLUT::NUM_ENTRIES,
+                                 &get_CollisionalRxn_Entry,
+                                 my_chemistry->NumberOfTemperatureBins
           ) != GR_SUCCESS) {
         return GrPrintAndReturnErr("error registering standard collisional "
                                    "reaction rates");
@@ -641,9 +641,9 @@ int grackle::impl::initialize_rates(
         add_k13dd_reaction_rate(&my_rates->k13dd, kUnit, my_chemistry);
 
         // maybe k13dd should be considered multi-dimensional?
-        if (grackle::impl::ratequery::RegBuilder_recipe_1d(
-                reg_builder, 1, &get_k13dd_Entry,
-                my_chemistry->NumberOfTemperatureBins * 14) != GR_SUCCESS) {
+        if (reg_builder->recipe_1d(1, &get_k13dd_Entry,
+                                   my_chemistry->NumberOfTemperatureBins * 14
+             ) != GR_SUCCESS) {
           return GrPrintAndReturnErr("error registering k13dd rate");
         }
 

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -40,6 +40,8 @@
 #include <stdlib.h> 
 #include <stdio.h>
 #include <math.h>
+#include <climits>
+#include <limits>
 
 #include "grackle.h"
 #include "grackle_macros.h"
@@ -445,6 +447,57 @@ grackle::impl::ratequery::Entry get_k13dd_Entry(
   }
 }
 
+/// @brief Checks the set of input parameters for specifying a 1D ln(T) grid
+///
+/// There are 2 sets of parameters.
+/// 1. when @p gas_T is ``true``, we check the set of parameters that specify
+///    a grid of gas temperatures. This grid is used for the vast majority of
+///    1D interpolations of rates.
+/// 2. when @p gas_T is ``false``, we check the set of parameters that specify a
+///    grid of dust temperatures.
+///
+/// @return ``GR_SUCCESS`` indicates success. Other values indicate an error.
+int check_generic_lnT_params(const chemistry_data& chem, bool gas_T) {
+  // strictly speaking 
+  int num = (gas_T) ? chem.NumberOfTemperatureBins : 
+                      chem.NumberOfDustTemperatureBins;
+  double start = (gas_T) ? chem.TemperatureStart : chem.DustTemperatureStart;
+  double end = (gas_T) ? chem.TemperatureEnd : chem.DustTemperatureEnd;
+  const char* T_kind = (gas_T) ? "Temperature" : "DustTemperature";
+
+  // this is the lowest possible start value:
+  // -> keep in mind that std::numeric_limits<T>::min() returns the lowest
+  //    POSITIVE (non-subnormal) value represented by a floating point type, T
+  // -> it must be positive since interpolation occurs in log-space
+  // -> we currently forbid subnormal numbers because they can significantly
+  //    slow down calculations on some hardware. Plus, there isn't any value
+  //    in representing Temperatures that small (for astrophysics sims)
+  double lowest_start = std::numeric_limits<double>::min();
+
+  if (std::numeric_limits<double>::min() > start) {
+    return GrPrintAndReturnErr("error: %sStart param must be at least %.17e",
+                               T_kind, lowest_start);
+  } else if (start >= end) {
+    return GrPrintAndReturnErr("error: %sEnd param must exceed %sStart param",
+                               T_kind, T_kind);
+  } else if (num < 2) {
+    // technically, NumberOfTemperatureBins and NumberOfDustTemperatureBins are
+    // actually misnomers
+    // - "bins" typically refer to a set of non-overlapping intervals with
+    //   finite widths. You usually use bins to aggregate values (like in
+    //   histograms). It is possible to break an entire interval into a single
+    //   bin.
+    // - These parameters actually specify the number of interpolation points,
+    //   equally spaced in log-space. To perform linear interpolation, you
+    //   always need at least 2 interpolation points.
+    // (this distinction would matter less if the parameters referred to bin
+    // edges rather than bins)
+    return GrPrintAndReturnErr("error: NumberOf%sBins must exceed 1",
+                               T_kind);
+  } else {
+    return GR_SUCCESS;
+  }
+}
 
 } // anonymous namespace
 
@@ -454,20 +507,29 @@ int grackle::impl::initialize_rates(
   code_units *my_units, double co_length_unit, double co_density_unit,
   ratequery::RegBuilder* reg_builder)
 { 
-    // TODO: we REALLY need to do an error check that
-    //    my_chemistry->NumberOfTemperatureBins >= 2
-    //  is satisfied. We should give some thought about whether this should
-    //  produce errors when primordial_chemistry == 0
-
-    // TODO: also add error-checks for:
-    //   TemperatureStart, TemperatureEnd, NumberOfDustTemperatureBins,
-    //   DustTemperatureStart, DustTemperatureEnd
+    // check NumberOfTemperatureBins, Temperature(Start|End) params
+    // -> can we skip this when primordial_chemistry == 0?
+    {
+      int rc = check_generic_lnT_params(*my_chemistry, true);
+      if (rc != GR_SUCCESS) {
+        return rc;
+      }
+    }
 
     int anyDust;
     if ( my_chemistry->h2_on_dust > 0 || my_chemistry->dust_chemistry > 0 || my_chemistry->dust_recombination_cooling > 0) {
         anyDust = TRUE;
     } else {
         anyDust = FALSE;
+    }
+
+    // check NumberOfDustTemperatureBins, DustTemperature(Start|End) params
+    // -> can we skip this when primordial_chemistry == 0?
+    if (anyDust) {
+      int rc = check_generic_lnT_params(*my_chemistry, false);
+      if (rc != GR_SUCCESS) {
+        return rc;
+      }
     }
 
     //* Obtain the conversion factors which convert between code and physical units. We define a_value = 1 at z = zInit such that a = a_value * [a].

--- a/src/clib/inject_model/load_data.cpp
+++ b/src/clib/inject_model/load_data.cpp
@@ -162,8 +162,7 @@ int configure_RegBuilder(const chemistry_data_storage* my_rates,
 
   // the length of each gas nuclide yield array is equal to the number of
   // injection pathways
-  if (reg_builder->recipe_1d(7, &nuclide_gas_yield_recipe, n_pathways) !=
-      GR_SUCCESS) {
+  if (reg_builder->recipe(7, &nuclide_gas_yield_recipe) != GR_SUCCESS) {
     return GrPrintAndReturnErr(
         "There was an issue making nuclide gas yield fractions (for each "
         "injection pathway) queryable");
@@ -176,8 +175,8 @@ int configure_RegBuilder(const chemistry_data_storage* my_rates,
 
     // the length of each grain species yield array is equal to the number of
     // injection pathways
-    if (reg_builder->recipe_1d(n_grain_species, &grain_yield_recipe,
-                               n_pathways) != GR_SUCCESS) {
+    if (reg_builder->recipe(n_grain_species, &grain_yield_recipe) !=
+        GR_SUCCESS) {
       return GrPrintAndReturnErr(
           "There was an issue making nuclide gas yield fractions (for each "
           "injection pathway) queryable");

--- a/src/clib/inject_model/load_data.cpp
+++ b/src/clib/inject_model/load_data.cpp
@@ -152,8 +152,8 @@ int configure_RegBuilder(const chemistry_data_storage* my_rates,
 
   // the length of each gas nuclide yield array is equal to the number of
   // injection pathways
-  if (rateq::RegBuilder_recipe_1d(reg_builder, 7, &nuclide_gas_yield_recipe,
-                                  n_pathways) != GR_SUCCESS) {
+  if (reg_builder->recipe_1d(7, &nuclide_gas_yield_recipe, n_pathways) !=
+      GR_SUCCESS) {
     return GrPrintAndReturnErr(
         "There was an issue making nuclide gas yield fractions (for each "
         "injection pathway) queryable");
@@ -166,9 +166,8 @@ int configure_RegBuilder(const chemistry_data_storage* my_rates,
 
     // the length of each grain species yield array is equal to the number of
     // injection pathways
-    if (rateq::RegBuilder_recipe_1d(reg_builder, n_grain_species,
-                                    &grain_yield_recipe,
-                                    n_pathways) != GR_SUCCESS) {
+    if (reg_builder->recipe_1d(n_grain_species, &grain_yield_recipe,
+                               n_pathways) != GR_SUCCESS) {
       return GrPrintAndReturnErr(
           "There was an issue making nuclide gas yield fractions (for each "
           "injection pathway) queryable");

--- a/src/clib/inject_model/load_data.cpp
+++ b/src/clib/inject_model/load_data.cpp
@@ -11,11 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include <cstring>  // std::strcmp
-#include "../dust/grain_species_info.hpp"
 #include "grackle_chemistry_data.h"
+#include "grain_metal_inject_pathways.hpp"
 #include "load_data.hpp"  // forward declarations
-#include "interp_grid.hpp"
 #include "raw_data.hpp"
+#include "../dust/grain_species_info.hpp"
+#include "../interp_grid.hpp"
 #include "../LUT.hpp"
 #include "../opaque_storage.hpp"
 #include "../ratequery.hpp"
@@ -33,31 +34,35 @@ namespace {  // stuff inside an anonymous namespace is local to this file
 ///
 /// @param my_rates The object from which the rate Entry is loaded
 /// @param i the index of the queried rate
-grackle::impl::ratequery::Entry nuclide_gas_yield_recipe(
+GRIMPL_NS::ratequery::Entry nuclide_gas_yield_recipe(
     chemistry_data_storage* my_rates, int i) {
-  namespace rateq = grackle::impl::ratequery;
+  namespace rateq = GRIMPL_NS::ratequery;
   if ((my_rates == nullptr) || (my_rates->opaque_storage == nullptr) ||
       (my_rates->opaque_storage->inject_pathway_props == nullptr)) {
     return rateq::mk_invalid_Entry();
   }
-  const grackle::impl::yields::MetalTables& tab =
-      my_rates->opaque_storage->inject_pathway_props->gas_metal_nuclide_yields;
+  const GRIMPL_NS::GrainMetalInjectPathways* props =
+      my_rates->opaque_storage->inject_pathway_props;
+  const GRIMPL_NS::yields::MetalTables& tab = props->gas_metal_nuclide_yields;
+
+  // all entries share a common shape
+  rateq::EntryShape shape = rateq::EntryShape::create_1d(props->n_pathways);
 
   switch (i) {
     case 0:
-      return rateq::new_Entry(tab.C, "inject_path_gas_yield_frac.C");
+      return rateq::new_Entry(tab.C, "inject_path_gas_yield_frac.C", shape);
     case 1:
-      return rateq::new_Entry(tab.O, "inject_path_gas_yield_frac.O");
+      return rateq::new_Entry(tab.O, "inject_path_gas_yield_frac.O", shape);
     case 2:
-      return rateq::new_Entry(tab.Mg, "inject_path_gas_yield_frac.Mg");
+      return rateq::new_Entry(tab.Mg, "inject_path_gas_yield_frac.Mg", shape);
     case 3:
-      return rateq::new_Entry(tab.Al, "inject_path_gas_yield_frac.Al");
+      return rateq::new_Entry(tab.Al, "inject_path_gas_yield_frac.Al", shape);
     case 4:
-      return rateq::new_Entry(tab.Si, "inject_path_gas_yield_frac.Si");
+      return rateq::new_Entry(tab.Si, "inject_path_gas_yield_frac.Si", shape);
     case 5:
-      return rateq::new_Entry(tab.S, "inject_path_gas_yield_frac.S");
+      return rateq::new_Entry(tab.S, "inject_path_gas_yield_frac.S", shape);
     case 6:
-      return rateq::new_Entry(tab.Fe, "inject_path_gas_yield_frac.Fe");
+      return rateq::new_Entry(tab.Fe, "inject_path_gas_yield_frac.Fe", shape);
     default:
       return rateq::mk_invalid_Entry();
   }
@@ -81,57 +86,65 @@ grackle::impl::ratequery::Entry nuclide_gas_yield_recipe(
 /// 2. It would be advantageous to adopt key-names that are composed of 2
 ///    strings (that way we could reuse string-literals holding the grain
 ///    species names)
-grackle::impl::ratequery::Entry grain_yield_recipe(
-    chemistry_data_storage* my_rates, int i) {
-  namespace rateq = grackle::impl::ratequery;
+GRIMPL_NS::ratequery::Entry grain_yield_recipe(chemistry_data_storage* my_rates,
+                                               int i) {
+  namespace rateq = GRIMPL_NS::ratequery;
   if ((my_rates == nullptr) || (my_rates->opaque_storage == nullptr) ||
       (my_rates->opaque_storage->inject_pathway_props == nullptr)) {
     return rateq::mk_invalid_Entry();
   }
-  const grackle::impl::GrainSpeciesCollection& tab =
-      my_rates->opaque_storage->inject_pathway_props->grain_yields;
-  double* const* data = tab.data;
+  const GRIMPL_NS::GrainMetalInjectPathways* props =
+      my_rates->opaque_storage->inject_pathway_props;
+  double* const* data = props->grain_yields.data;
+
+  // all entries share a common shape
+  rateq::EntryShape shape = rateq::EntryShape::create_1d(props->n_pathways);
 
   switch (i) {
     case 0:
       return rateq::new_Entry(data[OnlyGrainSpLUT::MgSiO3_dust],
-                              "inject_path_grain_yield_frac.MgSiO3_dust");
+                              "inject_path_grain_yield_frac.MgSiO3_dust",
+                              shape);
     case 1:
       return rateq::new_Entry(data[OnlyGrainSpLUT::AC_dust],
-                              "inject_path_grain_yield_frac.AC_dust");
+                              "inject_path_grain_yield_frac.AC_dust", shape);
     case 2:
       return rateq::new_Entry(data[OnlyGrainSpLUT::SiM_dust],
-                              "inject_path_grain_yield_frac.SiM_dust");
+                              "inject_path_grain_yield_frac.SiM_dust", shape);
     case 3:
       return rateq::new_Entry(data[OnlyGrainSpLUT::FeM_dust],
-                              "inject_path_grain_yield_frac.FeM_dust");
+                              "inject_path_grain_yield_frac.FeM_dust", shape);
     case 4:
       return rateq::new_Entry(data[OnlyGrainSpLUT::Mg2SiO4_dust],
-                              "inject_path_grain_yield_frac.Mg2SiO4_dust");
+                              "inject_path_grain_yield_frac.Mg2SiO4_dust",
+                              shape);
     case 5:
       return rateq::new_Entry(data[OnlyGrainSpLUT::Fe3O4_dust],
-                              "inject_path_grain_yield_frac.Fe3O4_dust");
+                              "inject_path_grain_yield_frac.Fe3O4_dust", shape);
     case 6:
       return rateq::new_Entry(data[OnlyGrainSpLUT::SiO2_dust],
-                              "inject_path_grain_yield_frac.SiO2_dust");
+                              "inject_path_grain_yield_frac.SiO2_dust", shape);
     case 7:
       return rateq::new_Entry(data[OnlyGrainSpLUT::MgO_dust],
-                              "inject_path_grain_yield_frac.MgO_dust");
+                              "inject_path_grain_yield_frac.MgO_dust", shape);
     case 8:
       return rateq::new_Entry(data[OnlyGrainSpLUT::FeS_dust],
-                              "inject_path_grain_yield_frac.FeS_dust");
+                              "inject_path_grain_yield_frac.FeS_dust", shape);
     case 9:
       return rateq::new_Entry(data[OnlyGrainSpLUT::Al2O3_dust],
-                              "inject_path_grain_yield_frac.Al2O3_dust");
+                              "inject_path_grain_yield_frac.Al2O3_dust", shape);
     case 10:
       return rateq::new_Entry(data[OnlyGrainSpLUT::ref_org_dust],
-                              "inject_path_grain_yield_frac.ref_org_dust");
+                              "inject_path_grain_yield_frac.ref_org_dust",
+                              shape);
     case 11:
       return rateq::new_Entry(data[OnlyGrainSpLUT::vol_org_dust],
-                              "inject_path_grain_yield_frac.vol_org_dust");
+                              "inject_path_grain_yield_frac.vol_org_dust",
+                              shape);
     case 12:
       return rateq::new_Entry(data[OnlyGrainSpLUT::H2O_ice_dust],
-                              "inject_path_grain_yield_frac.H2O_ice_dust");
+                              "inject_path_grain_yield_frac.H2O_ice_dust",
+                              shape);
     default:
       return rateq::mk_invalid_Entry();
   }

--- a/src/clib/inject_model/load_data.cpp
+++ b/src/clib/inject_model/load_data.cpp
@@ -140,12 +140,9 @@ grackle::impl::ratequery::Entry grain_yield_recipe(
 int configure_RegBuilder(const chemistry_data_storage* my_rates,
                          grackle::impl::ratequery::RegBuilder* reg_builder,
                          const char* const* inj_path_name_l, int n_pathways) {
-  namespace rateq = grackle::impl::ratequery;
-
   // make list of pathway names available to users through the ratequery API
-  if (rateq::RegBuilder_copied_str_arr1d(reg_builder, "inject_model_names",
-                                         inj_path_name_l,
-                                         n_pathways) != GR_SUCCESS) {
+  if (reg_builder->copied_str_arr1d("inject_model_names", inj_path_name_l,
+                                    n_pathways) != GR_SUCCESS) {
     return GrPrintAndReturnErr(
         "There was an issue making names of inject pathways queryable");
   }

--- a/src/clib/opaque_storage.cpp
+++ b/src/clib/opaque_storage.cpp
@@ -45,9 +45,7 @@ gr_opaque_storage::~gr_opaque_storage() {
   }
 
   if (registry != nullptr) {
-    // delete contents of registry
-    grackle::impl::ratequery::drop_Registry(registry);
-    // delete registry, itself
+    // delete will trigger the Registry's destructor
     delete registry;
   }
 }

--- a/src/clib/opaque_storage.hpp
+++ b/src/clib/opaque_storage.hpp
@@ -68,6 +68,25 @@ struct gr_opaque_storage {
   int n_kcol_rate_indices = 0;
   ///@}
 
+  /// Tracks the number of entries in the standard ln(T_gas) grid used for the
+  /// vast majority of 1D temperature values.
+  ///
+  /// This should be an EXACT copy of the value tracked by the
+  /// @ref chemistry_data::NumberOfTemperatureBins data member of the
+  /// @ref chemistry_data struct that was used to initialize the current
+  /// storage object.
+  ///
+  /// This exists as a kind of crude hack to allow the callback functions used
+  /// by the ratequery machinery to infer the shapes of a bunch rate arrays
+  /// (as written, it would be non-trivial for that machinery to access
+  /// this value from my_chemistry).
+  ///
+  /// @note
+  /// As already noted elsewhere, the name of this member is something of a
+  /// misnomer. It probably would be better to call it something like
+  /// NumberOfTemperatureInterpPoints
+  int NumberOfTemperatureBins;
+
   /// tracks the grid of values used for interpolating grain-species specific
   /// coefficients for computing rates of H2 formation on dust grains. (At the
   /// time of writing, chemistry_data_storage::h2dustS &

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -219,14 +219,14 @@ RegBuilder::~RegBuilder() noexcept {
 }
 
 int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
-  EntryShape common_props = mk_invalid_EntryShape();
+  EntryShape common_props = EntryShape::create_invalid();
   common_props.ndim = 0;
   return recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
                           int common_len) {
-  EntryShape common_props = mk_invalid_EntryShape();
+  EntryShape common_props = EntryShape::create_invalid();
   common_props.ndim = 1;
   common_props.shape[0] = common_len;
   return recipe_(recipe_fn, n_entries, common_props);
@@ -244,7 +244,7 @@ int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,
     std::memcpy(my_copy[i], str_arr1d[i], nbytes);
   }
   PtrUnion data(const_cast<const char* const*>(my_copy));
-  EntryShape props = mk_invalid_EntryShape();
+  EntryShape props = EntryShape::create_invalid();
   props.ndim = 1;
   props.shape[0] = len;
   return take_data_(name, data, props);
@@ -258,7 +258,7 @@ int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
   double* my_copy = new double[len];
   std::memcpy(my_copy, f64_arr1d, sizeof(double) * len);
   PtrUnion data(const_cast<const double*>(my_copy));
-  EntryShape props = mk_invalid_EntryShape();
+  EntryShape props = EntryShape::create_invalid();
   props.ndim = 1;
   props.shape[0] = len;
   return take_data_(name, data, props);

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -171,9 +171,8 @@ EntrySet::~EntrySet() noexcept {
   }
 }
 
-/// Helper function that takes ownership of owned_data
-static int RegBuilder_take_data_(RegBuilder* ptr, const char* raw_name,
-                                 PtrUnion owned_data, EntryProps props) {
+int RegBuilder::take_data_(const char* raw_name, PtrUnion owned_data,
+                           EntryProps props) {
   if (raw_name == nullptr) {
     return GrPrintAndReturnErr("raw_name is a nullptr");
   } else if (owned_data.is_null()) {
@@ -193,12 +192,12 @@ static int RegBuilder_take_data_(RegBuilder* ptr, const char* raw_name,
   tmp.data = owned_data;
   tmp.name = name;
   tmp.props = props;
-  ptr->owned_entries.push_back(tmp);
+  owned_entries.push_back(tmp);
   return GR_SUCCESS;
 }
 
-static int RegBuilder_recipe_(RegBuilder* ptr, fetch_Entry_recipe_fn* recipe_fn,
-                              int n_entries, EntryProps common_props) {
+int RegBuilder::recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
+                        EntryProps common_props) {
   if (recipe_fn == nullptr) {
     return GrPrintAndReturnErr("recipe_fn is a nullptr");
   } else if (n_entries <= 0) {
@@ -207,7 +206,7 @@ static int RegBuilder_recipe_(RegBuilder* ptr, fetch_Entry_recipe_fn* recipe_fn,
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
-  ptr->recipe_sets.emplace_back(n_entries, recipe_fn, common_props);
+  recipe_sets.emplace_back(n_entries, recipe_fn, common_props);
 
   return GR_SUCCESS;
 }
@@ -224,7 +223,7 @@ int RegBuilder_recipe_scalar(RegBuilder* ptr, int n_entries,
                              fetch_Entry_recipe_fn* recipe_fn) {
   EntryProps common_props = mk_invalid_EntryProps();
   common_props.ndim = 0;
-  return RegBuilder_recipe_(ptr, recipe_fn, n_entries, common_props);
+  return ptr->recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,
@@ -232,7 +231,7 @@ int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,
   EntryProps common_props = mk_invalid_EntryProps();
   common_props.ndim = 1;
   common_props.shape[0] = common_len;
-  return RegBuilder_recipe_(ptr, recipe_fn, n_entries, common_props);
+  return ptr->recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,
@@ -250,7 +249,7 @@ int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,
   EntryProps props = mk_invalid_EntryProps();
   props.ndim = 1;
   props.shape[0] = len;
-  return RegBuilder_take_data_(ptr, name, data, props);
+  return ptr->take_data_(name, data, props);
 }
 
 int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
@@ -264,7 +263,7 @@ int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
   EntryProps props = mk_invalid_EntryProps();
   props.ndim = 1;
   props.shape[0] = len;
-  return RegBuilder_take_data_(ptr, name, data, props);
+  return ptr->take_data_(name, data, props);
 }
 
 /// build a new Registry.

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -83,8 +83,7 @@ static Entry get_PhotoRxn_Entry(chemistry_data_storage* my_rates, int i) {
 int add_misc_recipies_to_RegBuilder(RegBuilder* ptr,
                                     const chemistry_data* my_chemistry) {
   if (my_chemistry->primordial_chemistry != 0) {
-    return RegBuilder_recipe_scalar(ptr, PhotoRxnLUT::NUM_ENTRIES,
-                                    &get_PhotoRxn_Entry);
+    return ptr->recipe_scalar(PhotoRxnLUT::NUM_ENTRIES, &get_PhotoRxn_Entry);
   }
   return GR_SUCCESS;
 }
@@ -219,11 +218,10 @@ RegBuilder::~RegBuilder() noexcept {
   }
 }
 
-int RegBuilder_recipe_scalar(RegBuilder* ptr, int n_entries,
-                             fetch_Entry_recipe_fn* recipe_fn) {
+int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
   EntryProps common_props = mk_invalid_EntryProps();
   common_props.ndim = 0;
-  return ptr->recipe_(recipe_fn, n_entries, common_props);
+  return recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -151,21 +151,19 @@ static void drop_owned_Entry_list_contents(Entry* entry_list,
   }
 }
 
-Entry EntrySet_access(const EntrySet* entry_set,
-                      chemistry_data_storage* my_rates, int i) {
-  if (entry_set->embedded_list.empty()) {  // in recipe-mode
-    if ((i < 0) || (i >= entry_set->len)) {
+Entry EntrySet::access(chemistry_data_storage* my_rates, int i) const {
+  if (embedded_list.empty()) {  // in recipe-mode
+    if ((i < 0) || (i >= len)) {
       return mk_invalid_Entry();
     }
-    Entry out = (entry_set->recipe_fn)(my_rates, i);
-    out.props = entry_set->common_recipe_props;
+    Entry out = (recipe_fn)(my_rates, i);
+    out.props = common_recipe_props;
     return out;
   } else {  // in embedded-list mode
-    if ((i < 0) ||
-        (static_cast<std::size_t>(i) >= entry_set->embedded_list.size())) {
+    if ((i < 0) || (static_cast<std::size_t>(i) >= embedded_list.size())) {
       return mk_invalid_Entry();
     }
-    return entry_set->embedded_list[i];
+    return embedded_list[i];
   }
 }
 
@@ -300,7 +298,7 @@ Registry RegBuilder_consume_and_build(RegBuilder* ptr) {
     int tot_entry_count = 0;
     for (int i = 0; i < n_sets; i++) {
       id_offsets[i] = tot_entry_count;
-      tot_entry_count += EntrySet_size(&ptr->recipe_sets[i]);
+      tot_entry_count += ptr->recipe_sets[i].size();
     }
     return Registry{tot_entry_count, id_offsets, std::move(ptr->recipe_sets)};
   }
@@ -347,8 +345,8 @@ static ratequery_rslt_ query_Entry(chemistry_data_storage* my_rates,
   for (std::size_t set_idx = 0; set_idx < n_sets; set_idx++) {
     EntrySet* cur_set = &registry->sets[set_idx];
     int tmp = i - registry->id_offsets[set_idx];
-    if ((tmp >= 0) && (tmp < EntrySet_size(cur_set))) {
-      return ratequery_rslt_{i, EntrySet_access(cur_set, my_rates, tmp)};
+    if ((tmp >= 0) && (tmp < cur_set->size())) {
+      return ratequery_rslt_{i, cur_set->access(my_rates, tmp)};
     }
   }
   return invalid_rslt_();
@@ -402,10 +400,10 @@ extern "C" grunstable_rateid_type grunstable_ratequery_id(
   std::size_t n_sets = registry->sets.size();
   for (std::size_t set_idx = 0; set_idx < n_sets; set_idx++) {
     const rate_q::EntrySet* set = &registry->sets[set_idx];
-    int set_len = EntrySet_size(set);
+    int set_len = set->size();
     for (int i = 0; i < set_len; i++) {
-      rate_q::Entry entry = rate_q::EntrySet_access(
-          set, const_cast<chemistry_data_storage*>(my_rates), i);
+      rate_q::Entry entry =
+          set->access(const_cast<chemistry_data_storage*>(my_rates), i);
       // todo: figure out how to give enough compiler hints so we can remove
       //       this nullptr-check
       GR_INTERNAL_REQUIRE(entry.name != nullptr, "sanity check!");

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -232,8 +232,8 @@ int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
   return recipe_(recipe_fn, n_entries, common_props);
 }
 
-int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,
-                                const char* const* str_arr1d, int len) {
+int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,
+                                 int len) {
   if (len <= 0) {
     return GrPrintAndReturnErr("len must be positive");
   }
@@ -247,11 +247,11 @@ int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,
   EntryProps props = mk_invalid_EntryProps();
   props.ndim = 1;
   props.shape[0] = len;
-  return ptr->take_data_(name, data, props);
+  return take_data_(name, data, props);
 }
 
-int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
-                                const double* f64_arr1d, int len) {
+int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
+                                 int len) {
   if (len <= 0) {
     return GrPrintAndReturnErr("len must be positive");
   }
@@ -261,7 +261,7 @@ int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
   EntryProps props = mk_invalid_EntryProps();
   props.ndim = 1;
   props.shape[0] = len;
-  return ptr->take_data_(name, data, props);
+  return take_data_(name, data, props);
 }
 
 /// build a new Registry.

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -224,12 +224,12 @@ int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
   return recipe_(recipe_fn, n_entries, common_props);
 }
 
-int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,
-                         fetch_Entry_recipe_fn* recipe_fn, int common_len) {
+int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
+                          int common_len) {
   EntryProps common_props = mk_invalid_EntryProps();
   common_props.ndim = 1;
   common_props.shape[0] = common_len;
-  return ptr->recipe_(recipe_fn, n_entries, common_props);
+  return recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -169,15 +169,11 @@ Entry EntrySet_access(const EntrySet* entry_set,
   }
 }
 
-void drop_EntrySet(EntrySet* ptr) {
-  if (ptr->embedded_list.empty()) {
-    // nothing to deallocate in recipe-mode
-  } else {
+EntrySet::~EntrySet() noexcept {
+  if (!embedded_list.empty()) {
     // in embedded-list-mode, we need to deallocate each Entry in the list
     // and the deallocate the actual list-pointer
-    drop_owned_Entry_list_contents(ptr->embedded_list.data(),
-                                   ptr->embedded_list.size());
-    ptr->embedded_list.clear();  // <- makes repeated calls to drop safer
+    drop_owned_Entry_list_contents(embedded_list.data(), embedded_list.size());
   }
 }
 
@@ -217,8 +213,7 @@ static int RegBuilder_recipe_(RegBuilder* ptr, fetch_Entry_recipe_fn* recipe_fn,
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
-  ptr->recipe_sets.push_back(
-      EntrySet{n_entries, std::vector<Entry>(), recipe_fn, common_props});
+  ptr->recipe_sets.emplace_back(n_entries, recipe_fn, common_props);
 
   return GR_SUCCESS;
 }
@@ -292,12 +287,7 @@ int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
 Registry RegBuilder_consume_and_build(RegBuilder* ptr) {
   // try to construct an EntrySet that contains all owned entries
   if (!ptr->owned_entries.empty()) {
-    int len = ptr->owned_entries.size();
-    EntrySet tmp{/* len = */ len,
-                 /* embedded_list = */ std::move(ptr->owned_entries),
-                 /* recipe_fn = */ nullptr,
-                 /* common_recipe_props = */ mk_invalid_EntryProps()};
-    ptr->recipe_sets.push_back(tmp);
+    ptr->recipe_sets.emplace_back(std::move(ptr->owned_entries));
   }
 
   // now actually set up the registry
@@ -313,16 +303,6 @@ Registry RegBuilder_consume_and_build(RegBuilder* ptr) {
       tot_entry_count += EntrySet_size(&ptr->recipe_sets[i]);
     }
     return Registry{tot_entry_count, id_offsets, std::move(ptr->recipe_sets)};
-  }
-}
-
-Registry::~Registry() {
-  if (sets.empty()) {
-    delete[] id_offsets;
-    std::size_t n_sets = sets.size();
-    for (std::size_t i = 0; i < n_sets; i++) {
-      drop_EntrySet(&sets[i]);
-    }
   }
 }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -219,17 +219,12 @@ RegBuilder::~RegBuilder() noexcept {
 }
 
 int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
-  EntryShape common_props = EntryShape::create_invalid();
-  common_props.ndim = 0;
-  return recipe_(recipe_fn, n_entries, common_props);
+  return recipe_(recipe_fn, n_entries, EntryShape::create_scalar());
 }
 
 int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
                           int common_len) {
-  EntryShape common_props = EntryShape::create_invalid();
-  common_props.ndim = 1;
-  common_props.shape[0] = common_len;
-  return recipe_(recipe_fn, n_entries, common_props);
+  return recipe_(recipe_fn, n_entries, EntryShape::create_1d(common_len));
 }
 
 int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,
@@ -244,10 +239,7 @@ int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,
     std::memcpy(my_copy[i], str_arr1d[i], nbytes);
   }
   PtrUnion data(const_cast<const char* const*>(my_copy));
-  EntryShape props = EntryShape::create_invalid();
-  props.ndim = 1;
-  props.shape[0] = len;
-  return take_data_(name, data, props);
+  return take_data_(name, data, EntryShape::create_1d(len));
 }
 
 int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
@@ -258,10 +250,7 @@ int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
   double* my_copy = new double[len];
   std::memcpy(my_copy, f64_arr1d, sizeof(double) * len);
   PtrUnion data(const_cast<const double*>(my_copy));
-  EntryShape props = EntryShape::create_invalid();
-  props.ndim = 1;
-  props.shape[0] = len;
-  return take_data_(name, data, props);
+  return take_data_(name, data, EntryShape::create_1d(len));
 }
 
 Registry RegBuilder::consume_and_build() {

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -83,7 +83,7 @@ static Entry get_PhotoRxn_Entry(chemistry_data_storage* my_rates, int i) {
 int add_misc_recipies_to_RegBuilder(RegBuilder* ptr,
                                     const chemistry_data* my_chemistry) {
   if (my_chemistry->primordial_chemistry != 0) {
-    return ptr->recipe_scalar(PhotoRxnLUT::NUM_ENTRIES, &get_PhotoRxn_Entry);
+    return ptr->recipe(PhotoRxnLUT::NUM_ENTRIES, &get_PhotoRxn_Entry);
   }
   return GR_SUCCESS;
 }
@@ -154,9 +154,7 @@ Entry EntrySet::access(chemistry_data_storage* my_rates, int i) const {
   if ((i < 0) || (i >= this->size())) {
     return mk_invalid_Entry();
   } else if (embedded_list.empty()) {  // in recipe-mode
-    Entry out = (recipe_fn)(my_rates, i);
-    out.props = common_recipe_props;
-    return out;
+    return (recipe_fn)(my_rates, i);
   } else {  // in embedded-list mode
     return embedded_list[i];
   }
@@ -195,18 +193,14 @@ int RegBuilder::take_data_(const char* raw_name, PtrUnion owned_data,
   return GR_SUCCESS;
 }
 
-int RegBuilder::recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
-                        EntryShape common_props) {
+int RegBuilder::recipe(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
   if (recipe_fn == nullptr) {
     return GrPrintAndReturnErr("recipe_fn is a nullptr");
   } else if (n_entries <= 0) {
     return GrPrintAndReturnErr("n_entries is not positive");
-  } else if (!common_props.is_valid()) {
-    return GrPrintAndReturnErr("common_props isn't valid");
   }
 
-  recipe_sets.emplace_back(n_entries, recipe_fn, common_props);
-
+  recipe_sets.emplace_back(n_entries, recipe_fn);
   return GR_SUCCESS;
 }
 
@@ -216,15 +210,6 @@ RegBuilder::~RegBuilder() noexcept {
     drop_owned_Entry_list_contents(owned_entries.data(), owned_entries.size());
     // the actual deletion of std::vector<Entry> is handled automatically
   }
-}
-
-int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
-  return recipe_(recipe_fn, n_entries, EntryShape::create_scalar());
-}
-
-int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
-                          int common_len) {
-  return recipe_(recipe_fn, n_entries, EntryShape::create_1d(common_len));
 }
 
 int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -178,7 +178,7 @@ int RegBuilder::take_data_(const char* raw_name, PtrUnion owned_data,
     return GrPrintAndReturnErr("owned_data holds a nullptr");
   } else if (!owned_data.is_const_ptr()) {
     return GrPrintAndReturnErr("owned_data isn't const");
-  } else if (!EntryShape_is_valid(props)) {
+  } else if (!props.is_valid()) {
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
@@ -201,7 +201,7 @@ int RegBuilder::recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
     return GrPrintAndReturnErr("recipe_fn is a nullptr");
   } else if (n_entries <= 0) {
     return GrPrintAndReturnErr("n_entries is not positive");
-  } else if (!EntryShape_is_valid(common_props)) {
+  } else if (!common_props.is_valid()) {
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
@@ -491,7 +491,7 @@ extern "C" int grunstable_ratequery_prop(
           .entry;
 
   const rate_q::EntryShape& props = entry.props;
-  if ((entry.name == nullptr) || !rate_q::EntryShape_is_valid(props)) {
+  if ((entry.name == nullptr) || !props.is_valid()) {
     return GR_FAIL;
   }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -59,21 +59,21 @@ static Entry get_PhotoRxn_Entry(chemistry_data_storage* my_rates, int i) {
   }
   switch (i) {
     case PhotoRxnLUT::k24:
-      return new_Entry(&my_rates->k24, "k24");
+      return new_Entry(&my_rates->k24, "k24", EntryShape::create_scalar());
     case PhotoRxnLUT::k25:
-      return new_Entry(&my_rates->k25, "k25");
+      return new_Entry(&my_rates->k25, "k25", EntryShape::create_scalar());
     case PhotoRxnLUT::k26:
-      return new_Entry(&my_rates->k26, "k26");
+      return new_Entry(&my_rates->k26, "k26", EntryShape::create_scalar());
     case PhotoRxnLUT::k27:
-      return new_Entry(&my_rates->k27, "k27");
+      return new_Entry(&my_rates->k27, "k27", EntryShape::create_scalar());
     case PhotoRxnLUT::k28:
-      return new_Entry(&my_rates->k28, "k28");
+      return new_Entry(&my_rates->k28, "k28", EntryShape::create_scalar());
     case PhotoRxnLUT::k29:
-      return new_Entry(&my_rates->k29, "k29");
+      return new_Entry(&my_rates->k29, "k29", EntryShape::create_scalar());
     case PhotoRxnLUT::k30:
-      return new_Entry(&my_rates->k30, "k30");
+      return new_Entry(&my_rates->k30, "k30", EntryShape::create_scalar());
     case PhotoRxnLUT::k31:
-      return new_Entry(&my_rates->k31, "k31");
+      return new_Entry(&my_rates->k31, "k31", EntryShape::create_scalar());
     default: {
       return mk_invalid_Entry();
     }

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -212,17 +212,11 @@ static int RegBuilder_recipe_(RegBuilder* ptr, fetch_Entry_recipe_fn* recipe_fn,
   return GR_SUCCESS;
 }
 
-void drop_RegBuilder(RegBuilder* ptr) {
-  // this first block is only done for consistency with other drop_ functions
-  // (unnecessary since no entry of recipe-sets holds any pointers to be freed)
-  if (!ptr->recipe_sets.empty()) {
-    ptr->recipe_sets.clear();
-  }
-  // this next block is very necessary!
-  if (!ptr->owned_entries.empty()) {
-    drop_owned_Entry_list_contents(ptr->owned_entries.data(),
-                                   ptr->owned_entries.size());
-    ptr->owned_entries.clear();  // <- make repeated calls of this fn safer
+RegBuilder::~RegBuilder() noexcept {
+  if (owned_entries.empty()) {
+    // this deletes the actual pointers in each tracked Entry
+    drop_owned_Entry_list_contents(owned_entries.data(), owned_entries.size());
+    // the actual deletion of std::vector<Entry> is handled automatically
   }
 }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -264,30 +264,25 @@ int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
   return take_data_(name, data, props);
 }
 
-/// build a new Registry.
-///
-/// In the process, the current Registry is consumed; it's effectively reset to
-/// the state immediately after it was initialized. (This lets us avoid
-/// reallocating lots of memory)
-Registry RegBuilder_consume_and_build(RegBuilder* ptr) {
+Registry RegBuilder::consume_and_build() {
   // try to construct an EntrySet that contains all owned entries
-  if (!ptr->owned_entries.empty()) {
-    ptr->recipe_sets.emplace_back(std::move(ptr->owned_entries));
+  if (!owned_entries.empty()) {
+    recipe_sets.emplace_back(std::move(owned_entries));
   }
 
   // now actually set up the registry
-  if (ptr->recipe_sets.empty()) {
+  if (recipe_sets.empty()) {
     return Registry{0, nullptr, std::vector<EntrySet>()};
   } else {
-    int n_sets = ptr->recipe_sets.size();
+    int n_sets = recipe_sets.size();
     // set up id_offsets and determine the total number of entries
     int* id_offsets = new int[n_sets];
     int tot_entry_count = 0;
     for (int i = 0; i < n_sets; i++) {
       id_offsets[i] = tot_entry_count;
-      tot_entry_count += ptr->recipe_sets[i].size();
+      tot_entry_count += recipe_sets[i].size();
     }
-    return Registry{tot_entry_count, id_offsets, std::move(ptr->recipe_sets)};
+    return Registry{tot_entry_count, id_offsets, std::move(recipe_sets)};
   }
 }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -171,14 +171,14 @@ EntrySet::~EntrySet() noexcept {
 }
 
 int RegBuilder::take_data_(const char* raw_name, PtrUnion owned_data,
-                           EntryProps props) {
+                           EntryShape props) {
   if (raw_name == nullptr) {
     return GrPrintAndReturnErr("raw_name is a nullptr");
   } else if (owned_data.is_null()) {
     return GrPrintAndReturnErr("owned_data holds a nullptr");
   } else if (!owned_data.is_const_ptr()) {
     return GrPrintAndReturnErr("owned_data isn't const");
-  } else if (!EntryProps_is_valid(props)) {
+  } else if (!EntryShape_is_valid(props)) {
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
@@ -196,12 +196,12 @@ int RegBuilder::take_data_(const char* raw_name, PtrUnion owned_data,
 }
 
 int RegBuilder::recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
-                        EntryProps common_props) {
+                        EntryShape common_props) {
   if (recipe_fn == nullptr) {
     return GrPrintAndReturnErr("recipe_fn is a nullptr");
   } else if (n_entries <= 0) {
     return GrPrintAndReturnErr("n_entries is not positive");
-  } else if (!EntryProps_is_valid(common_props)) {
+  } else if (!EntryShape_is_valid(common_props)) {
     return GrPrintAndReturnErr("common_props isn't valid");
   }
 
@@ -219,14 +219,14 @@ RegBuilder::~RegBuilder() noexcept {
 }
 
 int RegBuilder::recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn) {
-  EntryProps common_props = mk_invalid_EntryProps();
+  EntryShape common_props = mk_invalid_EntryShape();
   common_props.ndim = 0;
   return recipe_(recipe_fn, n_entries, common_props);
 }
 
 int RegBuilder::recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
                           int common_len) {
-  EntryProps common_props = mk_invalid_EntryProps();
+  EntryShape common_props = mk_invalid_EntryShape();
   common_props.ndim = 1;
   common_props.shape[0] = common_len;
   return recipe_(recipe_fn, n_entries, common_props);
@@ -244,7 +244,7 @@ int RegBuilder::copied_str_arr1d(const char* name, const char* const* str_arr1d,
     std::memcpy(my_copy[i], str_arr1d[i], nbytes);
   }
   PtrUnion data(const_cast<const char* const*>(my_copy));
-  EntryProps props = mk_invalid_EntryProps();
+  EntryShape props = mk_invalid_EntryShape();
   props.ndim = 1;
   props.shape[0] = len;
   return take_data_(name, data, props);
@@ -258,7 +258,7 @@ int RegBuilder::copied_f64_arr1d(const char* name, const double* f64_arr1d,
   double* my_copy = new double[len];
   std::memcpy(my_copy, f64_arr1d, sizeof(double) * len);
   PtrUnion data(const_cast<const double*>(my_copy));
-  EntryProps props = mk_invalid_EntryProps();
+  EntryShape props = mk_invalid_EntryShape();
   props.ndim = 1;
   props.shape[0] = len;
   return take_data_(name, data, props);
@@ -352,7 +352,7 @@ static void show_Entry(const Entry* entry) {
 */
 
 /// compute the number of items in an Entry described by @p props
-static long long get_n_items(EntryProps props) {
+static long long get_n_items(EntryShape props) {
   GR_INTERNAL_REQUIRE(props.ndim >= 0, "sanity check!");
 
   if (props.ndim == 0) {
@@ -490,8 +490,8 @@ extern "C" int grunstable_ratequery_prop(
                           rate_id)
           .entry;
 
-  const rate_q::EntryProps& props = entry.props;
-  if ((entry.name == nullptr) || !rate_q::EntryProps_is_valid(props)) {
+  const rate_q::EntryShape& props = entry.props;
+  if ((entry.name == nullptr) || !rate_q::EntryShape_is_valid(props)) {
     return GR_FAIL;
   }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -80,8 +80,8 @@ static Entry get_PhotoRxn_Entry(chemistry_data_storage* my_rates, int i) {
   }
 }
 
-int RegBuilder_misc_recipies(RegBuilder* ptr,
-                             const chemistry_data* my_chemistry) {
+int add_misc_recipies_to_RegBuilder(RegBuilder* ptr,
+                                    const chemistry_data* my_chemistry) {
   if (my_chemistry->primordial_chemistry != 0) {
     return RegBuilder_recipe_scalar(ptr, PhotoRxnLUT::NUM_ENTRIES,
                                     &get_PhotoRxn_Entry);

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -316,15 +316,13 @@ Registry RegBuilder_consume_and_build(RegBuilder* ptr) {
   }
 }
 
-void drop_Registry(Registry* ptr) {
-  if (!ptr->sets.empty()) {
-    delete[] ptr->id_offsets;
-    ptr->id_offsets = nullptr;
-    std::size_t n_sets = ptr->sets.size();
+Registry::~Registry() {
+  if (sets.empty()) {
+    delete[] id_offsets;
+    std::size_t n_sets = sets.size();
     for (std::size_t i = 0; i < n_sets; i++) {
-      drop_EntrySet(&ptr->sets[i]);
+      drop_EntrySet(&sets[i]);
     }
-    ptr->sets.clear();  // <- make it safer to call drop_Registry more than once
   }
 }
 

--- a/src/clib/ratequery.cpp
+++ b/src/clib/ratequery.cpp
@@ -152,17 +152,13 @@ static void drop_owned_Entry_list_contents(Entry* entry_list,
 }
 
 Entry EntrySet::access(chemistry_data_storage* my_rates, int i) const {
-  if (embedded_list.empty()) {  // in recipe-mode
-    if ((i < 0) || (i >= len)) {
-      return mk_invalid_Entry();
-    }
+  if ((i < 0) || (i >= this->size())) {
+    return mk_invalid_Entry();
+  } else if (embedded_list.empty()) {  // in recipe-mode
     Entry out = (recipe_fn)(my_rates, i);
     out.props = common_recipe_props;
     return out;
   } else {  // in embedded-list mode
-    if ((i < 0) || (static_cast<std::size_t>(i) >= embedded_list.size())) {
-      return mk_invalid_Entry();
-    }
     return embedded_list[i];
   }
 }

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <utility>  // std::swap
 
 #include "grackle.h"
 #include "utils-cpp.hpp"  // GRIMPL_FORCE_INLINE
@@ -281,10 +282,56 @@ struct EntrySet {
   /// @note
   /// only used in Recipe-mode
   EntryProps common_recipe_props;
-};
 
-/// deallocate the contents of an EntrySet
-void drop_EntrySet(EntrySet* ptr);
+  /// @brief construct an empty entry set
+  EntrySet()
+      : len(0),
+        recipe_fn{nullptr},
+        common_recipe_props{mk_invalid_EntryProps()} {}
+
+  /// @brief construct a set of entries in embedded list mode
+  explicit EntrySet(std::vector<Entry> embedded_list)
+      : len{static_cast<int>(embedded_list.size())},
+        embedded_list(embedded_list),
+        recipe_fn{nullptr},
+        common_recipe_props{mk_invalid_EntryProps()} {}
+
+  /// construct a set of entries in recipe-mode
+  EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn, EntryProps common_props)
+      : len{len}, recipe_fn{recipe_fn}, common_recipe_props{common_props} {}
+
+  // forbid copy-construction & copy assignment (if we want these, we would
+  // need custom implementations to properly handle embedded_list, or we would
+  // need to make Entry into a full-blown class)
+  EntrySet(const EntrySet&) = delete;
+  EntrySet& operator=(const EntrySet&) = delete;
+
+  // the following require custom implementations to properly handle
+  // embedded_list (we could use default implementations if there were proper
+  // move constructors for Entry)
+
+  /// construct new instance and move contents of @p other into it
+  EntrySet(EntrySet&& other) noexcept : EntrySet() { swap(other); }
+
+  /// move contents of @p other into this instance
+  EntrySet& operator=(EntrySet&& other) noexcept {
+    if (this != &other) {
+      swap(other);
+    }
+    return *this;
+  }
+
+  /// @brief destructor
+  ~EntrySet() noexcept;
+
+  /// @brief swaps contents
+  void swap(EntrySet& other) noexcept {
+    std::swap(len, other.len);
+    std::swap(embedded_list, other.embedded_list);
+    std::swap(recipe_fn, other.recipe_fn);
+    std::swap(common_recipe_props, other.common_recipe_props);
+  }
+};
 
 /// get the number of @ref Entry in the @ref EntrySet
 inline int EntrySet_size(const EntrySet* ptr) {
@@ -323,7 +370,11 @@ struct Registry {
   Registry& operator=(const Registry&) = delete;
 
   /// @brief Destructor
-  ~Registry();
+  ~Registry() noexcept {
+    if (id_offsets != nullptr) {
+      delete[] id_offsets;
+    }
+  }
 };
 
 /// An interface for gradually configuring a Registry

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -317,14 +317,14 @@ struct Registry {
   /// stores sets of entries
   std::vector<EntrySet> sets;
 
-  // forbid copy-construction & copy assignment (if we want these, then we
-  // should make EntrySet a full-blown class with a destructor)
+  // forbid copy-construction & copy assignment (these will provide custom
+  // implementations.
   Registry(const Registry&) = delete;
   Registry& operator=(const Registry&) = delete;
-};
 
-/// deallocate the contents of a registry
-void drop_Registry(Registry* ptr);
+  /// @brief Destructor
+  ~Registry();
+};
 
 /// An interface for gradually configuring a Registry
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -260,7 +260,7 @@ typedef Entry fetch_Entry_recipe_fn(chemistry_data_storage*, int);
 /// 2. Recipe-mode:
 ///    - In this case, the EntrySet provides access to Entry instances that
 ///      directly reference data managed by `chemistry_data_storage`
-struct EntrySet {
+class EntrySet {
   /// number of entries in the current set
   int len;
 
@@ -283,6 +283,7 @@ struct EntrySet {
   /// only used in Recipe-mode
   EntryProps common_recipe_props;
 
+public:
   /// @brief construct an empty entry set
   EntrySet()
       : len(0),
@@ -333,14 +334,7 @@ struct EntrySet {
   }
 
   /// @brief get the number of @ref Entry in the container
-  int size() const {
-    // if we mutation to data-members, we can always just return len
-    if (embedded_list.empty()) {
-      return len;
-    } else {
-      return static_cast<int>(embedded_list.size());
-    }
-  }
+  int size() const { return len; }
 
   /// look up an Entry
   ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -451,19 +451,18 @@ struct RegBuilder {
   ///
   /// @returns GR_SUCCESS if successful, otherwise returns a different value
   int recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn);
-};
 
-/// register a recipe for accessing 1D arrays
-///
-/// @param[inout] ptr The RegBuilder that will be updated
-/// @param[in] n_entries The number of entries accessible through the recipe
-/// @param[in] recipe_fn The recipe being registered
-/// @param[in] common_len The length shared by each 1D array accessible
-///     through this recipe.
-///
-/// @returns GR_SUCCESS if successful, otherwise returns a different value
-int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,
-                         fetch_Entry_recipe_fn* recipe_fn, int common_len);
+  /// register a recipe for accessing 1D arrays
+  ///
+  /// @param[in] n_entries The number of entries accessible through the recipe
+  /// @param[in] recipe_fn The recipe being registered
+  /// @param[in] common_len The length shared by each 1D array accessible
+  ///     through this recipe.
+  ///
+  /// @returns GR_SUCCESS if successful, otherwise returns a different value
+  int recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
+                int common_len);
+};
 
 /// copies a 1d array of strings to make a queryable entry
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -417,6 +417,21 @@ struct RegBuilder {
   /// transferred to an EntrySet.
   std::vector<Entry> owned_entries;
 
+  // helper methods
+
+  /// @brief builder takes ownership of the supplied data
+  ///
+  /// this implements common machinery for updating @ref owned_entries
+  int take_data_(const char* raw_name, PtrUnion owned_data, EntryProps props);
+
+  /// @brief builder creates a recipe
+  ///
+  /// this implements common machinery for updating @ref recipe_sets
+  int recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
+              EntryProps common_props);
+
+  // primary interface
+
   /// @brief default constructor
   RegBuilder() = default;
 

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -212,6 +212,8 @@ public:
 struct EntryShape {
   int ndim;
   int shape[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
+
+  bool is_valid() const noexcept { return ndim >= 0; }
 };
 
 inline EntryShape mk_invalid_EntryShape() {
@@ -219,8 +221,6 @@ inline EntryShape mk_invalid_EntryShape() {
   out.ndim = -1;
   return out;
 }
-
-inline bool EntryShape_is_valid(EntryShape obj) { return obj.ndim >= 0; }
 
 /// A queryable entity
 struct Entry {

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -357,10 +357,12 @@ struct Registry {
   /// stores sets of entries
   std::vector<EntrySet> sets;
 
-  // forbid copy-construction & copy assignment (these will provide custom
-  // implementations.
+  // forbid copy/move construction & assignment (they require custom
+  // implementations for as long as id_offsets is a regular pointer)
   Registry(const Registry&) = delete;
+  Registry(Registry&&) = delete;
   Registry& operator=(const Registry&) = delete;
+  Registry& operator=(Registry&&) = delete;
 
   /// @brief Destructor
   ~Registry() noexcept {

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -209,33 +209,33 @@ public:
 };
 
 /// Describes properties about the data in an entry
-struct EntryProps {
+struct EntryShape {
   int ndim;
   int shape[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
 };
 
-inline EntryProps mk_invalid_EntryProps() {
-  EntryProps out;
+inline EntryShape mk_invalid_EntryShape() {
+  EntryShape out;
   out.ndim = -1;
   return out;
 }
 
-inline bool EntryProps_is_valid(EntryProps obj) { return obj.ndim >= 0; }
+inline bool EntryShape_is_valid(EntryShape obj) { return obj.ndim >= 0; }
 
 /// A queryable entity
 struct Entry {
   PtrUnion data;
   const char* name;
-  EntryProps props;
+  EntryShape props;
 };
 
 inline Entry mk_invalid_Entry() {
-  return Entry{nullptr, nullptr, mk_invalid_EntryProps()};
+  return Entry{nullptr, nullptr, mk_invalid_EntryShape()};
 }
 
 /// Constructs an Entry
 inline Entry new_Entry(double* rate, const char* name) {
-  return Entry{PtrUnion(rate), name, mk_invalid_EntryProps()};
+  return Entry{PtrUnion(rate), name, mk_invalid_EntryShape()};
 }
 
 /// a recipe for querying 1 or more entries from a chemistry_data_storage
@@ -286,24 +286,24 @@ class EntrySet {
   ///
   /// @note
   /// only used in Recipe-mode
-  EntryProps common_recipe_props;
+  EntryShape common_recipe_props;
 
 public:
   /// @brief construct an empty entry set
   EntrySet()
       : len(0),
         recipe_fn{nullptr},
-        common_recipe_props{mk_invalid_EntryProps()} {}
+        common_recipe_props{mk_invalid_EntryShape()} {}
 
   /// @brief construct a set of entries in embedded list mode
   explicit EntrySet(std::vector<Entry> embedded_list)
       : len{static_cast<int>(embedded_list.size())},
         embedded_list(embedded_list),
         recipe_fn{nullptr},
-        common_recipe_props{mk_invalid_EntryProps()} {}
+        common_recipe_props{mk_invalid_EntryShape()} {}
 
   /// construct a set of entries in recipe-mode
-  EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn, EntryProps common_props)
+  EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn, EntryShape common_props)
       : len{len}, recipe_fn{recipe_fn}, common_recipe_props{common_props} {}
 
   // forbid copy-construction & copy assignment (if we want these, we would
@@ -423,13 +423,13 @@ class RegBuilder {
   /// @brief builder takes ownership of the supplied data
   ///
   /// this implements common machinery for updating @ref owned_entries
-  int take_data_(const char* raw_name, PtrUnion owned_data, EntryProps props);
+  int take_data_(const char* raw_name, PtrUnion owned_data, EntryShape props);
 
   /// @brief builder creates a recipe
   ///
   /// this implements common machinery for updating @ref recipe_sets
   int recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
-              EntryProps common_props);
+              EntryShape common_props);
 
 public:  // interface methods
   /// @brief default constructor

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -331,27 +331,26 @@ struct EntrySet {
     std::swap(recipe_fn, other.recipe_fn);
     std::swap(common_recipe_props, other.common_recipe_props);
   }
-};
 
-/// get the number of @ref Entry in the @ref EntrySet
-inline int EntrySet_size(const EntrySet* ptr) {
-  if (ptr->embedded_list.empty()) {
-    return ptr->len;
-  } else {
-    return static_cast<int>(ptr->embedded_list.size());
+  /// @brief get the number of @ref Entry in the container
+  int size() const {
+    // if we mutation to data-members, we can always just return len
+    if (embedded_list.empty()) {
+      return len;
+    } else {
+      return static_cast<int>(embedded_list.size());
+    }
   }
-}
 
-/// look up an Entry in an EntrySet
-///
-/// @param[in] entry_set The container object being queried
-/// @param[in] my_rates Used for looking up Entry in recipe-mode
-/// @param[in] i The index to query
-///
-/// @returns An instance that references memory owned by either my_rates or by
-///     the entry_set, itself.
-Entry EntrySet_access(const EntrySet* entry_set,
-                      chemistry_data_storage* my_rates, int i);
+  /// look up an Entry
+  ///
+  /// @param[in] my_rates Used for looking up Entry in recipe-mode
+  /// @param[in] i The index to query
+  ///
+  /// @returns An instance that references memory owned by either @p my_rates or
+  ///     by the container itself
+  Entry access(chemistry_data_storage* my_rates, int i) const;
+};
 
 /// Describes a registry of queryable entries
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -213,14 +213,15 @@ struct EntryShape {
   int ndim;
   int shape[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
 
+  /// @brief factory method for constructing invalid instance
+  static EntryShape create_invalid() {
+    EntryShape out;
+    out.ndim = -1;
+    return out;
+  }
+
   bool is_valid() const noexcept { return ndim >= 0; }
 };
-
-inline EntryShape mk_invalid_EntryShape() {
-  EntryShape out;
-  out.ndim = -1;
-  return out;
-}
 
 /// A queryable entity
 struct Entry {
@@ -230,12 +231,12 @@ struct Entry {
 };
 
 inline Entry mk_invalid_Entry() {
-  return Entry{nullptr, nullptr, mk_invalid_EntryShape()};
+  return Entry{nullptr, nullptr, EntryShape::create_invalid()};
 }
 
 /// Constructs an Entry
 inline Entry new_Entry(double* rate, const char* name) {
-  return Entry{PtrUnion(rate), name, mk_invalid_EntryShape()};
+  return Entry{PtrUnion(rate), name, EntryShape::create_invalid()};
 }
 
 /// a recipe for querying 1 or more entries from a chemistry_data_storage
@@ -293,14 +294,14 @@ public:
   EntrySet()
       : len(0),
         recipe_fn{nullptr},
-        common_recipe_props{mk_invalid_EntryShape()} {}
+        common_recipe_props{EntryShape::create_invalid()} {}
 
   /// @brief construct a set of entries in embedded list mode
   explicit EntrySet(std::vector<Entry> embedded_list)
       : len{static_cast<int>(embedded_list.size())},
         embedded_list(embedded_list),
         recipe_fn{nullptr},
-        common_recipe_props{mk_invalid_EntryShape()} {}
+        common_recipe_props{EntryShape::create_invalid()} {}
 
   /// construct a set of entries in recipe-mode
   EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn, EntryShape common_props)

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -213,10 +213,40 @@ struct EntryShape {
   int ndim;
   int shape[GRACKLE_CLOUDY_TABLE_MAX_DIMENSION];
 
+private:
+  EntryShape() = default;  // default constructor only used in factory methods
+public:
   /// @brief factory method for constructing invalid instance
   static EntryShape create_invalid() {
     EntryShape out;
     out.ndim = -1;
+    return out;
+  }
+
+  /// @brief factory method that constructs instance to describe a scalar value
+  static EntryShape create_scalar() {
+    EntryShape out;
+    out.ndim = 0;
+    return out;
+  }
+
+  /// @brief factory method for creating a 1D shape (most common case)
+  static EntryShape create_1d(int i) {
+    EntryShape out;
+    out.ndim = 1;
+    out.shape[0] = i;
+    return out;
+  }
+
+  /// @brief factory method for arbitrary number of dimensions
+  static EntryShape create(int ndim, const int* dims) {
+    GR_INTERNAL_REQUIRE(ndim > 0 && ndim <= GRACKLE_CLOUDY_TABLE_MAX_DIMENSION,
+                        "sanity check failed");
+    EntryShape out;
+    out.ndim = 1;
+    for (int i = 0; i < ndim; i++) {
+      out.shape[i] = dims[i];
+    }
     return out;
   }
 

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -499,17 +499,17 @@ struct RegBuilder {
   /// use (i.e. the abundances could be "baked into" some tables), but external
   /// simulation codes may want to know about to achieve better consistency.
   int copied_f64_arr1d(const char* name, const double* f64_arr1d, int len);
-};
 
-/// build a new Registry.
-///
-/// In the process, the current Registry is consumed; it's effectively reset to
-/// the state immediately after it was initialized. (This lets us avoid
-/// reallocating lots of memory)
-///
-/// @note
-/// For safety, the caller should still plan to call drop_RegBuilder
-Registry RegBuilder_consume_and_build(RegBuilder* ptr);
+  /// build a new @ref Registry.
+  ///
+  /// In the process, this builder is "consumed." In other words, it's
+  /// effectively reset to the empty state that it had immediately after it was
+  /// constructed.
+  ///
+  /// @note
+  /// The choice to consume the builder lets us minimize heap allocations
+  Registry consume_and_build();
+};
 
 /// registers miscellaneous recipes
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -406,7 +406,7 @@ struct Registry {
 /// @important
 /// Other parts of grackle should refrain from directly accessing the internals
 /// of this function (i.e. they should only use the associated methods)
-struct RegBuilder {
+class RegBuilder {
   /// a growable array that records recipies for accessing sets of entries
   std::vector<EntrySet> recipe_sets;
   /// a growable array of owned Entry instances
@@ -417,7 +417,8 @@ struct RegBuilder {
   /// transferred to an EntrySet.
   std::vector<Entry> owned_entries;
 
-  // helper methods
+  // helper methods:
+  // ---------------
 
   /// @brief builder takes ownership of the supplied data
   ///
@@ -430,8 +431,7 @@ struct RegBuilder {
   int recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
               EntryProps common_props);
 
-  // primary interface
-
+public:  // interface methods
   /// @brief default constructor
   RegBuilder() = default;
 

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -462,48 +462,44 @@ struct RegBuilder {
   /// @returns GR_SUCCESS if successful, otherwise returns a different value
   int recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
                 int common_len);
+
+  /// copies a 1d array of strings to make a queryable entry
+  ///
+  /// The resulting Registry will have a queryable entry corresponding to the
+  /// specified 1D array of strings. Importantly, the RegBuilder and Registry
+  /// hold a deepcopy of the specified strings.
+  ///
+  /// @param[in] name The queryable name that corresponds to the provided data
+  /// @param[in] str_arr1d The 1d array of strings
+  /// @param[in] len The length of @p str_arr1d
+  ///
+  /// @returns GR_SUCCESS if successful, otherwise returns a different value
+  ///
+  /// @note
+  /// This is intended to be used for making information available that Grackle
+  /// otherwise does not need access to.
+  int copied_str_arr1d(const char* name, const char* const* str_arr1d, int len);
+
+  /// copies a 1d array of doubles to make a queryable entry
+  ///
+  /// The resulting Registry will have a queryable entry corresponding to the
+  /// specified 1D array of doubles. Importantly, the RegBuilder and Registry
+  /// hold a deepcopy of the values.
+  ///
+  /// @param[in] name The queryable name that corresponds to the provided data
+  /// @param[in] f64_arr1d The 1d array of doubles
+  /// @param[in] len The length of @p f64_arr1d
+  ///
+  /// @returns GR_SUCCESS if successful, otherwise returns a different value
+  ///
+  /// @note
+  /// This is intended to be used for making information available that Grackle
+  /// otherwise does not need access to. For example, it might be used to
+  /// provide information about assumed abundances that Grackle doesn't directly
+  /// use (i.e. the abundances could be "baked into" some tables), but external
+  /// simulation codes may want to know about to achieve better consistency.
+  int copied_f64_arr1d(const char* name, const double* f64_arr1d, int len);
 };
-
-/// copies a 1d array of strings to make a queryable entry
-///
-/// The resulting Registry will have a queryable entry corresponding to the
-/// specified 1D array of strings. Importantly, the RegBuilder and Registry
-/// hold a deepcopy of the specified strings.
-///
-/// @param[inout] ptr The RegBuilder that will be updated
-/// @param[in] name The queryable name that corresponds to the provided data
-/// @param[in] str_arr1d The 1d array of strings
-/// @param[in] len The length of str_arr1d
-///
-/// @returns GR_SUCCESS if successful, otherwise returns a different value
-///
-/// @note
-/// This is intended to be used for making information available that Grackle
-/// otherwise does not need access to.
-int RegBuilder_copied_str_arr1d(RegBuilder* ptr, const char* name,
-                                const char* const* str_arr1d, int len);
-
-/// copies a 1d array of doubles to make a queryable entry
-///
-/// The resulting Registry will have a queryable entry corresponding to the
-/// specified 1D array of doubles. Importantly, the RegBuilder and Registry
-/// hold a deepcopy of the values.
-///
-/// @param[inout] ptr The RegBuilder that will be updated
-/// @param[in] name The queryable name that corresponds to the provided data
-/// @param[in] f64_arr1d The 1d array of doubles
-/// @param[in] len The length of str_list
-///
-/// @returns GR_SUCCESS if successful, otherwise returns a different value
-///
-/// @note
-/// This is intended to be used for making information available that Grackle
-/// otherwise does not need access to. For example, it might be used to provide
-/// information about assumed abundances that Grackle doesn't directly use (i.e.
-/// the abundances could be "baked into" some tables), but external simulation
-/// codes may want to know about to achieve better consistency.
-int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
-                                const double* f64_arr1d, int len);
 
 /// build a new Registry.
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -245,6 +245,11 @@ inline Entry new_Entry(double* rate, const char* name) {
 /// If `N` denotes the number of entries that can be queried by a given recipe,
 /// then this function should produce unique entries for each unique index that
 /// satisfies `0 <= index <= (N-1)`
+///
+/// @warning
+/// All callers of this function assume that the memory referenced by the
+/// returned objects @ref Entry.data and @ref Entry Entry.name do **NOT** need
+/// to be deallocated
 typedef Entry fetch_Entry_recipe_fn(chemistry_data_storage*, int);
 
 /// Describes a set of entries

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -265,8 +265,8 @@ inline Entry mk_invalid_Entry() {
 }
 
 /// Constructs an Entry
-inline Entry new_Entry(double* rate, const char* name) {
-  return Entry{PtrUnion(rate), name, EntryShape::create_invalid()};
+inline Entry new_Entry(double* rate, const char* name, EntryShape shape) {
+  return Entry{PtrUnion(rate), name, shape};
 }
 
 /// a recipe for querying 1 or more entries from a chemistry_data_storage

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -310,32 +310,19 @@ class EntrySet {
   /// a function pointer that can be used to access entries through a recipe
   fetch_Entry_recipe_fn* recipe_fn;
 
-  /// properties used by all entries accessed through a recipe
-  ///
-  /// In more detail, an entry returned by `recipe_fn` has its `props` member
-  /// overwritten by this value
-  ///
-  /// @note
-  /// only used in Recipe-mode
-  EntryShape common_recipe_props;
-
 public:
   /// @brief construct an empty entry set
-  EntrySet()
-      : len(0),
-        recipe_fn{nullptr},
-        common_recipe_props{EntryShape::create_invalid()} {}
+  EntrySet() : len(0), recipe_fn{nullptr} {}
 
   /// @brief construct a set of entries in embedded list mode
   explicit EntrySet(std::vector<Entry> embedded_list)
       : len{static_cast<int>(embedded_list.size())},
         embedded_list(embedded_list),
-        recipe_fn{nullptr},
-        common_recipe_props{EntryShape::create_invalid()} {}
+        recipe_fn{nullptr} {}
 
   /// construct a set of entries in recipe-mode
-  EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn, EntryShape common_props)
-      : len{len}, recipe_fn{recipe_fn}, common_recipe_props{common_props} {}
+  EntrySet(int len, fetch_Entry_recipe_fn* recipe_fn)
+      : len{len}, recipe_fn{recipe_fn} {}
 
   // forbid copy-construction & copy assignment (if we want these, we would
   // need custom implementations to properly handle embedded_list, or we would
@@ -366,7 +353,6 @@ public:
     std::swap(len, other.len);
     std::swap(embedded_list, other.embedded_list);
     std::swap(recipe_fn, other.recipe_fn);
-    std::swap(common_recipe_props, other.common_recipe_props);
   }
 
   /// @brief get the number of @ref Entry in the container
@@ -456,12 +442,6 @@ class RegBuilder {
   /// this implements common machinery for updating @ref owned_entries
   int take_data_(const char* raw_name, PtrUnion owned_data, EntryShape props);
 
-  /// @brief builder creates a recipe
-  ///
-  /// this implements common machinery for updating @ref recipe_sets
-  int recipe_(fetch_Entry_recipe_fn* recipe_fn, int n_entries,
-              EntryShape common_props);
-
 public:  // interface methods
   /// @brief default constructor
   RegBuilder() = default;
@@ -475,24 +455,13 @@ public:  // interface methods
 
   ~RegBuilder() noexcept;
 
-  /// register a recipe for accessing scalar values
+  /// register a recipe for accessing a rate array
   ///
   /// @param[in] n_entries The number of entries accessible through the recipe
   /// @param[in] recipe_fn The recipe being registered
   ///
   /// @returns GR_SUCCESS if successful, otherwise returns a different value
-  int recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn);
-
-  /// register a recipe for accessing 1D arrays
-  ///
-  /// @param[in] n_entries The number of entries accessible through the recipe
-  /// @param[in] recipe_fn The recipe being registered
-  /// @param[in] common_len The length shared by each 1D array accessible
-  ///     through this recipe.
-  ///
-  /// @returns GR_SUCCESS if successful, otherwise returns a different value
-  int recipe_1d(int n_entries, fetch_Entry_recipe_fn* recipe_fn,
-                int common_len);
+  int recipe(int n_entries, fetch_Entry_recipe_fn* recipe_fn);
 
   /// copies a 1d array of strings to make a queryable entry
   ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -417,20 +417,18 @@ struct RegBuilder {
   /// transferred to an EntrySet.
   std::vector<Entry> owned_entries;
 
-  // forbid copy-construction & copy assignment (if we want these, then we
-  // should make EntrySet & Entry full-blown classes with destructors)
+  /// @brief default constructor
+  RegBuilder() = default;
+
+  // forbid copy/move construction & assignment (if we want these, then we need
+  // custom handling for owned_entries)
   RegBuilder(const RegBuilder&) = delete;
+  RegBuilder(RegBuilder&&) = delete;
   RegBuilder& operator=(const RegBuilder&) = delete;
+  RegBuilder& operator=(RegBuilder&&) = delete;
+
+  ~RegBuilder() noexcept;
 };
-
-/// initialize a new instance
-inline RegBuilder new_RegBuilder() {
-  // by default it is automatically initialized
-  return RegBuilder{};
-}
-
-/// deallocates all storage within a RegBuilder instance
-void drop_RegBuilder(RegBuilder* ptr);
 
 /// register a recipe for accessing scalar values
 ///

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -454,14 +454,6 @@ int RegBuilder_recipe_scalar(RegBuilder* ptr, int n_entries,
 int RegBuilder_recipe_1d(RegBuilder* ptr, int n_entries,
                          fetch_Entry_recipe_fn* recipe_fn, int common_len);
 
-/// registers miscellaneous recipes
-///
-/// @note
-/// This is a hack until we can figure out a better spot to put definitions of
-/// some miscellaneous rates
-int RegBuilder_misc_recipies(RegBuilder* ptr,
-                             const chemistry_data* my_chemistry);
-
 /// copies a 1d array of strings to make a queryable entry
 ///
 /// The resulting Registry will have a queryable entry corresponding to the
@@ -512,6 +504,14 @@ int RegBuilder_copied_f64_arr1d(RegBuilder* ptr, const char* name,
 /// @note
 /// For safety, the caller should still plan to call drop_RegBuilder
 Registry RegBuilder_consume_and_build(RegBuilder* ptr);
+
+/// registers miscellaneous recipes
+///
+/// @note
+/// This is a hack until we can figure out a better spot to put definitions of
+/// some miscellaneous rates
+int add_misc_recipies_to_RegBuilder(RegBuilder* ptr,
+                                    const chemistry_data* my_chemistry);
 
 /** @}*/  // end of group
 

--- a/src/clib/ratequery.hpp
+++ b/src/clib/ratequery.hpp
@@ -443,17 +443,15 @@ struct RegBuilder {
   RegBuilder& operator=(RegBuilder&&) = delete;
 
   ~RegBuilder() noexcept;
-};
 
-/// register a recipe for accessing scalar values
-///
-/// @param[inout] ptr The RegBuilder that will be updated
-/// @param[in] n_entries The number of entries accessible through the recipe
-/// @param[in] recipe_fn The recipe being registered
-///
-/// @returns GR_SUCCESS if successful, otherwise returns a different value
-int RegBuilder_recipe_scalar(RegBuilder* ptr, int n_entries,
-                             fetch_Entry_recipe_fn* recipe_fn);
+  /// register a recipe for accessing scalar values
+  ///
+  /// @param[in] n_entries The number of entries accessible through the recipe
+  /// @param[in] recipe_fn The recipe being registered
+  ///
+  /// @returns GR_SUCCESS if successful, otherwise returns a different value
+  int recipe_scalar(int n_entries, fetch_Entry_recipe_fn* recipe_fn);
+};
 
 /// register a recipe for accessing 1D arrays
 ///


### PR DESCRIPTION
To be reviewed after #594 is merged

------

This PR modifies the ratequery machinery so that recipes for accessing the rates now directly report the shape of each rate.

### Motivation

Some basic background:
- the vast majority of rates (or entries) that are queryable through the ratequery machinery are made accessible through a callback function (called a "recipe") that fetches the basic entry information.
- prior to this commit, all entries accessed through a "recipe" had to share a common shape and the recipe itself didn't actually specify the shape of the returned buffer (i.e. the shape of all buffers accessed through a recipe were specified alongside the recipe when registering the recipe)

This PR changes things so that the recipes directly specify the shape of the fetched rate. This is important for making it easier to create recipes for the cloudy interpolation table. When you think about the axes of the cloud interpolation table (e.g. the $T$ array, the $n_H$ array, the $z$ array), they all have different shapes. Thus the old system would have required separate recipes for each of those axes. The new system makes it possible to create a single recipe for all of the axes. This will also be important if we want to make other kinds of multidimensional interpolation tables queryable in the future (plus, it slightly simplifies `ratequery::EntrySet`).

Note: this PR does NOT actually make the cloudy interpolation table accessible through the ratequery machinery (I have a separate mostly finished PR for doing that)

### The changes

The specific changes in this PR include

- renaming `ratequery::{EntryProps->EntryShape}`
- making `ratequery::EntryShape` more class-like
  - the existing `EntryShape_is_valid` function is now a method
  - the This PR modifies the ratequery machinery so that recipes for accessing the rates now directly report the shape of each rate.

### Motivation

Some basic background:
- the vast majority of rates (or entries) that are queryable through the ratequery machinery are made accessible through a callback function (called a "recipe") that fetches the basic entry information.
- prior to this commit, all entries accessed through a "recipe" had to share a common shape and the recipe itself didn't actually specify the shape of the returned buffer (i.e. the shape of all buffers accessed through a recipe were specified alongside the recipe when registering the recipe)

This PR changes things so that the recipes directly specify the shape of the fetched rate. This is important for making it easier to create recipes for the cloudy interpolation table. When you think about the axes of the cloud interpolation table (e.g. the $T$ array, the $n_H$ array, the $z$ array), they all have different shapes. Thus the old system would have required separate recipes for each of those axes. The new system makes it possible to create a single recipe for all of the axes. This will also be important if we want to make other kinds of multidimensional interpolation tables queryable in the future (plus, it slightly simplifies `ratequery::EntrySet` and  `ratequery::RegBuilder`).

Note: this PR does NOT actually make the cloudy interpolation table accessible through the ratequery machinery (I have a separate mostly finished PR for doing that)

### The changes

The specific changes in this PR include

- renaming `ratequery::{EntryProps->EntryShape}`
- making `ratequery::EntryShape` more class-like
  - the existing `ratequery::EntryShape_is_valid` function is now a method
  - the `ratequery::mk_invalid_EntryShape` is now a factory method
  - I added other factory methods to `ratequery::EntryShape` and made the default constructor private in order to force people to use the factory methods
  - For some context: since all of the recipe functions now need to specify the `ratequery::EntryShape` I felt it was important that all code for specifying the shape had to be very explicit (and I wanted to make it very harder to make a mistake when specifying shape)
- I adjusted `ratequery::EntrySet` and `ratequery::RegBuilder` to reflect the fact that recipe functions now included the entry shape (the implementation of these classes definitely got simpler)
- I stored a copy of the `NumberOfTemperatureBins` input parameter inside of `gr_opaque_storage`.
  - Honestly, this is a bit of a hack. But, it was the most convenient way to make the shape of all of the 1D rate arrays accessible through recipe functions.
  - For context, the ratequery machinery was all designed to function without being passed a pointer to the `chemistry_data` struct. We can revisit this in the future if we want
- I updated each of the existing recipes to now report the shapes of the associated recipes

### Followup

A followup PR will make the cloudy interpolation tables accessible through the ratequery machinery. (At the time of writing, that's 95% done)