### PR TITLE
Ncc/update lut

### DIFF
--- a/src/clib/LUT.hpp
+++ b/src/clib/LUT.hpp
@@ -77,7 +77,7 @@ struct SpLUT {
   // XMacros provided in grackle_field_data_fdatamembers.def (or we may need to
   // slightly revise the system?)
   enum {
-#define ENTRY(NAME) NAME,
+#define ENTRY(NAME, DUMMY_ARG) NAME,
 #include "field_data_evolved_species.def"
 #undef ENTRY
 

--- a/src/clib/LUT.hpp
+++ b/src/clib/LUT.hpp
@@ -86,29 +86,65 @@ struct SpLUT {
 
 };  // SpLUT struct
 
-/// Define a LUT that ONLY contains grain species
-struct OnlyGrainSpLUT {
-  // in the future, we may want to reimplement the following in terms of the
-  // XMacros provided in grackle_field_data_fdatamembers.def (or we may need to
-  // slightly revise the system?)
+/// @brief Define a LUT that ONLY contains primordial species
+struct PrimordialSpLUT {
   enum {
-    MgSiO3_dust,
-    AC_dust,
-    SiM_dust,
-    FeM_dust,
-    Mg2SiO4_dust,
-    Fe3O4_dust,
-    SiO2_dust,
-    MgO_dust,
-    FeS_dust,
-    Al2O3_dust,
-    ref_org_dust,
-    vol_org_dust,
-    H2O_ice_dust,
+#define ENUMERATOR_Primordial(NAME) NAME,
+#define ENUMERATOR_Metal(NAME) /* ... */
+#define ENUMERATOR_Dust(NAME)  /* ... */
+#define ENTRY(NAME, KIND) ENUMERATOR_##KIND(NAME)
+
+#include "field_data_evolved_species.def"
+
+#undef ENUMERATOR_Primordial
+#undef ENUMERATOR_Metal
+#undef ENUMERATOR_Dust
+#undef ENTRY
 
     NUM_ENTRIES  // <- always last (so it specifies the number of species)
   };
-};  // struct OnlyGrainSpLUT
+};
+
+/// @brief Define a LUT that ONLY contains metal species
+struct MetalSpLUT {
+  enum {
+#define ENUMERATOR_Primordial(NAME) /* ... */
+#define ENUMERATOR_Metal(NAME) NAME,
+#define ENUMERATOR_Dust(NAME) /* ... */
+#define ENTRY(NAME, KIND) ENUMERATOR_##KIND(NAME)
+
+#include "field_data_evolved_species.def"
+
+#undef ENUMERATOR_Primordial
+#undef ENUMERATOR_Metal
+#undef ENUMERATOR_Dust
+#undef ENTRY
+
+    NUM_ENTRIES  // <- always last (so it specifies the number of species)
+  };
+};
+
+/// @brief Define a LUT that ONLY contains evolved dust grain species
+struct DustSpLUT {
+  enum {
+#define ENUMERATOR_Primordial(NAME) /* ... */
+#define ENUMERATOR_Metal(NAME)      /* ... */
+#define ENUMERATOR_Dust(NAME) NAME,
+#define ENTRY(NAME, KIND) ENUMERATOR_##KIND(NAME)
+
+#include "field_data_evolved_species.def"
+
+#undef ENUMERATOR_Primordial
+#undef ENUMERATOR_Metal
+#undef ENUMERATOR_Dust
+#undef ENTRY
+
+    NUM_ENTRIES  // <- always last (so it specifies the number of species)
+  };
+};
+
+/// This alias exists for historical consistency
+using OnlyGrainSpLUT = DustSpLUT;
 
 /// Defines the LUT for Standard Collisional reaction rates
 ///

--- a/src/clib/api/set_default_chemistry_parameters.cpp
+++ b/src/clib/api/set_default_chemistry_parameters.cpp
@@ -58,7 +58,8 @@ extern "C" int gr_initialize_field_data(grackle_field_data *my_fields)
   // to hold datafields, to have values of NULL
 
   // part 1: modify species-field members that grackle can evolve
-  #define ENTRY(SPECIES_NAME) my_fields->SPECIES_NAME ## _density = nullptr;
+  #define ENTRY(SPECIES_NAME, DUMMY_ARG) \
+      my_fields->SPECIES_NAME ## _density = nullptr;
   #include "field_data_evolved_species.def"
   #undef ENTRY
 

--- a/src/clib/field_adaptor.hpp
+++ b/src/clib/field_adaptor.hpp
@@ -57,7 +57,8 @@ inline void copy_offset_fieldmember_ptrs_(grackle_field_data* dest,
       (src->MEMBER_NAME == NULL) ? NULL : src->MEMBER_NAME + offset;
 
 // part 1: handle species-field members that grackle can evolve
-#define ENTRY(SPECIES_NAME) GRIMPL_OFFSET_PTR_CPY(SPECIES_NAME##_density)
+#define ENTRY(SPECIES_NAME, DUMMY_ARG)                                         \
+  GRIMPL_OFFSET_PTR_CPY(SPECIES_NAME##_density)
 #include "field_data_evolved_species.def"
 #undef ENTRY
 
@@ -95,7 +96,7 @@ inline void copy_contigSpTable_fieldmember_ptrs_(grackle_field_data* my_fields,
   GRIMPL_REQUIRE(nelem_per_species > 0,
                  "The number of elements per species must exceed 0");
 
-#define ENTRY(SPECIES_NAME)                                                    \
+#define ENTRY(SPECIES_NAME, DUMMY_ARG)                                         \
   my_fields->SPECIES_NAME##_density =                                          \
       (&species_table[nelem_per_species * SpLUT::SPECIES_NAME]);
 #include "field_data_evolved_species.def"
@@ -183,7 +184,7 @@ public:
     // the following call does nothing if the size doesn't change
     sp_arr_of_ptrs_.resize(MAX_EVOLVED_SPECIES_FIELDS);
 
-#define ENTRY(SPECIES_NAME)                                                    \
+#define ENTRY(SPECIES_NAME, DUMMY_ARG)                                         \
   sp_arr_of_ptrs_[SpLUT::SPECIES_NAME] = field_data->SPECIES_NAME##_density;
 #include "field_data_evolved_species.def"
 #undef ENTRY

--- a/src/clib/field_data_evolved_species.def
+++ b/src/clib/field_data_evolved_species.def
@@ -7,12 +7,11 @@
 / This list is intended to be used with X-Macros in *.c files (to reduce
 / the amount of code required to interact with these fields)
 /
-/ Currently, we just specify the name of each species.
-/  - The corresponding entry in the grackle_field_data struct has an
-/    "_density" suffix
-/  - In the future, we will probably add other metadata such as the kind
-/    of species (e.g. primordial, metal, dust-grain, etc) and a description
-/    of the context when we expect the field to be used.
+/ Currently, we specify:
+/  - The name of each species. The corresponding entry in the grackle_field_data
+/    struct has an "_density" suffix
+/  - We also track whether the category of the species (i.e. is it Primordial,
+/    Metal, or (Dust)).
 /
 / Copyright (c) 2013, Enzo/Grackle Development Team.
 /
@@ -23,72 +22,72 @@
 ************************************************************************/
 
   // primordial_chemistry = 1
-ENTRY(e) // free-electrons
-ENTRY(HI)
-ENTRY(HII)
-ENTRY(HeI)
-ENTRY(HeII)
-ENTRY(HeIII)
+ENTRY(e, Primordial) // free-electrons
+ENTRY(HI, Primordial)
+ENTRY(HII, Primordial)
+ENTRY(HeI, Primordial)
+ENTRY(HeII, Primordial)
+ENTRY(HeIII, Primordial)
 
   // primordial_chemistry = 2
-ENTRY(HM)
-ENTRY(H2I)
-ENTRY(H2II)
+ENTRY(HM, Primordial)
+ENTRY(H2I, Primordial)
+ENTRY(H2II, Primordial)
 
   // primordial_chemistry = 3
-ENTRY(DI)
-ENTRY(DII)
-ENTRY(HDI)
+ENTRY(DI, Primordial)
+ENTRY(DII, Primordial)
+ENTRY(HDI, Primordial)
 
   // primordial_chemistry = 4
-ENTRY(DM)
-ENTRY(HDII)
-ENTRY(HeHII)
+ENTRY(DM, Primordial)
+ENTRY(HDII, Primordial)
+ENTRY(HeHII, Primordial)
 
   // metal_chemistry = 1
-ENTRY(CI)
-ENTRY(CII)
-ENTRY(CO)
-ENTRY(CO2)
-ENTRY(OI)
-ENTRY(OH)
-ENTRY(H2O)
-ENTRY(O2)
-ENTRY(SiI)
-ENTRY(SiOI)
-ENTRY(SiO2I)
-ENTRY(CH)
-ENTRY(CH2)
-ENTRY(COII)
-ENTRY(OII)
-ENTRY(OHII)
-ENTRY(H2OII)
-ENTRY(H3OII)
-ENTRY(O2II)
+ENTRY(CI, Metal)
+ENTRY(CII, Metal)
+ENTRY(CO, Metal)
+ENTRY(CO2, Metal)
+ENTRY(OI, Metal)
+ENTRY(OH, Metal)
+ENTRY(H2O, Metal)
+ENTRY(O2, Metal)
+ENTRY(SiI, Metal)
+ENTRY(SiOI, Metal)
+ENTRY(SiO2I, Metal)
+ENTRY(CH, Metal)
+ENTRY(CH2, Metal)
+ENTRY(COII, Metal)
+ENTRY(OII, Metal)
+ENTRY(OHII, Metal)
+ENTRY(H2OII, Metal)
+ENTRY(H3OII, Metal)
+ENTRY(O2II, Metal)
 
   // dust_species = 1
-ENTRY(Mg)
+ENTRY(Mg, Metal)
 
   // dust_species = 2
-ENTRY(Al)
-ENTRY(S)
-ENTRY(Fe)
+ENTRY(Al, Metal)
+ENTRY(S, Metal)
+ENTRY(Fe, Metal)
 
   // dust_species = 1
-ENTRY(MgSiO3_dust) // enstatite
-ENTRY(AC_dust) // amorphous carbon
+ENTRY(MgSiO3_dust, Dust) // enstatite
+ENTRY(AC_dust, Dust) // amorphous carbon
 
   // dust_species = 2
-ENTRY(SiM_dust) // metallic silicon
-ENTRY(FeM_dust) // metallic iron
-ENTRY(Mg2SiO4_dust) // forsterite
-ENTRY(Fe3O4_dust) // magnetite
-ENTRY(SiO2_dust) // silica
-ENTRY(MgO_dust) // magnesia
-ENTRY(FeS_dust) // troilite
-ENTRY(Al2O3_dust) // alumina
+ENTRY(SiM_dust, Dust) // metallic silicon
+ENTRY(FeM_dust, Dust) // metallic iron
+ENTRY(Mg2SiO4_dust, Dust) // forsterite
+ENTRY(Fe3O4_dust, Dust) // magnetite
+ENTRY(SiO2_dust, Dust) // silica
+ENTRY(MgO_dust, Dust) // magnesia
+ENTRY(FeS_dust, Dust) // troilite
+ENTRY(Al2O3_dust, Dust) // alumina
 
   // dust_species = 3
-ENTRY(ref_org_dust) // refractory organics
-ENTRY(vol_org_dust) // volatile organics
-ENTRY(H2O_ice_dust) // water ice
+ENTRY(ref_org_dust, Dust) // refractory organics
+ENTRY(vol_org_dust, Dust) // volatile organics
+ENTRY(H2O_ice_dust, Dust) // water ice

--- a/tests/unit/test_grain_species_info.cpp
+++ b/tests/unit/test_grain_species_info.cpp
@@ -59,7 +59,7 @@ std::vector<SpNameIndexPair> selected_sp_info_(UnaryPred p) {
   int count = 0;
 
 #define STRINGIFY_(NAME) #NAME
-#define ENTRY(NAME)                                                            \
+#define ENTRY(NAME, DUMMY)                                                     \
   if (p(STRINGIFY_(NAME))) {                                                   \
     out.push_back(SpNameIndexPair{STRINGIFY_(NAME), count});                   \
   }                                                                            \


### PR DESCRIPTION
This is a foundational PR that will help me finish #551.

Essentially, the idea will be to replace `SpLUT` with the combination of `OnlyGrainSpLUT` (renamed `DustSpLUT` in this PR), and the newly created `PrimordialSpLUT` and `MetalSpLUT`.

I totally understand that this may not be very convincing, right now. So feel free to hold off until #551 is ready to go.