### PR TITLE
[newchem-cpp] Add dust to gas ratio calculation for multi-grain model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-nccv21"
+        default: "gold-standard-nccv22"
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string

--- a/src/clib/dust/misc.hpp
+++ b/src/clib/dust/misc.hpp
@@ -115,7 +115,33 @@ inline void dust_related_props(
         my_fields->dust_density, my_fields->grid_dimension[0],
         my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
 
-    if (my_chemistry->use_dust_density_field == 1) {
+    if (my_chemistry->dust_species > 0) {
+      // Add up all dust mass densities
+      for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
+        dust2gas[i] = 0.0;
+      }
+
+      const GrainSpeciesInfo* grain_species_info =
+        my_rates->opaque_storage->grain_species_info;
+      for (int grsp_i = 0; grsp_i < grain_species_info->n_species(); grsp_i++) {
+        const GrainSpeciesInfoEntry& cur_grsp_info =
+          grain_species_info->species_info()[grsp_i];
+        const gr_float* grsp_density =
+          sp_densities.contig1d_ptr(cur_grsp_info.species_idx);
+        FortranView<const gr_float***> grsp_d(
+            grsp_density, my_fields->grid_dimension[0],
+            my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
+
+        for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
+          dust2gas[i] += grsp_d(i, idx_range.j, idx_range.k);
+        }
+      }
+
+      for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
+        dust2gas[i] /= d(i, idx_range.j, idx_range.k);
+      }
+    }
+    else if (my_chemistry->use_dust_density_field == 1) {
       for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
         // REMINDER: use of `itmask` over `itmask_metal` is
         //   currently required by Photo-electric heating

--- a/src/clib/dust/misc.hpp
+++ b/src/clib/dust/misc.hpp
@@ -122,12 +122,12 @@ inline void dust_related_props(
       }
 
       const GrainSpeciesInfo* grain_species_info =
-        my_rates->opaque_storage->grain_species_info;
+          my_rates->opaque_storage->grain_species_info;
       for (int grsp_i = 0; grsp_i < grain_species_info->n_species(); grsp_i++) {
         const GrainSpeciesInfoEntry& cur_grsp_info =
-          grain_species_info->species_info()[grsp_i];
+            grain_species_info->species_info()[grsp_i];
         const gr_float* grsp_density =
-          sp_densities.contig1d_ptr(cur_grsp_info.species_idx);
+            sp_densities.contig1d_ptr(cur_grsp_info.species_idx);
         FortranView<const gr_float***> grsp_d(
             grsp_density, my_fields->grid_dimension[0],
             my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
@@ -140,8 +140,7 @@ inline void dust_related_props(
       for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
         dust2gas[i] /= d(i, idx_range.j, idx_range.k);
       }
-    }
-    else if (my_chemistry->use_dust_density_field == 1) {
+    } else if (my_chemistry->use_dust_density_field == 1) {
       for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
         // REMINDER: use of `itmask` over `itmask_metal` is
         //   currently required by Photo-electric heating

--- a/src/clib/dust/misc.hpp
+++ b/src/clib/dust/misc.hpp
@@ -115,7 +115,7 @@ inline void dust_related_props(
         my_fields->dust_density, my_fields->grid_dimension[0],
         my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
 
-    if (my_chemistry->dust_species > 0) {
+    if (my_chemistry->dust_chemistry == 2) {
       // Add up all dust mass densities
       for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
         dust2gas[i] = 0.0;
@@ -128,12 +128,9 @@ inline void dust_related_props(
             grain_species_info->species_info()[grsp_i];
         const gr_float* grsp_density =
             sp_densities.contig1d_ptr(cur_grsp_info.species_idx);
-        FortranView<const gr_float***> grsp_d(
-            grsp_density, my_fields->grid_dimension[0],
-            my_fields->grid_dimension[1], my_fields->grid_dimension[2]);
 
         for (int i = idx_range.i_start; i <= idx_range.i_end; i++) {
-          dust2gas[i] += grsp_d(i, idx_range.j, idx_range.k);
+          dust2gas[i] += grsp_density[i];
         }
       }
 

--- a/src/clib/grackle_chemistry_data_fields.def
+++ b/src/clib/grackle_chemistry_data_fields.def
@@ -306,15 +306,6 @@ ENTRY(hd_reaction_rates, INT, 0)
  */
 ENTRY(gas_grain_cooling_rate, INT, 0)
 
-/* Alternative formulations of interstellar radiation heating
-   rate on uniform sized grains. Both are based on Goldsmith (2001)
-   and Krumholz (2014) and are in fact very similar. See
-   rate_functions.c for more details.
- * 0: 3.9e-24 / mh / fgr, where fgr is local dust-to-gas ratio
- * 1: 8.60892e-24 / (2.0 * mh) / fgr
- */
-ENTRY(uniform_grain_isrf_heating_rate, INT, 0)
-
 /* maximum number of subcycle iterations for solve_chemistry */
 ENTRY(max_iterations, INT, 10000)
 

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -191,6 +191,11 @@ extern "C" int local_initialize_chemistry_data(
       return GR_FAIL;
     }
 
+    if (my_chemistry->metal_chemistry < 1) {
+      fprintf(stderr, "ERROR: dust_chemistry > 0 requires metal_chemistry > 0.\n");
+      return GR_FAIL;
+    }
+
     if (my_chemistry->photoelectric_heating < 0) {
       my_chemistry->photoelectric_heating = 2;
       if (grackle_verbose) {

--- a/src/clib/initialize_chemistry_data.cpp
+++ b/src/clib/initialize_chemistry_data.cpp
@@ -191,11 +191,6 @@ extern "C" int local_initialize_chemistry_data(
       return GR_FAIL;
     }
 
-    if (my_chemistry->metal_chemistry < 1) {
-      fprintf(stderr, "ERROR: dust_chemistry > 0 requires metal_chemistry > 0.\n");
-      return GR_FAIL;
-    }
-
     if (my_chemistry->photoelectric_heating < 0) {
       my_chemistry->photoelectric_heating = 2;
       if (grackle_verbose) {
@@ -233,6 +228,11 @@ extern "C" int local_initialize_chemistry_data(
 
     if (my_chemistry->use_dust_density_field == 1) {
       fprintf(stderr, "ERROR: dust_chemistry = 2 requires use_dust_density_field = 0.\n");
+      return GR_FAIL;
+    }
+
+    if (my_chemistry->metal_chemistry < 1) {
+      fprintf(stderr, "ERROR: dust_chemistry = 2 requires metal_chemistry > 0.\n");
       return GR_FAIL;
     }
   }

--- a/src/clib/rate_functions.cpp
+++ b/src/clib/rate_functions.cpp
@@ -1478,23 +1478,10 @@ extern "C" double gammah_rate(double units, chemistry_data *my_chemistry)
 //Calculation of gamma_isrf.
 extern "C" double gamma_isrf_rate(double units, chemistry_data *my_chemistry)
 {
-  // Parameter definition.
   double fgr = 0.009387;
-  if (my_chemistry->uniform_grain_isrf_heating_rate == 0) {
-    // (Equation B15, Krumholz, 2014)
-    // Don't normalize by coolunit since tdust calculation is done in CGS.
-    return 3.9e-24 / GRIMPL_NS::constants::mH / fgr;
-  }
-  else if (my_chemistry->uniform_grain_isrf_heating_rate == 1) {
-    // For uniform grain size (Goldsmith 2001; Krumholz 2014)
-    return 8.60892e-24 / (2.0 * GRIMPL_NS::constants::mH) / fgr;
-    // F_isrf sigma_gr / mass_gr
-    // For MRN-like broken power low size distribution (Omukai 2000)
-    // The factor 2 to cancel out the molecular mass of H2.
-  }
-  else {
-    GR_INTERNAL_ERROR("uniform_grain_isrf_heating_rate can only be 0 or 1.\n");
-  }
+  // (Equation B15, Krumholz, 2014)
+  // Don't normalize by coolunit since tdust calculation is done in CGS.
+  return 3.9e-24 / GRIMPL_NS::constants::mH / fgr;
 }
 
 //Calculation of gamma_isrf2.

--- a/src/include/grackle_chemistry_data.h
+++ b/src/include/grackle_chemistry_data.h
@@ -284,15 +284,6 @@ typedef struct
    */
   int gas_grain_cooling_rate;
 
-  /* Alternative formulations of interstellar radiation heating
-     rate of grains. Both are based on Goldsmith (2001) and
-     Krumholz (2014) and are in fact very similar. See
-     rate_functions.c for more details.
-   * 0: 3.9e-24 / mh / fgr, where fgr is local dust-to-gas ratio
-   * 1: 8.60892e-24 / (2.0 * mh) / fgr
-   */
-  int uniform_grain_isrf_heating_rate;
-
   /* maximum number of subcycle iterations for solve_chemistry */
   int max_iterations;
 

--- a/src/include/grackle_fortran_interface.def
+++ b/src/include/grackle_fortran_interface.def
@@ -212,7 +212,6 @@ c     This is the fortran definition of grackle_chemistry_data
          INTEGER(C_INT) :: use_primordial_continuum_opacity
          INTEGER(C_INT) :: hd_reaction_rates
          INTEGER(C_INT) :: gas_grain_cooling_rate
-         INTEGER(C_INT) :: uniform_grain_isrf_heating_rate
          INTEGER(C_INT) :: max_iterations
          INTEGER(C_INT) :: exit_after_iterations_exceeded
 cc       INTEGER(C_INT) :: omp_nthreads // not supported in fortran

--- a/src/python/gracklepy/utilities/convenience.py
+++ b/src/python/gracklepy/utilities/convenience.py
@@ -80,8 +80,9 @@ def _setup_dust_densities(fc, state_vals, dust_to_gas_ratio):
         metal_density = state_vals[metal_field]
         dust_density = 0
         for gr, fmass in fc.chemistry_data._experimental_grain_inj_path_yields().items():
-            state_vals[gr] = fmass[0] * metal_density
-            dust_density += state_vals[gr]
+            fname = f"{gr}_density"
+            state_vals[fname] = fmass[0] * metal_density
+            dust_density += state_vals[fname]
 
         state_vals["dust_density"] = dust_density
 
@@ -204,7 +205,6 @@ def _setup_inj_pathway_fields(state_vals: dict[str, float],
                 f"pathways but not the '{primary_pathway_yield_field}' field"
             )
     state_vals[primary_pathway_yield_field] = state_vals["metal_density"]
-
 
 def setup_fluid_container(my_chemistry,
                           density=mass_hydrogen_cgs,

--- a/src/python/gracklepy/utilities/convenience.py
+++ b/src/python/gracklepy/utilities/convenience.py
@@ -78,13 +78,9 @@ def _setup_dust_densities(fc, state_vals, dust_to_gas_ratio):
     if fc.chemistry_data.dust_chemistry == 2:
         metal_field = fc.inject_pathway_density_yield_fields[0]
         metal_density = state_vals[metal_field]
-        dust_density = 0
         for gr, fmass in fc.chemistry_data._experimental_grain_inj_path_yields().items():
             fname = f"{gr}_density"
             state_vals[fname] = fmass[0] * metal_density
-            dust_density += state_vals[fname]
-
-        state_vals["dust_density"] = dust_density
 
     elif fc.chemistry_data.use_dust_density_field == 1:
         state_vals["dust_density"] = dust_to_gas_ratio * state_vals["density"]


### PR DESCRIPTION
This resolves Issue #593. This adds a calculation of the dust to gas ratio for the multi-grain dust model. With the original locic, we were just using the value from the `local_dust_to_gas_ratio` parameter multiplied by metallicity. Now, we explicitly sum the mass densities from all species. @mabruzzo, I did my best to follow existing examples, but let me know if I haven't followed the optimal procedure.

I also added another requirement that the multi-grain dust model runs with `metal_chemistry=1`. I'm surprised that wasn't in there already.

Finally, I'm not sure how this happened, but the multi-grain dust densities were not being set because the keys coming from `_experimental_grain_inj_path_yields()` were `<species>_dust` instead of `<species>_dust_density`. All of the dust density values were being set to tiny number.

Late addition: I also took the opportunity to remove the mostly pointless `uniform_grain_isrf_heating_rate` parameter which changes the associated cooling rate by ~10%. The value could not also be verified in the references it cites, which were actually the same references cited in the alternate number.

This will likely require a gold standard update.