### PR TITLE
[newchem-cpp] miscellaneous install bugs

### DIFF
--- a/cmake/GrackleConfig.cmake.in
+++ b/cmake/GrackleConfig.cmake.in
@@ -251,30 +251,46 @@ if (${_GRACKLE_LIBKIND} STREQUAL "static")
 
   unset(_FIND_H5_ARGS)
 
-  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
-    list(APPEND _EXTRA_ARGS QUIET)
-  endif()
-
-  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
-    list(APPEND _EXTRA_ARGS REQUIRED)
-  endif()
+  # the order in which we build up _FIND_H5_ARGS matters!
 
   # if we know the HDF5 version used to build to build Grackle as a static
-  # library, we really need to make sure the version number of the hdf5 library
-  # match the version number of the hdf5-headers (the documentation for the
-  # H5check_version function makes it clear a mismatch is bad!)
+  # library, we really should try to request it
   set(_DESIRED_HDF5_VERSION "@HDF5_VERSION@")
   if(NOT "${_DESIRED_HDF5_VERSION}" STREQUAL "")
-    list(APPEND _EXTRA_ARGS "${_DESIRED_HDF5_VERSION}" EXACT)
+    list(APPEND _FIND_H5_ARGS "${_DESIRED_HDF5_VERSION}")
+    if ("${_DESIRED_HDF5_VERSION}" VERSION_LESS "2.0.0")
+      # prior to version 2.0, HDF5 did not adhere to semver
+      # -> in this case, we REALLY need to make sure the version number of the
+      #    hdf5 library matches the version number of the hdf5-headers (the
+      #    documentation for the H5check_version function makes it clear a
+      #    mismatch is bad!)
+      list(APPEND _FIND_H5_ARGS EXACT)
+    else()
+      # do NOT append EXACT
+      # -> starting with HDF5 2.0, HDF5 is only ever built with CMake and we
+      #    can rely upon the version compatability checks provided in HDF5's
+      #    Config Package File
+    endif()
   endif()
   unset(_DESIRED_HDF5_VERSION)
 
+  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+    list(APPEND _FIND_H5_ARGS QUIET)
+  endif()
+
+  if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
+    list(APPEND _FIND_H5_ARGS REQUIRED)
+  endif()
+
+  set(_FIND_H5_ARGS "${_FIND_H5_ARGS};COMPONENTS;C")
+
   # now we actually find the dependencies
-  find_package(HDF5 COMPONENTS C ${_EXTRA_ARGS})
+  find_package(HDF5 ${_FIND_H5_ARGS})
   if(NOT HDF5_FOUND)
     _FIND_GRACKLE_FAIL(
       "Grackle couldn't be found because dependency HDF5 couldn't be found")
   endif()
+  unset(_FIND_H5_ARGS)
   # declare HDF5 target (details are omitted that aren't needed for linking)
   add_library(GRACKLE_HDF5_C INTERFACE IMPORTED)
   set_target_properties(GRACKLE_HDF5_C PROPERTIES

--- a/doc/source/Integration.rst
+++ b/doc/source/Integration.rst
@@ -168,7 +168,7 @@ The following snippet shows a sample Makefile for compiling a sample application
 
    c_example:
    	$(CC) $(CFLAGS) -c c_example.c -o c_example.o
-   	$(CC) $(LDFLAGS) $(OTHER_LDFLAGS) c_example.o -o c_example
+   	$(CC) c_example.o $(LDFLAGS) $(OTHER_LDFLAGS) -o c_example
 
 pkg-config also provides additional functionality, like querying version numbers, enforcing version requirements, etc.
 Most of that functionality is described in `this guide <https://people.freedesktop.org/~dbn/pkg-config-guide.html>`__.


### PR DESCRIPTION
To be reviewed after #620 is merged (strictly speaking, it doesn't depend on anything within #620, but they are both dependencies in a chain of PRs)

------

This addresses 2 long-standing installation-related bugs
1. It resolves an issue with static linking of Grackle via CMake
2. It resolves an issue with a sample Makefile shown in the documentation