### PR TITLE
[newchem-cpp] Remove use_multiple_dust_temperatures parameter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
       gold-standard-tag:
         description: "The gold-standard to use for generating the answers"
         type: string
-        default: "gold-standard-nccv22"
+        default: "gold-standard-nccv23"
       cache-tag:
         description: "A unique tag to append to the cache name"
         type: string

--- a/src/clib/field_data_misc_fdatamembers.def
+++ b/src/clib/field_data_misc_fdatamembers.def
@@ -65,7 +65,6 @@ ENTRY(H2_custom_shielding_factor)
   // use_isrf_field = 1
 ENTRY(isrf_habing)
 
-  // use_multiple_dust_temperatures = 1
 ENTRY(SiM_dust_temperature)
 ENTRY(FeM_dust_temperature)
 ENTRY(Mg2SiO4_dust_temperature)

--- a/src/clib/grackle_chemistry_data_fields.def
+++ b/src/clib/grackle_chemistry_data_fields.def
@@ -91,9 +91,6 @@ ENTRY(metal_abundances, INT, 0)
 */
 ENTRY(dust_species, INT, 0)
 
-/* Flag to solve temperatures of multiple grain species */
-ENTRY(use_multiple_dust_temperatures, INT, FALSE)
-
 /* add heating from UV background model
    0) off, 1) on */
 ENTRY(UVbackground, INT, 0)

--- a/src/include/grackle_chemistry_data.h
+++ b/src/include/grackle_chemistry_data.h
@@ -131,9 +131,6 @@ typedef struct
   */
   int dust_species;
 
-  /* Flag to solve temperatures of multiple grain species */
-  int use_multiple_dust_temperatures;
-
   /* photo-electric heating from irradiated dust */
   int photoelectric_heating;
   double photoelectric_heating_rate;

--- a/src/include/grackle_fortran_interface.def
+++ b/src/include/grackle_fortran_interface.def
@@ -156,7 +156,6 @@ c     This is the fortran definition of grackle_chemistry_data
          INTEGER(C_INT) :: multi_metals
          INTEGER(C_INT) :: metal_abundances
          INTEGER(C_INT) :: dust_species
-         INTEGER(C_INT) :: use_multiple_dust_temperatures
          INTEGER(C_INT) :: photoelectric_heating
          REAL(C_DOUBLE) :: photoelectric_heating_rate
          INTEGER(C_INT) :: use_isrf_field

--- a/src/include/grackle_types.h
+++ b/src/include/grackle_types.h
@@ -188,7 +188,6 @@ typedef struct
   // use_isrf_field = 1
   gr_float *isrf_habing;
 
-  // use_multiple_dust_temperatures = 1
   gr_float *SiM_dust_temperature;
   gr_float *FeM_dust_temperature;
   gr_float *Mg2SiO4_dust_temperature;

--- a/src/python/gracklepy/utilities/model_tests.py
+++ b/src/python/gracklepy/utilities/model_tests.py
@@ -39,7 +39,6 @@ _parameter_exclude = (
     {"metal_chemistry": 1, "primordial_chemistry": 1},
     {"metal_chemistry": 1, "metal_cooling": 0},
     {"grackle_data_file": "CloudyData_noUVB.h5", "UVbackground": 1},
-    {"dust_species": 0, "use_multiple_dust_temperatures": 1},
     {"primordial_chemistry": 0, "dust_recombination_cooling": 1},
 )
 
@@ -326,7 +325,6 @@ _model_test_grids = \
                 "variants": \
                 {
                     "dust_species": (1,),
-                    "use_multiple_dust_temperatures": (0, 1),
                     "multi_metals": (1,),
                 }
             },


### PR DESCRIPTION
I thought I'd done this, but this removes entirely the `use_multiple_dust_temperatures` parameter from the codebase. This may require a new gold standard simply because it may change the number of tests.