### PR TITLE
[newchem-cpp] convert physical constants from macros to C++ constants

### DIFF
--- a/src/clib/api/units.cpp
+++ b/src/clib/api/units.cpp
@@ -34,7 +34,8 @@ extern "C" void set_velocity_units(code_units *my_units)
 
 static double get_temperature_units_(double velocity_units)
 {
-  return GRIMPL_NS::constants::mH * std::pow(velocity_units, 2.0) / kboltz;
+  return (GRIMPL_NS::constants::mH * std::pow(velocity_units, 2.0)
+          / GRIMPL_NS::constants::kboltz);
 }
 
 

--- a/src/clib/api/units.cpp
+++ b/src/clib/api/units.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include "grackle.h"
 #include "phys_constants.hpp"
+#include "support/config.hpp"
 
 extern "C" double get_velocity_units(const code_units *my_units)
 {
@@ -33,7 +34,7 @@ extern "C" void set_velocity_units(code_units *my_units)
 
 static double get_temperature_units_(double velocity_units)
 {
-  return mh * std::pow(velocity_units, 2.0) / kboltz;
+  return GRIMPL_NS::constants::mH * std::pow(velocity_units, 2.0) / kboltz;
 }
 
 

--- a/src/clib/cool1d_multi_g.cpp
+++ b/src/clib/cool1d_multi_g.cpp
@@ -120,7 +120,7 @@ void grackle::impl::cool1d_multi_g(
       my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
 
   // Declare some constants:
-  const double mh_local_var = mh_grflt;
+  const double mh_local_var = constants::mH_grflt;
 
   const bool single_species_dust_model = my_chemistry->dust_chemistry == 1;
 

--- a/src/clib/cool1d_multi_g.cpp
+++ b/src/clib/cool1d_multi_g.cpp
@@ -258,7 +258,8 @@ void grackle::impl::cool1d_multi_g(
       logT[i] = std::log10(tgas[i]);
       if (my_chemistry->cmb_temperature_floor == 1)
         logTcmb[i] = std::log10(comp2);
-      logrho[i] = std::log10(d(i, idx_range.j, idx_range.k) * dom * mh);
+      logrho[i] =
+          std::log10(d(i, idx_range.j, idx_range.k) * dom * constants::mH);
       if (my_chemistry->primordial_chemistry > 0) {
         logH[i] = std::log10(HI(i, idx_range.j, idx_range.k) * dom);
         logH2[i] = std::log10(HI(i, idx_range.j, idx_range.k) * dom);

--- a/src/clib/cool1d_multi_g.cpp
+++ b/src/clib/cool1d_multi_g.cpp
@@ -288,7 +288,7 @@ void grackle::impl::cool1d_multi_g(
       logdvdr[i] = -8.79947961814e0 + 0.5e0 * logrho[i];  // km/s / cm
       lshield_con[i] =
           std::sqrt((my_chemistry->Gamma * constants::pi_fortran_val *
-                     kboltz_grflt * tgas[i]) /
+                     constants::kboltz_grflt * tgas[i]) /
                     (GravConst_grflt * mmw[i] * mh_local_var *
                      d(i, idx_range.j, idx_range.k) * dom * mh_local_var));
     }

--- a/src/clib/cool1d_multi_g.cpp
+++ b/src/clib/cool1d_multi_g.cpp
@@ -289,7 +289,7 @@ void grackle::impl::cool1d_multi_g(
       lshield_con[i] =
           std::sqrt((my_chemistry->Gamma * constants::pi_fortran_val *
                      constants::kboltz_grflt * tgas[i]) /
-                    (GravConst_grflt * mmw[i] * mh_local_var *
+                    (constants::GravConst_grflt * mmw[i] * mh_local_var *
                      d(i, idx_range.j, idx_range.k) * dom * mh_local_var));
     }
   }

--- a/src/clib/dust/calc_all_tdust_gasgr_1d.cpp
+++ b/src/clib/dust/calc_all_tdust_gasgr_1d.cpp
@@ -37,7 +37,7 @@ void calc_all_tdust_gasgr_1d(
     LnTLinInterpBuf logTlininterp_buf,
     InternalDustPropBuf internal_dust_prop_buf,
     GrainSpeciesCollection grain_kappa) {
-  const double mh_local_var = mh_grflt;
+  const double mh_local_var = constants::mH_grflt;
   int i;
 
   // Cooling/heating slice locals

--- a/src/clib/dust/calc_tdust_1d.hpp
+++ b/src/clib/dust/calc_tdust_1d.hpp
@@ -28,7 +28,7 @@ namespace GRIMPL_NAMESPACE_DECL {
 namespace Tdust_detail {
 
 /// @brief Four times the Stefan-Boltzmann constant
-inline constexpr double sigma_sb_times_4 = 4.0 * sigma_sb_grflt;
+inline constexpr double sigma_sb_times_4 = 4.0 * constants::sigma_sb_grflt;
 
 /// @brief Calculate grain heating/cooling balance
 ///

--- a/src/clib/dust/calc_tdust_3d.cpp
+++ b/src/clib/dust/calc_tdust_3d.cpp
@@ -22,6 +22,7 @@
 #include "field_adaptor.hpp"
 #include "gas_props.hpp"
 #include "grackle.h"
+#include "phys_constants.hpp"
 #include "support/index_helper.hpp"
 #include "inject_model/grain_metal_inject_pathways.hpp"
 #include "inject_model/misc.hpp"
@@ -40,7 +41,7 @@ void calc_tdust_3d(
 )
 {
 
-  const double mh_local_var = mh_grflt;
+  const double mh_local_var = constants::mH_grflt;
 
   // Set unit-related quantities
   const double dom = internalu_calc_dom_(internalu);

--- a/src/clib/grackle_macros.h
+++ b/src/clib/grackle_macros.h
@@ -60,30 +60,6 @@
 #define PFORTRAN_NAME(NAME) FORTRAN_NAME(NAME)
 #endif
 
-/* Function macro for gr_float literal */
-
-/// @def GRFLOAT_C(DBL_LITERAL)
-/// @brief expands to a a floating point literal having the value specified by
-///     it argument and the type `gr_float`. The argument must be a literal
-///     with the type `double`
-///
-/// @par More details
-/// This is directly analogous to the `INT32_C(ARG)` or `INTMAX_C(ARG)` macros
-/// defined by the standard <stdint.h> header, but it is designed for
-/// `gr_float` than rather fixed-size integer types. In more detail:
-/// - if `sizeof(gr_float) == sizeof(float)` the macro expands to the input
-///   argument with the `f` suffix.
-/// - otherwise, the macro expands to the input argument
-///
-/// @par Concrete Example
-/// The snippet, `GRFLOAT_C(1.0)` expands to either `1.0f` or `1.0`.
-#ifdef GRACKLE_FLOAT_4
-  #define INNER_CONCAT_(A, B) A ## B
-  #define GRFLOAT_C(DBL_LITERAL) ( INNER_CONCAT_(DBL_LITERAL, f) )
-#elif defined(GRACKLE_FLOAT_8)
-  #define GRFLOAT_C(DBL_LITERAL) ( DBL_LITERAL )
-#endif
-
 /* Standard definitions (well, fairly standard) */
 
 #ifdef FAIL
@@ -108,10 +84,16 @@
 #define huge 1.0e20
 #endif
 
-// the following 4 are explicitly defined to always match the values used by
-// the fortran layer (in the future, maybe we can consolidate?)
-#define tiny_fortran_val GRFLOAT_C(1.0e-20)
-#define huge_fortran_val GRFLOAT_C(1.0e20)
+// the following constants are explicitly defined to always match the values
+// historically used in the fortran layer (maybe we can consolidate?)
+#ifdef GRACKLE_FLOAT_4
+#define tiny_fortran_val 1.0e-20f
+#define huge_fortran_val 1.0e20f
+#elif defined(GRACKLE_FLOAT_8)
+#define tiny_fortran_val 1.0e-20
+#define huge_fortran_val 1.0e20
+#endif
+
 #define tiny8 1.0e-40
 #define huge8 1.0e40
 

--- a/src/clib/initialize_rates.cpp
+++ b/src/clib/initialize_rates.cpp
@@ -496,8 +496,8 @@ int grackle::impl::initialize_rates(
     *   a constant (it has a factor a^3), so the number densities must be converted
     *   from comoving to proper.
     */ 
-    double kUnit = (pow(my_units->a_units, 3) * mh) / (densityBase1 * timeBase1);
-    double kUnit_3Bdy = kUnit * (pow(my_units->a_units, 3) * mh) / densityBase1;
+    double kUnit = (pow(my_units->a_units, 3) * constants::mH) / (densityBase1 * timeBase1);
+    double kUnit_3Bdy = kUnit * (pow(my_units->a_units, 3) * constants::mH) / densityBase1;
 
     /*
     * 2) Set the dimensions of the cooling coefficients.
@@ -526,7 +526,7 @@ int grackle::impl::initialize_rates(
     *   are different by the reciprocal of the above factor multiplying [L]).
     * 
     */
-    double coolingUnits = (pow(my_units->a_units, 5) * pow(lengthBase1, 2) * pow(mh, 2))
+    double coolingUnits = (pow(my_units->a_units, 5) * pow(lengthBase1, 2) * pow(constants::mH, 2))
                           / (densityBase1 * pow(timeBase1, 3));
 
     if (my_chemistry->use_primordial_continuum_opacity == 1) {

--- a/src/clib/internal_units.hpp
+++ b/src/clib/internal_units.hpp
@@ -205,7 +205,7 @@ inline double internalu_get_mh_(InternalGrUnits internalu) {
   // initialized as a floating point literal (with the same precision as
   // gr_float and then it is casted to a double)
   switch (internalu.mh_choice_) {
-    case InternalU_MassH_Choice::DOUBLE: return mh;
+    case InternalU_MassH_Choice::DOUBLE: return constants::mH;
     case InternalU_MassH_Choice::GRFLOAT: return (double)(constants::mH_grflt);
     case InternalU_MassH_Choice::ABBREVIATED: return 1.67e-24;
   }

--- a/src/clib/internal_units.hpp
+++ b/src/clib/internal_units.hpp
@@ -49,13 +49,10 @@ namespace GRIMPL_NAMESPACE_DECL {
 /// code. Once we finish transcription, we'll "rip the band-aid off" and use
 /// a consistent constant throughout the codebase.
 enum class InternalU_MassH_Choice {
-  /// - A value of 1 indicates that we'll use `mh_grflt` (the constant is
-  ///   expressed as a value of type gr_float -- this is consistent with what
-  ///   Grackle's Fortran routines have historically done).
   /// Denotes that we'll use `mh` which is always expressed as a double. Prior
   /// to transcription, nearly all of Grackle's C functions used this constant
   DOUBLE = 1,
-  /// Denotes that we'll use `mh_grflt`, which is always expressed a value of
+  /// Denotes that we'll use `constants::mH_grflt`, which is always expressed a value of
   /// type gr_float. Prior to transcription, all of Grackle's Fortran's
   /// functions used this constant
   GRFLOAT = 2,
@@ -209,7 +206,7 @@ inline double internalu_get_mh_(InternalGrUnits internalu) {
   // gr_float and then it is casted to a double)
   switch (internalu.mh_choice_) {
     case InternalU_MassH_Choice::DOUBLE: return mh;
-    case InternalU_MassH_Choice::GRFLOAT: return (double)(mh_grflt);
+    case InternalU_MassH_Choice::GRFLOAT: return (double)(constants::mH_grflt);
     case InternalU_MassH_Choice::ABBREVIATED: return 1.67e-24;
   }
   return NAN; // should be unreachable

--- a/src/clib/internal_units.hpp
+++ b/src/clib/internal_units.hpp
@@ -257,7 +257,7 @@ inline double internalu_calc_coef_ljeans_(InternalGrUnits internalu,
                                                  double gamma) {
   const double mh_local_var = internalu_get_mh_(internalu);
   return sqrt((gamma * constants::pi_fortran_val * constants::kboltz_grflt) /
-              (GravConst_grflt * mh_local_var * internalu.dbase1));
+              (constants::GravConst_grflt * mh_local_var * internalu.dbase1));
 }
 
 

--- a/src/clib/internal_units.hpp
+++ b/src/clib/internal_units.hpp
@@ -256,7 +256,7 @@ inline double internalu_calc_dom_(InternalGrUnits internalu) {
 inline double internalu_calc_coef_ljeans_(InternalGrUnits internalu,
                                                  double gamma) {
   const double mh_local_var = internalu_get_mh_(internalu);
-  return sqrt((gamma * constants::pi_fortran_val * kboltz_grflt) /
+  return sqrt((gamma * constants::pi_fortran_val * constants::kboltz_grflt) /
               (GravConst_grflt * mh_local_var * internalu.dbase1));
 }
 

--- a/src/clib/lookup_cool_rates1d.hpp
+++ b/src/clib/lookup_cool_rates1d.hpp
@@ -61,7 +61,7 @@ void secondary_ionization_adjustments(IndexRange idx_range,
       my_fields->HII_density, my_fields->grid_dimension[0],
       my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
 
-  const double everg = ev2erg_grflt;
+  const double everg = constants::ev2erg_grflt;
   const double e24 = 13.6;
   const double e26 = 24.6;
 

--- a/src/clib/lookup_cool_rates1d.hpp
+++ b/src/clib/lookup_cool_rates1d.hpp
@@ -390,8 +390,9 @@ inline void model_H2I_dissociation_shielding(
                          (-0.9639 * std::log10(tgas_touse) + 3.892);
 
         double x = 2.0e-15 * N_H2;
-        double b_doppler = 1e-5 * std::sqrt(2. * kboltz_grflt * tgas1d[i] /
-                                            (2. * constants::mH_grflt));
+        double b_doppler =
+            1e-5 * std::sqrt(2. * constants::kboltz_grflt * tgas1d[i] /
+                             (2. * constants::mH_grflt));
         double f_shield =
             0.965 / std::pow((1. + x / b_doppler), aWG2019) +
             0.035 * std::exp(-8.5e-4 * std::sqrt(1. + x)) / std::sqrt(1. + x);

--- a/src/clib/lookup_cool_rates1d.hpp
+++ b/src/clib/lookup_cool_rates1d.hpp
@@ -390,8 +390,8 @@ inline void model_H2I_dissociation_shielding(
                          (-0.9639 * std::log10(tgas_touse) + 3.892);
 
         double x = 2.0e-15 * N_H2;
-        double b_doppler =
-            1e-5 * std::sqrt(2. * kboltz_grflt * tgas1d[i] / (2. * mh_grflt));
+        double b_doppler = 1e-5 * std::sqrt(2. * kboltz_grflt * tgas1d[i] /
+                                            (2. * constants::mH_grflt));
         double f_shield =
             0.965 / std::pow((1. + x / b_doppler), aWG2019) +
             0.035 * std::exp(-8.5e-4 * std::sqrt(1. + x)) / std::sqrt(1. + x);

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -54,12 +54,11 @@ namespace GRIMPL_NAMESPACE_DECL {
 
 /************************************************/
 
-/* Boltzmann's constant [cm2gs-2K-1] or [ergK-1] */
-
-#define kboltz 1.3806504e-16
-#define kboltz_grflt GRFLOAT_C(kboltz)
-
 namespace constants {
+/// @brief Boltzmann's constant [cm^2 g s^-2 K^-1] or [erg K^-1]
+inline constexpr double kboltz = 1.3806504e-16;
+inline constexpr gr_float kboltz_grflt = static_cast<gr_float>(kboltz);
+
 /// @brief mass of hydrogen [g]
 inline constexpr double mH = 1.67262171e-24;
 inline constexpr gr_float mH_grflt = static_cast<gr_float>(mH);

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -112,17 +112,22 @@ inline constexpr gr_float kpc_grflt = static_cast<gr_float>(kpc);
 inline constexpr gr_float pc = 3.0857e18;
 inline constexpr gr_float pc_grflt = static_cast<gr_float>(pc);
 
-}  // namespace constants
-
 /************************************************/
 
 /* Miscellaneous values adopted from phys_const.def */
 
 /************************************************/
 
-#define hplanck_grflt GRFLOAT_C(6.6260693e-27)
-#define ev2erg_grflt GRFLOAT_C(1.60217653e-12)
-#define sigma_sb_grflt GRFLOAT_C(5.670373e-5)
+/// @brief Planck's constant [g cm^2 s^-1]
+inline constexpr gr_float hplanck_grflt = static_cast<gr_float>(6.6260693e-27);
+
+/// @brief ergs per electronvolt (eV)
+inline constexpr gr_float ev2erg_grflt = static_cast<gr_float>(1.60217653e-12);
+
+/// @brief Stefan–Boltzmann constant [g s^-3 K^-4]
+inline constexpr gr_float sigma_sb_grflt = static_cast<gr_float>(5.670373e-5);
+
+}  // namespace constants
 
 /** @}*/  // end of group
 

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -20,7 +20,6 @@
 
 #include "grackle.h"  // gr_float
 #include "grackle_float.h"
-#include "grackle_macros.h"  // GRFLOAT_C
 #include "support/config.hpp"
 
 // reminder macros are totally unaffected by the presence of this namespace

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -26,35 +26,19 @@
 // reminder macros are totally unaffected by the presence of this namespace
 namespace GRIMPL_NAMESPACE_DECL {
 
-/// @defgroup PhysConsts Physical Constants
+/// @brief This namespace specifies physical constants (in CGS units)
 ///
-/// This group of entities specify Physical Constants (in CGS units)
-///
-/// Historically, all constants in this file always expanded to floating point
-/// values of type `double`.
-/// - In constrast, the "phys_const.def" fortran header always defined
-///   macro-constants that expand to floating-point values of type `gr_float`.
-/// - To aide with transcribing code from Fortran to C/C++ we have
-///   defined versions of most constants in this file that expand to constant
-///   of type `gr_float`. These constants have the `_grflt` suffix.
-///
-/// Ideas for the future:
-/// =====================
-/// - It would be nice to do away with the alternative versions of these
-///   constants
-/// - It would be nice to convert all constants from MACROS to c++ constans
-///   (reminiscent of the style of the <numbers> header from C++ 20)
-///   - it's generally considered better practice to use named constants than
-///     macros (it can certainly simplify things with debuggers)
-///   - we've already started to do this with the pi constants (this was spurred
-///     on by the fact that error arose with g++ if we targetted C++ 20)
-/** @{*/
-
-/* Physics constants */
-
-/************************************************/
-
+/// The constants ending with a _grflt underscore exist in order to aide with
+/// transcription (the original fortran logic defined macro-constants that
+/// expanded to literals of type gr_float). Now that transcription is complete
+/// it would be nice to remove all versions of the constants with the _gr_flt
+/// suffix (but that will require an update to the gold standard).
 namespace constants {
+
+//************************************************
+// Physics constants
+//************************************************
+
 /// @brief Boltzmann's constant [cm^2 g s^-2 K^-1] or [erg K^-1]
 inline constexpr double kboltz = 1.3806504e-16;
 inline constexpr gr_float kboltz_grflt = static_cast<gr_float>(kboltz);
@@ -82,11 +66,9 @@ inline constexpr float pi_fortran_val = 3.14159265f;
 inline constexpr double pi_fortran_val = 3.141592653589793;
 #endif
 
-/************************************************/
-
-/* Astronomical constant */
-
-/************************************************/
+//************************************************
+// Astronomical constant
+//************************************************
 
 /// @brief Speed of light [cm s^-1]
 inline constexpr double clight = 2.99792458e10;
@@ -112,11 +94,9 @@ inline constexpr gr_float kpc_grflt = static_cast<gr_float>(kpc);
 inline constexpr gr_float pc = 3.0857e18;
 inline constexpr gr_float pc_grflt = static_cast<gr_float>(pc);
 
-/************************************************/
-
-/* Miscellaneous values adopted from phys_const.def */
-
-/************************************************/
+//*************************************************
+// Miscellaneous values adopted from phys_const.def
+//*************************************************
 
 /// @brief Planck's constant [g cm^2 s^-1]
 inline constexpr gr_float hplanck_grflt = static_cast<gr_float>(6.6260693e-27);
@@ -129,9 +109,6 @@ inline constexpr gr_float ev2erg_grflt = static_cast<gr_float>(ev2erg);
 inline constexpr gr_float sigma_sb_grflt = static_cast<gr_float>(5.670373e-5);
 
 }  // namespace constants
-
-/** @}*/  // end of group
-
 }  // namespace GRIMPL_NAMESPACE_DECL
 
 #endif  // PHYS_CONSTANTS_HPP

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -81,7 +81,6 @@ inline constexpr float pi_fortran_val = 3.14159265f;
 #else
 inline constexpr double pi_fortran_val = 3.141592653589793;
 #endif
-}  // namespace constants
 
 /************************************************/
 
@@ -89,20 +88,19 @@ inline constexpr double pi_fortran_val = 3.141592653589793;
 
 /************************************************/
 
-/* Speed of light [cms-1] */
+/// @brief Speed of light [cm s^-1]
+inline constexpr double clight = 2.99792458e10;
+inline constexpr gr_float clight_grflt = static_cast<gr_float>(clight);
 
-#define clight 2.99792458e10
-#define clight_grflt GRFLOAT_C(clight)
+/// @brief Gravitational constant [cm^3 g^-1 s^-2]
+inline constexpr double GravConst = 6.67428e-8;
+inline constexpr gr_float GravConst_grflt = static_cast<gr_float>(GravConst);
 
-/* Gravitational constant [cm3g-1s-2]*/
+/// @brief Solar mass [g]
+inline constexpr double SolarMass = 1.9891e33;
+inline constexpr gr_float SolarMass_grflt = static_cast<gr_float>(SolarMass);
 
-#define GravConst 6.67428e-8
-#define GravConst_grflt GRFLOAT_C(GravConst)
-
-/* Solar mass [g] */
-
-#define SolarMass 1.9891e33
-#define SolarMass_grflt GRFLOAT_C(SolarMass)
+}  // namespace constants
 
 /* Megaparsec [cm] */
 

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -59,13 +59,10 @@ namespace GRIMPL_NAMESPACE_DECL {
 #define kboltz 1.3806504e-16
 #define kboltz_grflt GRFLOAT_C(kboltz)
 
-/* Mass of hydrogen [g] */
-
-#define mh 1.67262171e-24
-
 namespace constants {
-
-inline constexpr gr_float mH_grflt = GRFLOAT_C(mh);
+/// @brief mass of hydrogen [g]
+inline constexpr double mH = 1.67262171e-24;
+inline constexpr gr_float mH_grflt = static_cast<gr_float>(mH);
 
 /// @brief mass of an electron [g]
 inline constexpr double me = 9.10938215e-28;

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -62,9 +62,10 @@ namespace GRIMPL_NAMESPACE_DECL {
 /* Mass of hydrogen [g] */
 
 #define mh 1.67262171e-24
-#define mh_grflt GRFLOAT_C(mh)
 
 namespace constants {
+
+inline constexpr gr_float mH_grflt = GRFLOAT_C(mh);
 
 /// @brief mass of an electron [g]
 inline constexpr double me = 9.10938215e-28;

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -122,7 +122,8 @@ inline constexpr gr_float pc_grflt = static_cast<gr_float>(pc);
 inline constexpr gr_float hplanck_grflt = static_cast<gr_float>(6.6260693e-27);
 
 /// @brief ergs per electronvolt (eV)
-inline constexpr gr_float ev2erg_grflt = static_cast<gr_float>(1.60217653e-12);
+inline constexpr double ev2erg = 1.60217653e-12;
+inline constexpr gr_float ev2erg_grflt = static_cast<gr_float>(ev2erg);
 
 /// @brief Stefan–Boltzmann constant [g s^-3 K^-4]
 inline constexpr gr_float sigma_sb_grflt = static_cast<gr_float>(5.670373e-5);

--- a/src/clib/phys_constants.hpp
+++ b/src/clib/phys_constants.hpp
@@ -100,18 +100,19 @@ inline constexpr gr_float GravConst_grflt = static_cast<gr_float>(GravConst);
 inline constexpr double SolarMass = 1.9891e33;
 inline constexpr gr_float SolarMass_grflt = static_cast<gr_float>(SolarMass);
 
+/// @brief Megaparsec [cm]
+inline constexpr gr_float Mpc = 3.0857e24;
+inline constexpr gr_float Mpc_grflt = static_cast<gr_float>(Mpc);
+
+/// @brief kiloparsec [cm]
+inline constexpr gr_float kpc = 3.0857e21;
+inline constexpr gr_float kpc_grflt = static_cast<gr_float>(kpc);
+
+/// @brief parsec [cm]
+inline constexpr gr_float pc = 3.0857e18;
+inline constexpr gr_float pc_grflt = static_cast<gr_float>(pc);
+
 }  // namespace constants
-
-/* Megaparsec [cm] */
-
-#define Mpc 3.0857e24
-#define Mpc_grflt GRFLOAT_C(Mpc)
-
-#define kpc 3.0857e21
-#define kpc_grflt GRFLOAT_C(kpc)
-
-#define pc 3.0857e18
-#define pc_grflt GRFLOAT_C(pc)
 
 /************************************************/
 

--- a/src/clib/rate_functions.cpp
+++ b/src/clib/rate_functions.cpp
@@ -949,11 +949,11 @@ extern "C" double reHeII1_rate(double T, double units, chemistry_data *my_chemis
 
         //These depend on if the user has chosen recombination case A or B.
         if (my_chemistry->CaseBRecombination == 1) {
-            return 1.26e-14 * kboltz * T * std::pow(lambdaHeII, 0.75)
-                            / units;
+            return (1.26e-14 * GRIMPL_NS::constants::kboltz * T
+                    * std::pow(lambdaHeII, 0.75) / units);
         } else {
-            return 3e-14 * kboltz * T * std::pow(lambdaHeII, 0.654)
-                    / units;
+            return (3e-14 * GRIMPL_NS::constants::kboltz * T *
+                    std::pow(lambdaHeII, 0.654) / units);
         }
     } else {
         return tiny;
@@ -1038,7 +1038,8 @@ extern "C" double hyd01k_rate(double T, double units, chemistry_data *my_chemist
         par_dum = 1.4e-13 * std::exp( (T / 125.0) - std::pow(T / 577.0, 2) );
     }
 
-    return par_dum * std::exp( -std::fmin( std::log(dhuge), 8.152e-13 / (kboltz * T) ) )
+    return par_dum * std::exp( -std::fmin( std::log(dhuge),
+                                           8.152e-13 / (GRIMPL_NS::constants::kboltz * T) ) )
             / units;
 }
             
@@ -1046,7 +1047,8 @@ extern "C" double hyd01k_rate(double T, double units, chemistry_data *my_chemist
 extern "C" double h2k01_rate(double T, double units, chemistry_data *my_chemistry)
 {
     //Dummy parameter used in the calculation.
-    double par_dum = 8.152e-13 * ( 4.2 / (kboltz * (T + 1190.0)) + 1.0 / (kboltz * T));
+    double par_dum = 8.152e-13 * ( 4.2 / (GRIMPL_NS::constants::kboltz * (T + 1190.0))
+        + 1.0 / (GRIMPL_NS::constants::kboltz * T));
 
     return 1.45e-12 * std::sqrt(T) * std::exp(-std::fmin(std::log(dhuge), par_dum)) / units;
 }
@@ -1438,9 +1440,9 @@ extern "C" double gasGrain2_rate(double T, double units, chemistry_data *my_chem
 {
   namespace constants = ::GRIMPL_NS::constants;
   double f_vel = 0.5 / std::sqrt(2.0) + 0.0833333 / std::sqrt(4.0);
-  double vH_avg = std::sqrt(kboltz * T / 2.0 / constants::pi / constants::mH);
+  double vH_avg = std::sqrt(constants::kboltz * T / 2.0 / constants::pi / constants::mH);
 
-  return (dust_dampener(T) * f_vel * 4.0 * vH_avg * 2.0 * kboltz * constants::mH
+  return (dust_dampener(T) * f_vel * 4.0 * vH_avg * 2.0 * constants::kboltz * constants::mH
           / units);
   // Later multiplied by sigma_gr / mass_gr for arbitrary size distribution.
 }
@@ -1507,9 +1509,10 @@ extern "C" double gamma_isrf2_rate(double units, chemistry_data *my_chemistry)
 //Calculation of grain growth rate.
 extern "C" double grain_growth_rate(double T, double units, chemistry_data *my_chemistry)
 {
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / GRIMPL_NS::constants::pi
-                               / GRIMPL_NS::constants::mH);
-    return 4.0 * vH_avg * GRIMPL_NS::constants::mH / units;
+    namespace constants = ::GRIMPL_NS::constants;
+    double vH_avg = std::sqrt( constants::kboltz * T / 2.0 / constants::pi
+                               / constants::mH);
+    return 4.0 * vH_avg * constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted
     // onto the entire surface area of grains.
 }
@@ -1529,7 +1532,7 @@ extern "C" double h2dust_S_rate(double T, double T_dust, double units, chemistry
     double bHP_aPC = 1.0/4.0 * std::pow(1.0 + std::sqrt((E_HC_Silicate - E_S_Silicate) /
                      (E_HP_Silicate - E_S_Silicate)), 2.0) * std::exp(-E_S_Silicate / T_dust);
     double epsilon_H2 = std::pow(1.0 + bHP_aPC, -1.0);
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / constants::pi / constants::mH);
+    double vH_avg = std::sqrt( constants::kboltz * T / 2.0 / constants::pi / constants::mH);
 
     return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted
@@ -1551,7 +1554,7 @@ extern "C" double h2dust_C_rate(double T, double T_dust, double units, chemistry
     double bHP_aPC = 1.0/4.0 * std::pow(1.0 + std::sqrt((E_HC_AmCarbon - E_S_AmCarbon) /
                      (E_HP_AmCarbon - E_S_AmCarbon)), 2.0) * std::exp(-E_S_AmCarbon / T_dust);
     double epsilon_H2 = std::pow(1.0 + bHP_aPC, -1.0);
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / constants::pi / constants::mH);
+    double vH_avg = std::sqrt( constants::kboltz * T / 2.0 / constants::pi / constants::mH);
 
     return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted

--- a/src/clib/rate_functions.cpp
+++ b/src/clib/rate_functions.cpp
@@ -1386,7 +1386,7 @@ extern "C" double cieco_rate(double T, double units, chemistry_data *my_chemistr
 {
     double cierate = cie_thin_cooling_rate(T);
 
-    return cierate * (mh/2.0) / units;
+    return cierate * (GRIMPL_NS::constants::mH/2.0) / units;
 }
 
 extern "C" double dust_dampener(double T)
@@ -1436,10 +1436,12 @@ extern "C" double gasGrain_rate(double T, double units, chemistry_data *my_chemi
 
 extern "C" double gasGrain2_rate(double T, double units, chemistry_data *my_chemistry)
 {
+  namespace constants = ::GRIMPL_NS::constants;
   double f_vel = 0.5 / std::sqrt(2.0) + 0.0833333 / std::sqrt(4.0);
-  double vH_avg = std::sqrt(kboltz * T / 2.0 / GRIMPL_NS::constants::pi / mh);
+  double vH_avg = std::sqrt(kboltz * T / 2.0 / constants::pi / constants::mH);
 
-  return dust_dampener(T) * f_vel * 4.0 * vH_avg * 2.0 * kboltz * mh / units;
+  return (dust_dampener(T) * f_vel * 4.0 * vH_avg * 2.0 * kboltz * constants::mH
+          / units);
   // Later multiplied by sigma_gr / mass_gr for arbitrary size distribution.
 }
 
@@ -1479,11 +1481,11 @@ extern "C" double gamma_isrf_rate(double units, chemistry_data *my_chemistry)
   if (my_chemistry->uniform_grain_isrf_heating_rate == 0) {
     // (Equation B15, Krumholz, 2014)
     // Don't normalize by coolunit since tdust calculation is done in CGS.
-    return 3.9e-24 / mh / fgr;
+    return 3.9e-24 / GRIMPL_NS::constants::mH / fgr;
   }
   else if (my_chemistry->uniform_grain_isrf_heating_rate == 1) {
     // For uniform grain size (Goldsmith 2001; Krumholz 2014)
-    return 8.60892e-24 / (2.0 * mh) / fgr;
+    return 8.60892e-24 / (2.0 * GRIMPL_NS::constants::mH) / fgr;
     // F_isrf sigma_gr / mass_gr
     // For MRN-like broken power low size distribution (Omukai 2000)
     // The factor 2 to cancel out the molecular mass of H2.
@@ -1505,8 +1507,9 @@ extern "C" double gamma_isrf2_rate(double units, chemistry_data *my_chemistry)
 //Calculation of grain growth rate.
 extern "C" double grain_growth_rate(double T, double units, chemistry_data *my_chemistry)
 {
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / GRIMPL_NS::constants::pi / mh);
-    return 4.0 * vH_avg * mh / units;
+    double vH_avg = std::sqrt( kboltz * T / 2.0 / GRIMPL_NS::constants::pi
+                               / GRIMPL_NS::constants::mH);
+    return 4.0 * vH_avg * GRIMPL_NS::constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted
     // onto the entire surface area of grains.
 }
@@ -1514,6 +1517,7 @@ extern "C" double grain_growth_rate(double T, double units, chemistry_data *my_c
 //Calculation of H2 formation rate on S grain surfaces. (Cazaux & Tielens 2002)
 extern "C" double h2dust_S_rate(double T, double T_dust, double units, chemistry_data *my_chemistry)
 {
+    namespace constants = ::GRIMPL_NS::constants;
     // Constants. 
     double E_HC_Silicate = 200.0, E_HP_Silicate = 650.0, E_S_Silicate = 3.0e4;
 
@@ -1525,9 +1529,9 @@ extern "C" double h2dust_S_rate(double T, double T_dust, double units, chemistry
     double bHP_aPC = 1.0/4.0 * std::pow(1.0 + std::sqrt((E_HC_Silicate - E_S_Silicate) /
                      (E_HP_Silicate - E_S_Silicate)), 2.0) * std::exp(-E_S_Silicate / T_dust);
     double epsilon_H2 = std::pow(1.0 + bHP_aPC, -1.0);
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / GRIMPL_NS::constants::pi / mh);
+    double vH_avg = std::sqrt( kboltz * T / 2.0 / constants::pi / constants::mH);
 
-    return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * mh / units;
+    return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted
     // onto the entire surface area of grains.
 }
@@ -1535,6 +1539,7 @@ extern "C" double h2dust_S_rate(double T, double T_dust, double units, chemistry
 //Calculation of H2 formation rate on C grain surfaces. (Cazaux & Tielens 2002)
 extern "C" double h2dust_C_rate(double T, double T_dust, double units, chemistry_data *my_chemistry)
 {
+    namespace constants = ::GRIMPL_NS::constants;
     // Constants.
     double E_HC_AmCarbon = 250.0, E_HP_AmCarbon = 800.0, E_S_AmCarbon = 3.0e4;
 
@@ -1546,9 +1551,9 @@ extern "C" double h2dust_C_rate(double T, double T_dust, double units, chemistry
     double bHP_aPC = 1.0/4.0 * std::pow(1.0 + std::sqrt((E_HC_AmCarbon - E_S_AmCarbon) /
                      (E_HP_AmCarbon - E_S_AmCarbon)), 2.0) * std::exp(-E_S_AmCarbon / T_dust);
     double epsilon_H2 = std::pow(1.0 + bHP_aPC, -1.0);
-    double vH_avg = std::sqrt( kboltz * T / 2.0 / GRIMPL_NS::constants::pi / mh);
+    double vH_avg = std::sqrt( kboltz * T / 2.0 / constants::pi / constants::mH);
 
-    return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * mh / units;
+    return 0.5 * 4.0 * vH_avg * S_H * epsilon_H2 * constants::mH / units;
     // Factor of 4 because gas-phase molecules are accreted
     // onto the entire surface area of grains.
 }

--- a/src/clib/update_UVbackground_rates.cpp
+++ b/src/clib/update_UVbackground_rates.cpp
@@ -169,10 +169,10 @@ int grackle::impl::update_UVbackground_rates(const chemistry_data *my_chemistry,
   // Now convert the rates to code units.
 
   InternalGrUnits internalu = new_internalu_legacy_C_(my_units);
-  double ev2erg = 1.60217653e-12;
+
   /* compared to Enzo source, there's an additional factor of
      1/ev2erg here, because the heating rates are stored as eV/s. */
-  double CoolingUnits = internalu.coolunit / ev2erg;
+  double CoolingUnits = internalu.coolunit / constants::ev2erg;
 
   my_uvb_rates->k24 *= my_units->time_units;
   my_uvb_rates->k25 *= my_units->time_units;


### PR DESCRIPTION
This is intended to be a followup to PR #603.

-------

In PR #603, I floated the idea of converting physical constants from macros to constants (I made that change for `pi` to avoid a compilation issue with c++ 20, but was hesitant to go further because it might change the gold-standard and I wanted to minimize the number of files that I touched).

This PR makes the conversion for all other constants in `phys_constants.hpp`

I also removed the `GRFLOAT_C` since it primarily existed to help us define the `_grflt` versions of the macros.

I'm still not entirely sure whether this is going to require a gold-standard update (I don't think it will, but we'll see after all the tests finish running)